### PR TITLE
feat(panel): support auto-fitting panel width to content

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ require("diffview").setup({
   },
   file_panel = {
     listing_style = "tree",
-    win_config = { position = "left", width = 35 },
+    win_config = { position = "left", width = 35 }, -- Use "auto" to fit content
   },
   hooks = {},   -- See :h diffview-config-hooks
   keymaps = {}, -- See :h diffview-config-keymaps

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -806,10 +806,12 @@ win_config                                      *diffview-config-win_config*
                 Determines whether the window should be a float or a normal
                 split.
 
-            {width} (integer)
+            {width} (integer|"auto")
                 The width of the window (in character cells). If `type` is
                 `"split"` then this is only applicable when `position` is
-                `"left"|"right"`.
+                `"left"|"right"`. When set to `"auto"`, the panel
+                automatically sizes itself to fit all displayed content
+                (file names, stats, tree indentation, etc.).
 
             {height} (integer)
                 The height of the window (in character cells). If `type` is

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -83,7 +83,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
       },
       win_config = {                      -- See |diffview-config-win_config|
         position = "left",
-        width = 35,
+        width = 35,                       -- Set to "auto" to fit content.
         win_opts = {},
       },
       show = true,                        -- Show the file panel when opening Diffview.

--- a/lua/diffview/tests/functional/panel_spec.lua
+++ b/lua/diffview/tests/functional/panel_spec.lua
@@ -48,6 +48,155 @@ describe("diffview.ui.panel", function()
     end)
   end)
 
