### PR TITLE
fix(view): guard against `nil` hash in `update_merge_context`

### DIFF
--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -198,7 +198,7 @@ function FileEntry:update_merge_context(ctx)
 
   local layout = self.layout --[[@as Diff4 ]]
 
-  if layout.a then
+  if layout.a and ctx.ours.hash then
     layout.a.file.winbar = (" OURS (Current changes) %s %s"):format(
       (ctx.ours.hash):sub(1, 10),
       ctx.ours.ref_names and ("(" .. ctx.ours.ref_names .. ")") or ""
@@ -209,14 +209,14 @@ function FileEntry:update_merge_context(ctx)
     layout.b.file.winbar = " LOCAL (Working tree)"
   end
 
-  if layout.c then
+  if layout.c and ctx.theirs.hash then
     layout.c.file.winbar = (" THEIRS (Incoming changes) %s %s"):format(
       (ctx.theirs.hash):sub(1, 10),
       ctx.theirs.ref_names and ("(" .. ctx.theirs.ref_names .. ")") or ""
     )
   end
 
-  if layout.d then
+  if layout.d and ctx.base.hash then
     layout.d.file.winbar = (" BASE (Common ancestor) %s %s"):format(
       (ctx.base.hash):sub(1, 10),
       ctx.base.ref_names and ("(" .. ctx.base.ref_names .. ")") or ""

--- a/lua/diffview/tests/functional/file_entry_spec.lua
+++ b/lua/diffview/tests/functional/file_entry_spec.lua
@@ -52,6 +52,85 @@ describe("diffview.scene.file_entry", function()
     assert.False(captured.b.nulled)
   end)
 
+  describe("update_merge_context", function()
+    local function make_entry_with_layout()
+      local file_stubs = {}
+      local layout = {}
+      for _, key in ipairs({ "a", "b", "c", "d" }) do
+        file_stubs[key] = { winbar = nil }
+        layout[key] = { file = file_stubs[key] }
+      end
+
+      local entry = FileEntry({
+        adapter = { ctx = { toplevel = "/tmp" } },
+        path = "a.txt",
+        oldpath = nil,
+        revs = {},
+        layout = layout,
+        status = "M",
+        stats = {},
+        kind = "working",
+      })
+
+      return entry, layout, file_stubs
+    end
+
+    it("does not error when merge context entries have nil hashes", function()
+      local entry, _, file_stubs = make_entry_with_layout()
+
+      assert.has_no.errors(function()
+        entry:update_merge_context({
+          ours = {},
+          theirs = {},
+          base = {},
+        })
+      end)
+
+      -- Winbars for ours/theirs/base should remain unset.
+      assert.is_nil(file_stubs.a.winbar)
+      assert.is_nil(file_stubs.c.winbar)
+      assert.is_nil(file_stubs.d.winbar)
+      -- LOCAL winbar is always set.
+      eq(" LOCAL (Working tree)", file_stubs.b.winbar)
+    end)
+
+    it("sets winbars correctly when hashes are present", function()
+      local entry, _, file_stubs = make_entry_with_layout()
+      local hash = "abc123def456"
+
+      entry:update_merge_context({
+        ours = { hash = hash, ref_names = "main" },
+        theirs = { hash = hash, ref_names = "feature" },
+        base = { hash = hash },
+      })
+
+      assert.is_not_nil(file_stubs.a.winbar)
+      assert.truthy(file_stubs.a.winbar:find("OURS"))
+      assert.truthy(file_stubs.a.winbar:find("main"))
+      assert.truthy(file_stubs.c.winbar:find("THEIRS"))
+      assert.truthy(file_stubs.c.winbar:find("feature"))
+      assert.truthy(file_stubs.d.winbar:find("BASE"))
+      assert.truthy(file_stubs.d.winbar:find(hash:sub(1, 10)))
+      eq(" LOCAL (Working tree)", file_stubs.b.winbar)
+    end)
+
+    it("handles a mix of present and missing hashes", function()
+      local entry, _, file_stubs = make_entry_with_layout()
+
+      assert.has_no.errors(function()
+        entry:update_merge_context({
+          ours = { hash = "abc123def456" },
+          theirs = {},
+          base = { hash = "def789abc012" },
+        })
+      end)
+
+      assert.truthy(file_stubs.a.winbar:find("OURS"))
+      assert.is_nil(file_stubs.c.winbar)
+      assert.truthy(file_stubs.d.winbar:find("BASE"))
+    end)
+  end)
+
   it("forwards force flag to contained files when destroyed", function()
     local seen = {}
     local layout_destroyed = false


### PR DESCRIPTION
When a git command fails in `get_merge_context` (e.g., `git show MERGE_HEAD`), the entry is set to `{}` with no hash field. Skip winbar updates for entries with missing hashes instead of crashing.