### PR TITLE
fix: guard against external autocmd failures on buffer set

### DIFF
--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -25,6 +25,7 @@ local M = {}
 local Window = oop.create_class("Window")
 
 Window.winopt_store = {}
+Window._set_buf_warned = false
 
 ---@class Window.init.opt
 ---@field id integer
@@ -156,7 +157,25 @@ Window.open_file = async.void(function(self)
   vim.b[self.file.bufnr].context_enabled = false    -- context.vim
 
   local conf = config.get_config()
-  api.nvim_win_set_buf(self.id, self.file.bufnr)
+  local set_buf_ok, set_buf_err, recovered = utils.set_win_buf(self.id, self.file.bufnr)
+  if recovered and not Window._set_buf_warned then
+    Window._set_buf_warned = true
+    utils.warn(
+      "An external autocommand failed while opening a Diffview buffer. "
+      .. "Diffview retried without window events.",
+      true
+    )
+  end
+
+  if recovered then
+    logger:warn(set_buf_err)
+  end
+
+  if not set_buf_ok then
+    logger:error(set_buf_err)
+    self:open_fallback()
+    return
+  end
 
   if self.file.rev.type == RevType.LOCAL then
     self:_save_winopts()

--- a/lua/diffview/tests/functional/utils_spec.lua
+++ b/lua/diffview/tests/functional/utils_spec.lua
@@ -1,0 +1,104 @@
+local helpers = require("diffview.tests.helpers")
+local utils = require("diffview.utils")
+
+local eq = helpers.eq
+
+describe("diffview.utils.set_win_buf", function()
+  it("does not retry when setting the window buffer succeeds", function()
+    local original_set_win_buf = vim.api.nvim_win_set_buf
+    local original_no_win_event_call = utils.no_win_event_call
+
+    local calls = 0
+    local ok, err = pcall(function()
+      vim.api.nvim_win_set_buf = function() calls = calls + 1 end
+      utils.no_win_event_call = function() error("should not be called") end
+
+      local success, msg, recovered = utils.set_win_buf(1, 1)
+
+      eq(true, success)
+      eq(nil, msg)
+      eq(false, recovered)
+      eq(1, calls)
+    end)
+
+    vim.api.nvim_win_set_buf = original_set_win_buf
+    utils.no_win_event_call = original_no_win_event_call
+
+    if not ok then error(err) end
+  end)
+
+  it("retries with ignored events when the first set fails", function()
+    local original_set_win_buf = vim.api.nvim_win_set_buf
+    local original_no_win_event_call = utils.no_win_event_call
+
+    local calls = 0
+    local no_event_calls = 0
+    local ok, err = pcall(function()
+      vim.api.nvim_win_set_buf = function()
+        calls = calls + 1
+        if calls == 1 then
+          error(
+            'BufEnter Autocommands for "*": Vim:E903: Process failed to start: too many open files'
+          )
+        end
+      end
+      utils.no_win_event_call = function(f)
+        no_event_calls = no_event_calls + 1
+        local success, inner_err = pcall(f)
+        return success, inner_err
+      end
+
+      local success, msg, recovered = utils.set_win_buf(1, 1)
+
+      eq(true, success)
+      eq(true, recovered)
+      eq(2, calls)
+      eq(1, no_event_calls)
+      assert.True(msg and msg:find("too many open files", 1, true) ~= nil)
+    end)
+
+    vim.api.nvim_win_set_buf = original_set_win_buf
+    utils.no_win_event_call = original_no_win_event_call
+
+    if not ok then error(err) end
+  end)
+
+  it("returns an error when both attempts fail", function()
+    local original_set_win_buf = vim.api.nvim_win_set_buf
+    local original_no_win_event_call = utils.no_win_event_call
+
+    local calls = 0
+    local no_event_calls = 0
+    local ok, err = pcall(function()
+      vim.api.nvim_win_set_buf = function()
+        calls = calls + 1
+        if calls == 1 then
+          error("first failure")
+        end
+
+        error("second failure")
+      end
+      utils.no_win_event_call = function(f)
+        no_event_calls = no_event_calls + 1
+        local success, inner_err = pcall(f)
+        if not success then
+          return false, "retry failure"
+        end
+        return success, inner_err
+      end
+
+      local success, msg, recovered = utils.set_win_buf(1, 1)
+
+      eq(false, success)
+      eq(false, recovered)
+      eq(2, calls)
+      eq(1, no_event_calls)
+      eq("retry failure", msg)
+    end)
+
+    vim.api.nvim_win_set_buf = original_set_win_buf
+    utils.no_win_event_call = original_no_win_event_call
+
+    if not ok then error(err) end
+  end)
+end)

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -289,7 +289,10 @@ function Panel:open()
     api.nvim_win_call(rel_winid, function()
       vim.cmd(split_dir .. " " .. split_cmd)
       self.winid = api.nvim_get_current_win()
-      api.nvim_win_set_buf(self.winid, self.bufid)
+      local ok, err = utils.set_win_buf(self.winid, self.bufid)
+      if not ok then
+        error(err)
+      end
 
       if config.relative == "editor" then
         local dir = ({ left = "H", bottom = "J", top = "K", right = "L" })[position]

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -79,6 +79,31 @@ function M.no_win_event_call(f)
   return ok, err
 end
 
+---Set a window buffer while gracefully handling external autocommand failures.
+---On failure, retry once while window and buffer enter/leave events are
+---ignored.
+---@param winid integer
+---@param bufnr integer
+---@return boolean success
+---@return string? err Error string on failure. When `success == true` and `recovered == true`, this contains the first failure message.
+---@return boolean recovered
+function M.set_win_buf(winid, bufnr)
+  local ok, err = pcall(api.nvim_win_set_buf, winid, bufnr)
+  if ok then
+    return true, nil, false
+  end
+
+  local retry_ok, retry_err = M.no_win_event_call(function()
+    api.nvim_win_set_buf(winid, bufnr)
+  end)
+
+  if retry_ok then
+    return true, tostring(err), true
+  end
+
+  return false, tostring(retry_err or err), false
+end
+
 ---Update a given window by briefly setting it as the current window.
 ---@param winid integer
 function M.update_win(winid)

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -549,7 +549,10 @@ end
 ---@static
 function File.load_null_buffer(winid)
   local bn = File._get_null_buffer()
-  api.nvim_win_set_buf(winid, bn)
+  local ok, err = utils.set_win_buf(winid, bn)
+  if not ok then
+    error(err)
+  end
   File.NULL_FILE:attach_buffer()
 end
 


### PR DESCRIPTION
Workaround for an error message originating from https://github.com/nvim-lualine/lualine.nvim/issues/699.