### PR TITLE
fix(panel): preserve selections and folder state across tab switches

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -555,6 +555,17 @@ signs                                           *diffview-config-signs*
             {done} (string)
                 Sign indicating completion/resolution.
 
+            {selected_file} (string)
+                Sign shown next to selected files.
+
+            {selected_dir} (string)
+                Sign shown next to directories where every file is
+                selected.
+
+            {partially_selected_dir} (string)
+                Sign shown next to directories where some (but not
+                all) files are selected.
+
 view.x.layout                                   *diffview-config-view.x.layout*
         Type: >
             "diff1_plain"
@@ -1454,8 +1465,11 @@ toggle_select_entry                             *diffview-actions-toggle_select_
         Also works in visual mode to toggle all files in the selected
         line range. When files are selected, `toggle_stage_entry` and
         `restore_entry` will operate on all selected files as a batch.
-        Selections are cleared after a batch operation or when the file
-        list is refreshed.
+        Selected files are indicated by `signs.selected_file`;
+        directories with some selected files show
+        `signs.partially_selected_dir`.
+        Selections are preserved across tab switches and file list
+        refreshes. Selections are cleared after a batch operation.
 
 clear_select_entries                            *diffview-actions-clear_select_entries*
         Contexts: `file_panel`

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -38,6 +38,9 @@ DEFAULT CONFIG                                  *diffview.defaults*
       fold_closed = "",
       fold_open = "",
       done = "✓",
