### PR TITLE
fix: guard convert_layout against nil revs (#612)

### DIFF
--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -118,6 +118,8 @@ end
 
 ---@param target_layout Layout
 function FileEntry:convert_layout(target_layout)
+  if not self.revs then return end
+
   local get_data
 
   for _, file in ipairs(self.layout:files()) do

--- a/lua/diffview/tests/functional/file_entry_spec.lua
+++ b/lua/diffview/tests/functional/file_entry_spec.lua
@@ -1,8 +1,22 @@
 local FileEntry = require("diffview.scene.file_entry").FileEntry
+local Diff2Hor = require("diffview.scene.layouts.diff_2_hor").Diff2Hor
 local RevType = require("diffview.vcs.rev").RevType
 local GitRev = require("diffview.vcs.adapters.git.rev").GitRev
 
 describe("diffview.file_entry", function()
+  it("convert_layout skips null entries without error (#612)", function()
+    local adapter = { ctx = { toplevel = vim.uv.cwd() } }
+    local entry = FileEntry.new_null_entry(adapter)
+    local original_layout = entry.layout
+
+    -- Must not error; null entries have no revs.
+    assert.has_no.errors(function()
+      entry:convert_layout(Diff2Hor)
+    end)
+
+    assert.are.equal(original_layout, entry.layout)
+  end)
+
   it("does not treat should_null errors as truthy null markers", function()
     local captured
     local layout_class = setmetatable({


### PR DESCRIPTION
Null file entries created by FileEntry.new_null_entry() have no revs field, causing cycle_layout to crash in FileHistoryView.