### PR TITLE
fix: three bugs introduced by merged PRs

### DIFF
--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -225,7 +225,12 @@ function M.diff_against_default_branch()
   else
     -- Get an adapter for the current working directory.
     local err
-    err, adapter = require("diffview.vcs").get_adapter()
+    local cfile = pl:vim_expand("%")
+    local top_indicators = utils.vec_join(
+      vim.bo.buftype == "" and pl:absolute(cfile) or nil,
+      pl:realpath(".")
+    )
+    err, adapter = require("diffview.vcs").get_adapter({ top_indicators = top_indicators })
     if err or not adapter then
       utils.err("Failed to get VCS adapter: " .. (err or "unknown error"))
       return

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -280,6 +280,11 @@ return function(view)
       end
       if not item or not item.commit then return end
 
+      if not view.adapter.get_commit_url then
+        utils.err("Opening commits in browser is not supported for this VCS.")
+        return
+      end
+
       local url = view.adapter:get_commit_url(item.commit.hash)
       if not url then
         utils.err("Could not construct browser URL. Remote URL not recognized.")

--- a/lua/diffview/ui/panels/commit_log_panel.lua
+++ b/lua/diffview/ui/panels/commit_log_panel.lua
@@ -76,7 +76,7 @@ function CommitLogPanel:init(parent, adapter, opt)
 end
 
 function CommitLogPanel:init_buffer()
-  CommitLogPanel:super_class().init_buffer(self)
+  CommitLogPanel.super_class.init_buffer(self)
 
   local conf = get_user_config().keymaps
   local default_opt = { silent = true, nowait = true, buffer = self.bufid }


### PR DESCRIPTION
- fix(oop): use dot syntax for super_class call in CommitLogPanel (commit_log_panel.lua). The colon syntax constructed a spurious instance; every other super-call in the codebase uses dot access.

- fix(actions): pass required opt table to vcs.get_adapter() in diff_against_default_branch (actions.lua). Calling with no argument crashed when no diffview was open.

- fix(hg): guard get_commit_url call in open_commit_in_browser (file_history/listeners.lua). The method only exists on GitAdapter; HgAdapter users got a nil call crash.