### PR TITLE
fix: misc. minor big fixes

### DIFF
--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -607,13 +607,15 @@ function M.cycle_layout()
   end
 
   -- Use config or fall back to defaults.
+  local default_standard = { Diff2Hor.__get(), Diff2Ver.__get() }
+  local default_merge_tool = { Diff3Hor.__get(), Diff3Ver.__get(), Diff3Mixed.__get(), Diff4Mixed.__get(), Diff1.__get() }
+
+  local resolved_standard = resolve_layouts(cycle_config.default)
+  local resolved_merge_tool = resolve_layouts(cycle_config.merge_tool)
+
   local layout_cycles = {
-    standard = #(cycle_config.default or {}) > 0
-        and resolve_layouts(cycle_config.default)
-        or { Diff2Hor.__get(), Diff2Ver.__get() },
-    merge_tool = #(cycle_config.merge_tool or {}) > 0
-        and resolve_layouts(cycle_config.merge_tool)
-        or { Diff3Hor.__get(), Diff3Ver.__get(), Diff3Mixed.__get(), Diff4Mixed.__get(), Diff1.__get() },
+    standard = #resolved_standard > 0 and resolved_standard or default_standard,
+    merge_tool = #resolved_merge_tool > 0 and resolved_merge_tool or default_merge_tool,
   }
 
   local view = lib.get_current_view()

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -389,6 +389,10 @@ DiffView.update_files = debounce.debounce_trailing(
     if err then
       utils.err("Failed to update files in a diff view!", true)
       logger:error("[DiffView] Failed to update files!")
+      self.is_loading = false
+      self.panel.is_loading = false
+      self.panel:render()
+      self.panel:redraw()
       callback(err)
       return
     end

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -269,7 +269,7 @@ return function(view)
         local item = view.panel:get_item_at_cursor()
         if item then
           vim.fn.setreg('"', item.commit.hash)
-          utils.info(string.format("Copied '%s' to the clipboard.", item.commit.hash))
+          utils.info(string.format("Copied '%s' to the default register.", item.commit.hash))
         end
       end
     end,
@@ -299,7 +299,7 @@ return function(view)
       elseif vim.fn.has("unix") == 1 then
         cmd = { "xdg-open", url }
       elseif vim.fn.has("win32") == 1 then
-        cmd = { "cmd", "/c", "start", '""', url }
+        cmd = { "cmd", "/c", "start", "", url }
       end
 
       if cmd then


### PR DESCRIPTION
* Clear loading flags on error in update_files to prevent the file panel from getting stuck showing "Fetching changes...".
* Fix misleading "clipboard" message for copy_hash (uses unnamed reg).
* Fix Windows cmd /c start empty title arg for open_commit_in_browser.
* Guard against empty resolved layout list in cycle_layout to prevent division-by-zero when config contains only unknown layout names.