### PR TITLE
fix(file): emit `BufReadPost` after async keymap registration

### DIFF
--- a/lua/diffview/tests/functional/keymap_save_spec.lua
+++ b/lua/diffview/tests/functional/keymap_save_spec.lua
@@ -237,6 +237,69 @@ describe("keymap save/restore on attach/detach", function()
     api.nvim_buf_delete(bufnr, { force = true })
   end)
 
+  describe("BufReadPost emission after keymap registration", function()
+    it("fires BufReadPost on first attach", function()
+      local bufnr = scratch_buf()
+      local fired = false
+
+      local au_id = api.nvim_create_autocmd("BufReadPost", {
+        buffer = bufnr,
+        callback = function() fired = true end,
+      })
+
+      local file = make_file(bufnr)
+      attach_with_test_keymap(file)
+
+      assert.is_true(fired)
+
+      file:detach_buffer()
+      api.nvim_del_autocmd(au_id)
+      api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("skips BufReadPost when diffview_disable_ts is set", function()
+      local bufnr = scratch_buf()
+      local fired = false
+
+      vim.b[bufnr].diffview_disable_ts = true
+
+      local au_id = api.nvim_create_autocmd("BufReadPost", {
+        buffer = bufnr,
+        callback = function() fired = true end,
+      })
+
+      local file = make_file(bufnr)
+      attach_with_test_keymap(file)
+
+      assert.is_false(fired)
+
+      file:detach_buffer()
+      api.nvim_del_autocmd(au_id)
+      api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("fires BufReadPost only once on repeated attach", function()
+      local bufnr = scratch_buf()
+      local count = 0
+
+      local au_id = api.nvim_create_autocmd("BufReadPost", {
+        buffer = bufnr,
+        callback = function() count = count + 1 end,
+      })
+
+      local file = make_file(bufnr)
+      attach_with_test_keymap(file)
+      attach_with_test_keymap(file)
+      attach_with_test_keymap(file)
+
+      assert.equals(1, count)
+
+      file:detach_buffer()
+      api.nvim_del_autocmd(au_id)
+      api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
   it("preserves saved keymap opts (noremap, nowait, expr)", function()
     local bufnr = scratch_buf()
 

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -527,6 +527,26 @@ function File:attach_buffer(force, opt)
       end
 
       File.attached[self.bufnr] = state
+
+      -- Keymaps are registered asynchronously (after buffer creation and
+      -- content loading). Fire BufReadPost once so plugins like which-key.nvim
+      -- re-scan buffer-local keymaps and make them discoverable immediately.
+      -- Guard: emit only on first attach to avoid re-running all BufReadPost
+      -- handlers on repeated open_file() calls for the same buffer.
+      -- Skip for buffers where treesitter was intentionally disabled
+      -- (large_file_threshold): BufReadPost would trigger a full treesitter
+      -- re-parse, defeating the large-file optimisation.
+      if not vim.b[self.bufnr].diffview_buf_read_emitted
+        and not vim.b[self.bufnr].diffview_disable_ts
+      then
+        vim.b[self.bufnr].diffview_buf_read_emitted = true
+        api.nvim_buf_call(self.bufnr, function()
+          pcall(api.nvim_exec_autocmds, "BufReadPost", {
+            buffer = self.bufnr,
+            modeline = false,
+          })
+        end)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/sindrets/diffview.nvim/issues/564.