### PR TITLE
fix(file): detach LSP clients and disable auto-format on `diffview://` buffers

### DIFF
--- a/TIPS.md
+++ b/TIPS.md
@@ -75,16 +75,16 @@ Common questions, useful patterns, and known compatibility issues.
     character/word-level diff highlights. See
     [Companion Plugins](README.md#companion-plugins) for setup details.
 
-## LSP Diagnostics in Diff Buffers
+## LSP and Formatting in Diff Buffers
 
-- Diagnostics only appear for the working tree (LOCAL) side of diffs.
-- When comparing commits (e.g., `DiffviewOpen main..HEAD`), neither side is the
-  working tree, so LSP won't attach to those buffers.
-- To see diagnostics, compare against the working tree: `DiffviewOpen main`
-  (not `main..HEAD`). The right side will show your current files with
-  diagnostics.
-- Inlay hints are automatically disabled for non-working-tree buffers to
-  prevent position mismatch errors.
+- LSP clients are automatically detached from non-working-tree diff buffers
+  (those with `diffview://` URIs). This prevents errors from LSP servers that
+  do not support the custom URI scheme, and avoids incorrect LSP features on
+  historical content.
+- Auto-formatting is disabled on these buffers (`vim.b.autoformat = false`).
+- Diagnostics and other LSP features only appear for the working tree (LOCAL)
+  side of diffs. To see them, compare against the working tree:
+  `DiffviewOpen main` (not `main..HEAD`).
 
 ## Neogit Integration
 

--- a/lua/diffview/tests/functional/file_spec.lua
+++ b/lua/diffview/tests/functional/file_spec.lua
@@ -138,4 +138,62 @@ describe("diffview.vcs.file", function()
     assert.is_nil(file.bufnr)
     assert.is_false(vim.api.nvim_buf_is_valid(pre_cancel_bufnr))
   end))
+
+  describe("diffview:// buffer guards", function()
+    local file_counter = 0
+    local created_files = {}
+
+    ---Create a File with a COMMIT rev whose create_buffer succeeds.
+    ---Uses a unique path each time so buffers are not reused across tests.
+    ---@return vcs.File
+    local function make_commit_file()
+      file_counter = file_counter + 1
+
+      local adapter = {
+        ctx = {
+          toplevel = vim.uv.cwd(),
+          dir = vim.uv.cwd(),
+        },
+        is_binary = function()
+          return false
+        end,
+        show = async.wrap(function(_, _, _, callback)
+          callback(nil, { "line1", "line2" })
+        end),
+      }
+
+      local file = File({
+        adapter = adapter,
+        path = "test_guard_" .. file_counter .. ".txt",
+        kind = "working",
+        rev = GitRev(RevType.COMMIT, "abc1234"),
+      })
+      table.insert(created_files, file)
+      return file
+    end
+
+    after_each(function()
+      for _, file in ipairs(created_files) do
+        File.safe_delete_buf(file.bufnr)
+      end
+      created_files = {}
+    end)
+
+    it("sets autoformat=false on diffview:// buffers", helpers.async_test(function()
+      local file = make_commit_file()
+      async.await(file:create_buffer())
+
+      assert.is_not_nil(file.bufnr)
+      assert.is_false(vim.b[file.bufnr].autoformat)
+    end))
+
+    it("registers an LspAttach autocmd on diffview:// buffers", helpers.async_test(function()
+      local file = make_commit_file()
+      async.await(file:create_buffer())
+
+      assert.is_not_nil(file.bufnr)
+      local aus = vim.api.nvim_get_autocmds({ event = "LspAttach", buffer = file.bufnr })
+      assert.is_true(#aus > 0)
+    end))
+  end)
 end)

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -336,6 +336,27 @@ File.create_buffer = async.wrap(function(self, callback)
   vim.bo[self.bufnr].modifiable = true
   api.nvim_buf_set_lines(self.bufnr, 0, -1, false, lines)
 
+  -- Prevent LSP clients from attaching to diffview:// buffers. LSP servers
+  -- may not support the custom URI scheme, and the buffer content may be
+  -- from a different revision making LSP features incorrect or harmful.
+  api.nvim_create_autocmd("LspAttach", {
+    buffer = self.bufnr,
+    callback = function(ev)
+      local client_id = ev.data and ev.data.client_id
+      if not client_id then return end
+      vim.schedule(function()
+        if api.nvim_buf_is_valid(ev.buf) then
+          pcall(vim.lsp.buf_detach_client, ev.buf, client_id)
+        end
+      end)
+    end,
+  })
+
+  -- Disable auto-formatting. Diffview buffers contain committed or staged
+  -- content that should not be reformatted. The `autoformat` variable is
+  -- a common convention (LazyVim, conform.nvim, etc.).
+  vim.b[self.bufnr].autoformat = false
+
   api.nvim_buf_call(self.bufnr, function()
     vim.cmd("filetype detect")
   end)


### PR DESCRIPTION
Fixes #72 and #73.