+      selected_file = "✓",
+      selected_dir = "●",
+      partially_selected_dir = "◐",
     },
     view = {
       -- Configure the layout and behavior of different types of views.

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -77,6 +77,9 @@ M.defaults = {
     fold_closed = "",
     fold_open = "",
     done = "✓",
+    selected_file = "✓",
+    selected_dir = "●",
+    partially_selected_dir = "◐",
   },
   view = {
     default = {

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -303,7 +303,7 @@ end
 ---@param self DiffView
 ---@param file FileEntry
 ---@param focus? boolean Bring focus to the diff buffers.
----@param highlight? boolean Bring the cursor to the file entry in the panel.
+---@param highlight? boolean|nil true=force highlight, false=suppress, nil=auto (highlight when panel not focused).
 DiffView.set_file = async.void(function(self, file, focus, highlight)
   ---@diagnostic disable: invisible
   self:ensure_layout()
@@ -314,7 +314,7 @@ DiffView.set_file = async.void(function(self, file, focus, highlight)
     if f == file then
       self.panel:set_cur_file(file)
 
-      if highlight or not self.panel:is_focused() then
+      if highlight ~= false and (highlight or not self.panel:is_focused()) then
         self.panel:highlight_file(file)
       end
 
@@ -595,7 +595,7 @@ DiffView.update_files = debounce.debounce_trailing(
     self.panel:render()
     self.panel:redraw()
 
-    self:set_file(self.panel.cur_file or self.panel:next_file(), false, not self.initialized)
+    self:set_file(self.panel.cur_file or self.panel:next_file(), false, not self.initialized or nil)
 
     -- Position cursor at the requested row on first open.
     if not self.initialized and self.options.selected_row then

--- a/lua/diffview/scene/views/diff/file_panel.lua
+++ b/lua/diffview/scene/views/diff/file_panel.lua
@@ -331,7 +331,7 @@ function FilePanel:highlight_file(file)
           while dir and dir.name == "directory" do
             if dir.context and dir.context.collapsed then
               was_concealed = true
-              dir.context.collapsed = false
+              self:set_dir_collapsed(dir.context, false)
             end
 
             dir = utils.tbl_access(dir, { "parent", "parent" })
@@ -397,11 +397,32 @@ function FilePanel:reconstrain_cursor()
   })
 end
 
+---Set collapsed state for a directory, propagating to underlying tree nodes
+---so that get_collapsed_state() picks up the correct value for flattened dirs.
+---@param item DirData
+---@param collapsed boolean
+function FilePanel:set_dir_collapsed(item, collapsed)
+  item.collapsed = collapsed
+  if item._node then
+    local node = item._node
+    while node do
+      if node.data and type(node.data.collapsed) == "boolean" then
+        node.data.collapsed = collapsed
+      end
+      if #node.children == 1 and node.children[1]:has_children() then
+        node = node.children[1]
+      else
+        break
+      end
+    end
+  end
+end
+
 ---@param item DirData|any
 ---@param open boolean
 function FilePanel:set_item_fold(item, open)
   if type(item.collapsed) == "boolean" and open == item.collapsed then
-    item.collapsed = not open
+    self:set_dir_collapsed(item, not open)
     self:render()
     self:redraw()
 
@@ -420,30 +441,86 @@ function FilePanel:toggle_item_fold(item)
   self:set_item_fold(item, item.collapsed)
 end
 
+---Compute a stable key for a file entry that survives object replacement.
+---@param file FileEntry
+---@return string
+function FilePanel.selection_key(file)
+  return file.kind .. ":" .. file.path
+end
+
+---Select a file entry.
+---@param file FileEntry
+function FilePanel:select_file(file)
+  self.selected_files[FilePanel.selection_key(file)] = true
+end
+
+---Deselect a file entry.
+---@param file FileEntry
+function FilePanel:deselect_file(file)
+  self.selected_files[FilePanel.selection_key(file)] = nil
+end
+
 ---Toggle selection for a file entry.
 ---@param file FileEntry
 function FilePanel:toggle_selection(file)
-  if self.selected_files[file] then
-    self.selected_files[file] = nil
+  local key = FilePanel.selection_key(file)
+  if self.selected_files[key] then
+    self.selected_files[key] = nil
   else
-    self.selected_files[file] = true
+    self.selected_files[key] = true
   end
 end
 
 ---@param file FileEntry
 ---@return boolean
 function FilePanel:is_selected(file)
-  return self.selected_files[file] == true
+  return self.selected_files[FilePanel.selection_key(file)] == true
+end
+
+---Return the selection state of a directory's files.
+---@param dir_data DirData
+---@return "all"|"some"|"none"
+function FilePanel:dir_selection_state(dir_data)
+  if not dir_data._node then return "none" end
+  local leaves = dir_data._node:leaves()
+  if #leaves == 0 then return "none" end
+  local selected, total = 0, 0
+  for _, leaf in ipairs(leaves) do
+    if leaf.data then
+      total = total + 1
+      if self:is_selected(leaf.data) then
+        selected = selected + 1
+      end
+    end
+  end
+  if selected == 0 then return "none" end
+  if selected == total then return "all" end
+  return "some"
 end
 
 ---Get all currently selected files.
 ---@return FileEntry[]
 function FilePanel:get_selected_files()
   local result = {}
-  for file in pairs(self.selected_files) do
-    result[#result + 1] = file
+  for _, file in self.files:iter() do
+    if self.selected_files[FilePanel.selection_key(file)] then
+      result[#result + 1] = file
+    end
   end
   return result
+end
+
+---Remove selections for files that no longer exist.
+function FilePanel:prune_selections()
+  local valid_keys = {}
+  for _, file in self.files:iter() do
+    valid_keys[FilePanel.selection_key(file)] = true
+  end
+  for key in pairs(self.selected_files) do
+    if not valid_keys[key] then
+      self.selected_files[key] = nil
+    end
+  end
 end
 
 ---Clear all file selections.

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -18,7 +18,9 @@ return function(view)
     tab_enter = function()
       local file = view.panel.cur_file
       if file then
-        view:set_file(file, false, true)
+        -- Suppress highlight_file to avoid expanding collapsed directories;
+        -- the panel cursor is restored separately below.
+        view:set_file(file, false, false)
       end
 
       -- Restore panel cursor position.
@@ -78,8 +80,8 @@ return function(view)
     ---@diagnostic disable-next-line: unused-local
     files_updated = function(_, files)
       view.initialized = true
-      -- File entries are replaced on update; clear stale selections.
-      view.panel:clear_selections()
+      -- File entries may be replaced on update; prune stale selections.
+      view.panel:prune_selections()
     end,
     close = function()
       if view.panel:is_focused() then
@@ -178,9 +180,9 @@ return function(view)
         for _, leaf in ipairs(leaves) do
           if leaf.data then
             if all_selected then
-              view.panel.selected_files[leaf.data] = nil
+              view.panel:deselect_file(leaf.data)
             else
-              view.panel.selected_files[leaf.data] = true
+              view.panel:select_file(leaf.data)
             end
           end
         end
@@ -501,7 +503,7 @@ return function(view)
       }) do
         file_set.comp:deep_some(function(comp, _, _)
           if comp.name == "directory" then
-            (comp.context --[[@as DirData ]]).collapsed = false
+            view.panel:set_dir_collapsed(comp.context --[[@as DirData ]], false)
           end
         end)
       end
@@ -519,7 +521,7 @@ return function(view)
       }) do
         file_set.comp:deep_some(function(comp, _, _)
           if comp.name == "directory" then
-            (comp.context --[[@as DirData ]]).collapsed = true
+            view.panel:set_dir_collapsed(comp.context --[[@as DirData ]], true)
           end
         end)
       end

--- a/lua/diffview/scene/views/diff/render.lua
+++ b/lua/diffview/scene/views/diff/render.lua
@@ -4,11 +4,12 @@ local utils = require("diffview.utils")
 
 local pl = utils.path
 
+---@param conf DiffviewConfig
 ---@param panel FilePanel
 ---@param comp  RenderComponent
 ---@param show_path boolean
 ---@param depth integer|nil
-local function render_file(panel, comp, show_path, depth)
+local function render_file(conf, panel, comp, show_path, depth)
   ---@type FileEntry
   local file = comp.context
 
@@ -21,7 +22,7 @@ local function render_file(panel, comp, show_path, depth)
   end
 
   if marked then
-    comp:add_text("* ", "DiffviewFilePanelMarked")
+    comp:add_text(conf.signs.selected_file .. " ", "DiffviewFilePanelMarked")
   else
     comp:add_text("  ")
   end
@@ -38,7 +39,7 @@ local function render_file(panel, comp, show_path, depth)
     elseif file.stats.conflicts then
       local has_conflicts = file.stats.conflicts > 0
       comp:add_text(
-        " " .. (has_conflicts and file.stats.conflicts or config.get_config().signs.done),
+        " " .. (has_conflicts and file.stats.conflicts or conf.signs.done),
         has_conflicts and "DiffviewFilePanelConflicts" or "DiffviewFilePanelInsertions"
       )
     end
@@ -55,11 +56,12 @@ local function render_file(panel, comp, show_path, depth)
   comp:ln()
 end
 
+---@param conf DiffviewConfig
 ---@param panel FilePanel
 ---@param comp RenderComponent
-local function render_file_list(panel, comp)
+local function render_file_list(conf, panel, comp)
   for _, file_comp in ipairs(comp.components) do
-    render_file(panel, file_comp, true)
+    render_file(conf, panel, file_comp, true)
   end
 end
 
@@ -76,14 +78,13 @@ local function get_dir_status_text(ctx, tree_options)
   return " "
 end
 
+---@param conf DiffviewConfig
 ---@param panel FilePanel
 ---@param depth integer
 ---@param comp RenderComponent
-local function render_file_tree_recurse(panel, depth, comp)
-  local conf = config.get_config()
-
+local function render_file_tree_recurse(conf, panel, depth, comp)
   if comp.name == "file" then
-    render_file(panel, comp, false, depth)
+    render_file(conf, panel, comp, false, depth)
     return
   end
 
@@ -115,6 +116,12 @@ local function render_file_tree_recurse(panel, depth, comp)
     "DiffviewFolderSign"
   )
 
+  local sel_state = panel:dir_selection_state(ctx)
+  if sel_state == "all" then
+    dir:add_text(conf.signs.selected_dir .. " ", "DiffviewFilePanelMarked")
+  elseif sel_state == "some" then
+    dir:add_text(conf.signs.partially_selected_dir .. " ", "DiffviewFilePanelMarked")
+  end
   dir:add_text(ctx.name .. "/", "DiffviewFolderName")
   -- Show file count when folder is collapsed.
   if ctx.collapsed and ctx._node then
@@ -125,27 +132,29 @@ local function render_file_tree_recurse(panel, depth, comp)
 
   if not ctx.collapsed then
     for _, item in ipairs(items.components) do
-      render_file_tree_recurse(panel, depth + 1, item)
+      render_file_tree_recurse(conf, panel, depth + 1, item)
     end
   end
 end
 
+---@param conf DiffviewConfig
 ---@param panel FilePanel
 ---@param comp RenderComponent
-local function render_file_tree(panel, comp)
+local function render_file_tree(conf, panel, comp)
   for _, c in ipairs(comp.components) do
-    render_file_tree_recurse(panel, 0, c)
+    render_file_tree_recurse(conf, panel, 0, c)
   end
 end
 
+---@param conf DiffviewConfig
 ---@param panel FilePanel
 ---@param listing_style "list"|"tree"
 ---@param comp RenderComponent
-local function render_files(panel, listing_style, comp)
+local function render_files(conf, panel, listing_style, comp)
   if listing_style == "list" then
-    return render_file_list(panel, comp)
+    return render_file_list(conf, panel, comp)
   end
-  render_file_tree(panel, comp)
+  render_file_tree(conf, panel, comp)
 end
 
 ---@param panel FilePanel
@@ -190,7 +199,7 @@ return function(panel)
     comp:add_text("(" .. #panel.files.conflicting .. ")", "DiffviewFilePanelCounter")
     comp:ln()
 
-    render_files(panel, panel.listing_style, panel.components.conflicting.files.comp)
+    render_files(conf, panel, panel.listing_style, panel.components.conflicting.files.comp)
     panel.components.conflicting.margin.comp:add_line()
   end
 
@@ -211,7 +220,7 @@ return function(panel)
     elseif #panel.files.working == 0 then
       panel.components.working.files.comp:add_line("  (empty)", "DiffviewDim1")
     else
-      render_files(panel, panel.listing_style, panel.components.working.files.comp)
+      render_files(conf, panel, panel.listing_style, panel.components.working.files.comp)
     end
     panel.components.working.margin.comp:add_line()
   end
@@ -225,7 +234,7 @@ return function(panel)
     if #panel.files.staged == 0 then
       panel.components.staged.files.comp:add_line("  (empty)", "DiffviewDim1")
     else
-      render_files(panel, panel.listing_style, panel.components.staged.files.comp)
+      render_files(conf, panel, panel.listing_style, panel.components.staged.files.comp)
     end
     panel.components.staged.margin.comp:add_line()
   end

--- a/lua/diffview/tests/functional/panel_spec.lua
+++ b/lua/diffview/tests/functional/panel_spec.lua
@@ -283,18 +283,37 @@ describe("diffview.ui.panel", function()
   describe("FilePanel multi-selection", function()
     local FilePanel = require("diffview.scene.views.diff.file_panel").FilePanel
 
-    -- Minimal stub that satisfies FilePanel:init without needing a real adapter.
-    local function make_panel()
+    ---Create a mock FileDict that supports iteration over the given entries.
+    ---@param entries table[]?
+    ---@return table
+    local function make_mock_files(entries)
+      local all = entries or {}
+      local files = {}
+      function files:iter()
+        local i = 0
+        return function()
+          i = i + 1
+          if i <= #all then
+            return i, all[i]
+          end
+        end
+      end
+      function files:len()
+        return #all
+      end
+      return files
+    end
+
+    ---Minimal stub that satisfies FilePanel:init without needing a real adapter.
+    ---@param entries table[]?
+    local function make_panel(entries)
       local adapter = { ctx = { toplevel = "/tmp", dir = "/tmp/.git" } }
-      local files = setmetatable({}, {
-        __index = function() return {} end,
-      })
-      return FilePanel(adapter, files, {})
+      return FilePanel(adapter, make_mock_files(entries), {})
     end
 
     -- Lightweight stand-in for a FileEntry (only identity matters).
-    local function make_entry(path)
-      return { path = path, kind = "working" }
+    local function make_entry(path, kind)
+      return { path = path, kind = kind or "working" }
     end
 
     it("starts with no selections", function()
@@ -303,16 +322,16 @@ describe("diffview.ui.panel", function()
     end)
 
     it("toggle_selection marks a file", function()
-      local panel = make_panel()
       local f = make_entry("a.lua")
+      local panel = make_panel({ f })
       panel:toggle_selection(f)
       eq(true, panel:is_selected(f))
       eq(1, #panel:get_selected_files())
     end)
 
     it("toggle_selection unmarks a previously marked file", function()
-      local panel = make_panel()
       local f = make_entry("a.lua")
+      local panel = make_panel({ f })
       panel:toggle_selection(f)
       panel:toggle_selection(f)
       eq(false, panel:is_selected(f))
@@ -320,10 +339,10 @@ describe("diffview.ui.panel", function()
     end)
 
     it("tracks multiple selections independently", function()
-      local panel = make_panel()
       local a = make_entry("a.lua")
       local b = make_entry("b.lua")
       local c = make_entry("c.lua")
+      local panel = make_panel({ a, b, c })
       panel:toggle_selection(a)
       panel:toggle_selection(b)
       eq(true, panel:is_selected(a))
@@ -333,9 +352,9 @@ describe("diffview.ui.panel", function()
     end)
 
     it("clear_selections removes all marks", function()
-      local panel = make_panel()
       local a = make_entry("a.lua")
       local b = make_entry("b.lua")
+      local panel = make_panel({ a, b })
       panel:toggle_selection(a)
       panel:toggle_selection(b)
       panel:clear_selections()
@@ -347,6 +366,223 @@ describe("diffview.ui.panel", function()
     it("is_selected returns false for unknown entries", function()
       local panel = make_panel()
       eq(false, panel:is_selected(make_entry("nope.lua")))
+    end)
+
+    it("selections survive file entry replacement", function()
+      -- Simulate what happens on tab switch: a selected file entry is
+      -- replaced by a new object with the same path and kind.
+      local old = make_entry("src/foo.lua")
+      local panel = make_panel({ old })
+      panel:toggle_selection(old)
+      eq(true, panel:is_selected(old))
+
+      -- Replace with a new object (same path/kind, different identity).
+      local new = make_entry("src/foo.lua")
+      assert.is_not.equal(old, new)
+      panel.files = make_mock_files({ new })
+
+      -- Selection should carry over to the replacement entry.
+      eq(true, panel:is_selected(new))
+      local selected = panel:get_selected_files()
+      eq(1, #selected)
+      eq(new, selected[1])
+    end)
+
+    it("prune_selections removes stale entries", function()
+      local a = make_entry("a.lua")
+      local b = make_entry("b.lua")
+      local panel = make_panel({ a, b })
+      panel:toggle_selection(a)
+      panel:toggle_selection(b)
+
+      -- Remove 'b' from the file list (simulating a file disappearing).
+      panel.files = make_mock_files({ a })
+      panel:prune_selections()
+
+      eq(true, panel:is_selected(a))
+      -- 'b' is no longer in the file list, so it should be pruned.
+      eq(false, panel:is_selected(b))
+      eq(1, #panel:get_selected_files())
+    end)
+
+    it("select_file and deselect_file work", function()
+      local f = make_entry("x.lua")
+      local panel = make_panel({ f })
+      panel:select_file(f)
+      eq(true, panel:is_selected(f))
+      panel:deselect_file(f)
+      eq(false, panel:is_selected(f))
+    end)
+
+    it("distinguishes files by kind", function()
+      local working = make_entry("f.lua", "working")
+      local staged = make_entry("f.lua", "staged")
+      local panel = make_panel({ working, staged })
+      panel:toggle_selection(working)
+      eq(true, panel:is_selected(working))
+      eq(false, panel:is_selected(staged))
+    end)
+  end)
+
+  describe("FilePanel set_dir_collapsed", function()
+    local FilePanel = require("diffview.scene.views.diff.file_panel").FilePanel
+    local Node = require("diffview.ui.models.file_tree.node").Node
+
+    local function make_panel()
+      local adapter = { ctx = { toplevel = "/tmp", dir = "/tmp/.git" } }
+      local files = {}
+      function files:iter() return function() end end
+      function files:len() return 0 end
+      return FilePanel(adapter, files, {})
+    end
+
+    it("propagates collapsed state to tree nodes in a flattened chain", function()
+      -- Build a simple tree chain: A -> B -> leaf
+      local a_data = { name = "a", path = "a", kind = "working", collapsed = false }
+      local b_data = { name = "b", path = "a/b", kind = "working", collapsed = false }
+
+      local a_node = Node("a", a_data)
+      local b_node = Node("b", b_data)
+      local leaf_node = Node("file.lua", { path = "a/b/file.lua" })
+      a_node:add_child(b_node)
+      b_node:add_child(leaf_node)
+
+      -- Simulate a flattened DirData created by create_comp_schema.
+      local flattened = {
+        name = "a/b",
+        path = "a/b",
+        kind = "working",
+        collapsed = false,
+        _node = a_node,
+      }
+
+      local panel = make_panel()
+      panel:set_dir_collapsed(flattened, true)
+
+      eq(true, flattened.collapsed)
+      eq(true, a_data.collapsed)
+      eq(true, b_data.collapsed)
+    end)
+
+    it("does not walk past the end of a flatten chain", function()
+      -- Tree: a -> b -> [c (dir), x.lua]
+      -- Flatten combines a/b (single-child chain). c is a separate subdir.
+      local a_data = { name = "a", path = "a", kind = "working", collapsed = false }
+      local b_data = { name = "b", path = "a/b", kind = "working", collapsed = false }
+      local c_data = { name = "c", path = "a/b/c", kind = "working", collapsed = false }
+
+      local a_node = Node("a", a_data)
+      local b_node = Node("b", b_data)
+      local c_node = Node("c", c_data)
+      local leaf1 = Node("x.lua", { path = "a/b/x.lua" })
+      local leaf2 = Node("y.lua", { path = "a/b/c/y.lua" })
+      a_node:add_child(b_node)
+      b_node:add_child(c_node)
+      b_node:add_child(leaf1)
+      c_node:add_child(leaf2)
+
+      local flattened = {
+        name = "a/b",
+        path = "a/b",
+        kind = "working",
+        collapsed = false,
+        _node = a_node,
+      }
+
+      local panel = make_panel()
+      panel:set_dir_collapsed(flattened, true)
+
+      eq(true, flattened.collapsed)
+      -- a and b are part of the flatten chain (a has one child: b).
+      eq(true, a_data.collapsed)
+      -- b has multiple children, so the walk stops after b.
+      eq(true, b_data.collapsed)
+      -- c is a separate subdir, not part of the flatten chain.
+      eq(false, c_data.collapsed)
+    end)
+
+    it("dir_selection_state reflects none/some/all", function()
+      local a_data = { name = "a", path = "a", kind = "working", collapsed = false }
+      local a_node = Node("a", a_data)
+      local f1 = { path = "a/x.lua", kind = "working" }
+      local f2 = { path = "a/y.lua", kind = "working" }
+      a_node:add_child(Node("x.lua", f1))
+      a_node:add_child(Node("y.lua", f2))
+      a_data._node = a_node
+
+      local panel = make_panel()
+      eq("none", panel:dir_selection_state(a_data))
+
+      panel:select_file(f1)
+      eq("some", panel:dir_selection_state(a_data))
+
+      panel:select_file(f2)
+      eq("all", panel:dir_selection_state(a_data))
+
+      panel:deselect_file(f1)
+      eq("some", panel:dir_selection_state(a_data))
+    end)
+
+    it("dir_selection_state returns none without _node", function()
+      local panel = make_panel()
+      eq("none", panel:dir_selection_state({ collapsed = false }))
+    end)
+  end)
+
+  describe("FileTree collapsed state with flatten_dirs", function()
+    local FileTree = require("diffview.ui.models.file_tree.file_tree").FileTree
+
+    ---Create a minimal FileEntry stub.
+    local function make_entry(path, kind)
+      return { path = path, kind = kind or "working", status = "M", basename = path }
+    end
+
+    it("get_collapsed_state reads from tree nodes (not flattened DirData)", function()
+      -- Build a tree with a flattenable chain: src/components/foo.lua
+      local tree = FileTree({ make_entry("src/components/foo.lua") })
+
+      -- Manually collapse the tree nodes (simulating set_dir_collapsed propagation).
+      local function collapse_nodes(node)
+        if node:has_children() and node.data and node.data.collapsed ~= nil then
+          node.data.collapsed = true
+        end
+        for _, child in ipairs(node.children) do
+          collapse_nodes(child)
+        end
+      end
+      for _, child in ipairs(tree.root.children) do
+        collapse_nodes(child)
+      end
+
+      local state = tree:get_collapsed_state()
+
+      -- Both intermediate nodes should report collapsed = true.
+      eq(true, state["src"])
+      eq(true, state["src/components"])
+    end)
+
+    it("set_collapsed_state restores to tree nodes", function()
+      local tree = FileTree({ make_entry("src/components/foo.lua") })
+
+      tree:set_collapsed_state({ ["src"] = true, ["src/components"] = true })
+
+      local state = tree:get_collapsed_state()
+      eq(true, state["src"])
+      eq(true, state["src/components"])
+    end)
+
+    it("create_comp_schema sets _node to outermost node in flattened chain", function()
+      local tree = FileTree({ make_entry("src/components/foo.lua") })
+      local schema = tree:create_comp_schema({ flatten_dirs = true })
+
+      -- With flatten_dirs, "src" and "components" should be combined into
+      -- a single directory component.
+      eq("directory", schema[1].name)
+      local dir_data = schema[1].context
+      assert.truthy(dir_data._node)
+
+      -- _node should point to the outermost node ("src"), not an inner one.
+      eq("src", dir_data._node.name)
     end)
   end)
 end)

--- a/lua/diffview/ui/models/file_tree/file_tree.lua
+++ b/lua/diffview/ui/models/file_tree/file_tree.lua
@@ -115,6 +115,7 @@ function FileTree:create_comp_schema(data)
     dir_data._node = node
 
     if data.flatten_dirs then
+      local flatten_root = node
       while #node.children == 1 and node.children[1]:has_children() do
         ---@type DirData
         local subdir_data = node.children[1].data
@@ -124,7 +125,7 @@ function FileTree:create_comp_schema(data)
           kind = subdir_data.kind,
           collapsed = dir_data.collapsed and subdir_data.collapsed,
           status = dir_data.status,
-          _node = node,
+          _node = flatten_root,
         }
         node = node.children[1]
       end


### PR DESCRIPTION
Partially relates to https://github.com/sindrets/diffview.nvim/issues/582.