### PR TITLE
fix(git): correct typo `rev_names` -> `ref_names` in merge context

### DIFF
--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -330,7 +330,7 @@ function GitAdapter:get_merge_context()
 
   ret.theirs = code ~= 0 and {} or {
     hash = out[1],
-    rev_names = out[2],
+    ref_names = out[2],
   }
 
   out, code = self:exec_sync({ "merge-base", "HEAD", their_head }, self.ctx.toplevel)


### PR DESCRIPTION
The `theirs` entry in `get_merge_context` used `rev_names` instead of `ref_names`, so the ref name was never displayed in the winbar. (This bug has been present on the original sindrets repro since 168c8fc.)