+  describe("auto-width", function()
+    local api = vim.api
+
+    ---Create a minimal panel with the given width config.
+    local function make_panel(width)
+      local conf = vim.tbl_deep_extend("force", Panel.default_config_split, {
+        position = "left",
+        width = width,
+      })
+      return Panel({
+        bufname = "TestAutoWidth",
+        config = conf,
+      })
+    end
+
+    it("get_config accepts 'auto' as a width value", function()
+      local panel = make_panel("auto")
+      local config = panel:get_config()
+      eq("auto", config.width)
+    end)
+
+    it("get_config accepts a numeric width value", function()
+      local panel = make_panel(42)
+      local config = panel:get_config()
+      eq(42, config.width)
+    end)
+
+    it("get_config rejects an invalid width value", function()
+      local panel = make_panel("bogus")
+      assert.has_error(function()
+        panel:get_config()
+      end)
+    end)
+
+    it("infer_width returns vim.o.columns when width is 'auto'", function()
+      local panel = make_panel("auto")
+      eq(vim.o.columns, panel:infer_width())
+    end)
+
+    it("infer_width returns configured width for numeric values", function()
+      local panel = make_panel(50)
+      -- Panel is not open, so it falls through to config.width.
+      eq(50, panel:infer_width())
+    end)
+
+    it("compute_content_width measures buffer lines", function()
+      local panel = make_panel("auto")
+      -- Manually create a buffer and populate it so we can test measurement.
+      local bufid = api.nvim_create_buf(false, true)
+      panel.bufid = bufid
+      api.nvim_buf_set_lines(bufid, 0, -1, false, {
+        "short",
+        "a moderately long line here",
+        "x",
+      })
+
+      local width = panel:compute_content_width()
+      -- Panel is not open, so textoff defaults to 2 (signcolumn).
+      -- Expected: max display width (27) + 2 + 1 = 30.
+      local expected = api.nvim_strwidth("a moderately long line here") + 2 + 1
+      eq(expected, width)
+
+      api.nvim_buf_delete(bufid, { force = true })
+    end)
+
+    it("compute_content_width falls back when buffer is not loaded", function()
+      -- With "auto" width and no class-level default, falls back to 35.
+      local panel = make_panel("auto")
+      eq(35, panel:compute_content_width())
+    end)
+
+    it("compute_content_width uses class default width when buffer is not loaded", function()
+      -- When the panel subclass defines a numeric default width, use that.
+      local panel = make_panel("auto")
+      local saved = Panel.default_config_split.width
+      Panel.default_config_split.width = 40
+      eq(40, panel:compute_content_width())
+      Panel.default_config_split.width = saved
+    end)
+
+    it("compute_content_width clamps to half the editor width", function()
+      local panel = make_panel("auto")
+      local bufid = api.nvim_create_buf(false, true)
+      panel.bufid = bufid
+      -- Create a line wider than half the editor.
+      local long_line = string.rep("x", vim.o.columns)
+      api.nvim_buf_set_lines(bufid, 0, -1, false, { long_line })
+
+      local width = panel:compute_content_width()
+      -- Raw content width would exceed the clamp, but compute_content_width
+      -- itself does not clamp; clamping is done in resize(). So the raw
+      -- value should exceed half the editor width.
+      local raw_expected = api.nvim_strwidth(long_line) + 2 + 1
+      eq(raw_expected, width)
+
+      api.nvim_buf_delete(bufid, { force = true })
+    end)
+    it("resize applies computed auto-width to an open split panel", function()
+      local panel = make_panel("auto")
+      -- Stub abstract methods so init_buffer can complete.
+      panel.update_components = function() end
+      panel.render = function() end
+      panel:init_buffer()
+
+      -- Populate the buffer with known content.
+      vim.bo[panel.bufid].modifiable = true
+      api.nvim_buf_set_lines(panel.bufid, 0, -1, false, {
+        "short",
+        "a moderately long line here",
+      })
+      vim.bo[panel.bufid].modifiable = false
+
+      panel:open()
+      assert.truthy(panel:is_open())
+
+      -- The window should have been sized to fit the content.
+      local win_width = api.nvim_win_get_width(panel.winid)
+      local info = vim.fn.getwininfo(panel.winid)
+      local textoff = (info and info[1]) and info[1].textoff or 2
+      local expected = api.nvim_strwidth("a moderately long line here") + textoff + 1
+      eq(expected, win_width)
+
+      panel:destroy()
+    end)
+
+    it("resize clamps auto-width to half the editor width", function()
+      local panel = make_panel("auto")
+      panel.update_components = function() end
+      panel.render = function() end
+      panel:init_buffer()
+
+      -- Populate with an extremely long line.
+      vim.bo[panel.bufid].modifiable = true
+      api.nvim_buf_set_lines(panel.bufid, 0, -1, false, {
+        string.rep("x", vim.o.columns),
+      })
+      vim.bo[panel.bufid].modifiable = false
+
+      panel:open()
+      assert.truthy(panel:is_open())
+
+      local win_width = api.nvim_win_get_width(panel.winid)
+      local max_width = math.floor(vim.o.columns * 0.5)
+      assert.is_true(win_width <= max_width)
+
+      panel:destroy()
+    end)
+  end)
+
   describe("subclass contracts", function()
     -- The actual panels used by the two view types must inherit the same
     -- interface.

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -171,7 +171,11 @@ function Panel:get_config()
     vim.validate({
       position = valid_enum(config.position, { "left", "top", "right", "bottom" }),
       relative = valid_enum(config.relative, { "editor", "win" }),
-      width = { config.width, "number", true },
+      width = {
+        config.width,
+        function(v) return v == nil or v == "auto" or type(v) == "number" end,
+        "'auto' or number",
+      },
       height = { config.height, "number", true },
       win_opts = { config.win_opts, "table" }
     })
@@ -247,8 +251,17 @@ function Panel:resize()
   local config = self:get_config()
 
   if config.type == "split" then
-    if self.state.form == "column" and config.width then
-      api.nvim_win_set_width(self.winid, config.width)
+    if self.state.form == "column" then
+      local width = config.width
+      if width == "auto" then
+        width = self:compute_content_width()
+        -- Clamp and use pcall: the computed width may exceed available space.
+        local max_width = math.floor(vim.o.columns * 0.5)
+        width = math.min(width, max_width)
+        pcall(api.nvim_win_set_width, self.winid, width)
+      elseif width then
+        api.nvim_win_set_width(self.winid, width)
+      end
     elseif self.state.form == "row" and config.height then
       api.nvim_win_set_height(self.winid, config.height)
     end
@@ -309,9 +322,9 @@ function Panel:open()
     end
   end
 
-  self:resize()
   utils.set_local(self.winid, self.class.winopts)
   utils.set_local(self.winid, config.win_opts)
+  self:resize()
 end
 
 function Panel:close()
@@ -412,6 +425,55 @@ function Panel:redraw()
   renderer.render(self.bufid, self.render_data)
   perf:time()
   logger:lvl(10):debug(perf)
+
+  -- Only resize on redraw when auto-fitting; fixed dimensions are applied
+  -- once in open() and should not override user-initiated resizing.
+  local config = self:get_config()
+  if config.type == "split" and config.width == "auto" then
+    self:resize()
+  end
+end
+
+---Compute the minimum window width needed to display all buffer content
+---without truncation, accounting for sign column and other gutter elements.
+---@return integer
+function Panel:compute_content_width()
+  if not self:buf_loaded() then
+    -- Fall back to configured width if numeric, otherwise a sensible default.
+    local config = self:get_config()
+    local default = self.class.default_config_split and self.class.default_config_split.width
+    if type(default) == "number" then
+      return default
+    elseif type(config.width) == "number" then
+      return config.width
+    end
+    return 35
+  end
+
+  local lines = api.nvim_buf_get_lines(self.bufid, 0, -1, false)
+  local max_width = 0
+
+  for _, line in ipairs(lines) do
+    local w = api.nvim_strwidth(line)
+    if w > max_width then
+      max_width = w
+    end
+  end
+
+  -- Account for gutter columns (sign column, etc.).
+  local textoff = 0
+  if self:is_open() then
+    local info = vim.fn.getwininfo(self.winid)
+    if info and info[1] then
+      textoff = info[1].textoff
+    end
+  else
+    -- Default: signcolumn = "yes" adds 2 columns.
+    textoff = 2
+  end
+
+  -- +1 for a bit of right-side breathing room.
+  return max_width + textoff + 1
 end
 
 ---Update components, render and redraw.
@@ -518,10 +580,17 @@ function Panel:get_height()
 end
 
 function Panel:infer_width()
+  local config = self:get_config()
+
+  -- When auto-fitting, return a large value so that rendering does not
+  -- truncate content. The actual window width is set later by resize().
+  if config.width == "auto" then
+    return vim.o.columns
+  end
+
   local cur_width = self:get_width()
   if cur_width then return cur_width end
 
-  local config = self:get_config()
   if config.width then return config.width end
 
   -- PanelFloatSpec requires both width and height to be defined. If we get


### PR DESCRIPTION
Allow `win_config.width = "auto"` so the file panel (and file history panel) dynamically sizes itself to fit all displayed content instead of using a fixed column count.