### PR TITLE
feat(panel): add list_options.path_style option for full path display

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -812,6 +812,16 @@ file_panel                                      *diffview-config-file_panel*
                   Append "/" to folder names in the file tree.
                   Default: `true`
 
+            {list_options} (table)
+                Options for the list listing style:
+                • {path_style} ("basename"|"full")
+                  How to display file names in the list.
+                  `"basename"` shows the file name followed by the
+                  parent path in a dimmed highlight.
+                  `"full"` shows the full path with uniform
+                  highlighting.
+                  Default: `"basename"`
+
             {win_config} (table|function)
                 See |diffview-config-win_config|.
 

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -93,6 +93,9 @@ DEFAULT CONFIG                                  *diffview.defaults*
         folder_count_style = "grouped",   -- "grouped" (e.g. "2M 1D"), "simple" (e.g. "3"), or "none".
         folder_trailing_slash = true,     -- Append "/" to folder names in the file tree.
       },
+      list_options = {                    -- Only applies when listing_style is 'list'
+        path_style = "basename",          -- "basename" (name + dimmed path) or "full" (full path, uniform highlight).
+      },
       win_config = {                      -- See |diffview-config-win_config|
         position = "left",
         width = 35,                       -- Set to "auto" to fit content.

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -159,6 +159,9 @@ M.defaults = {
       folder_count_style = "grouped", -- "grouped" (e.g. "2M 1D"), "simple" (e.g. "3"), or "none".
       folder_trailing_slash = true, -- Append "/" to folder names in the file tree.
     },
+    list_options = {
+      path_style = "basename", -- "basename" (name + dimmed path) or "full" (full path, uniform highlight).
+    },
     win_config = {
       position = "left",
       width = 35,

--- a/lua/diffview/scene/views/diff/render.lua
+++ b/lua/diffview/scene/views/diff/render.lua
@@ -104,7 +104,15 @@ local function render_file(conf, panel, comp, show_path, depth, sign_pad)
 
   local icon, icon_hl = hl.get_file_icon(file.basename, file.extension)
   comp:add_text(icon, icon_hl)
-  comp:add_text(file.basename, file.active and "DiffviewFilePanelSelected" or "DiffviewFilePanelFileName")
+
+  local name_hl = file.active and "DiffviewFilePanelSelected" or "DiffviewFilePanelFileName"
+  local path_style = show_path and conf.file_panel.list_options.path_style or nil
+
+  if path_style == "full" and #file.parent_path > 0 then
+    comp:add_text(file.parent_path .. "/", name_hl)
+  end
+
+  comp:add_text(file.basename, name_hl)
 
   if file.stats then
     if file.stats.additions then
@@ -124,7 +132,7 @@ local function render_file(conf, panel, comp, show_path, depth, sign_pad)
     comp:add_text(" !", "DiffviewFilePanelConflicts")
   end
 
-  if show_path then
+  if show_path and path_style ~= "full" then
     comp:add_text(" " .. file.parent_path, "DiffviewFilePanelPath")
   end
 


### PR DESCRIPTION
- Add `file_panel.file_name_style` config option (`"basename"` or `"path"`)
- When set to `"path"`, file entries in the file panel show the full path (`parent_path/basename`) with uniform highlighting, instead of the default behavior of showing only the basename with a dimmed path appended after it

# Usage:
```lua
require("diffview").setup({
  file_panel = {
    listing_style = 'list',
    file_name_style = "path",
  },
})
```