### PR TITLE
fix(panel): strip external treesitter/syntax from panel buffers

### DIFF
--- a/lua/diffview/tests/functional/panel_spec.lua
+++ b/lua/diffview/tests/functional/panel_spec.lua
@@ -259,6 +259,53 @@ describe("diffview.ui.panel", function()
     end)
   end)
 
+  describe("stop external treesitter parsers", function()
+    -- Panel content is rendered manually via extmarks, so a tree-sitter
+    -- parser attached by an external plugin (e.g. render-markdown.nvim)
+    -- can mis-interpret file paths like `foo_bar_baz` as markdown italics.
+
+    local function make_panel()
+      return Panel({
+        bufname = "TestStopTreesitter",
+        config = Panel.default_config_split,
+      })
+    end
+
+    it("stops treesitter on the panel buffer during init_buffer", function()
+      local saved = vim.treesitter.stop
+      local calls = {}
+      vim.treesitter.stop = function(buf) table.insert(calls, buf) end
+
+      local panel = make_panel()
+      panel.update_components = function() end
+      panel.render = function() end
+      panel:init_buffer()
+
+      eq(true, vim.tbl_contains(calls, panel.bufid))
+
+      vim.treesitter.stop = saved
+      panel:destroy()
+    end)
+
+    it("registers a BufWinEnter autocmd on the panel buffer", function()
+      local panel = make_panel()
+      panel.update_components = function() end
+      panel.render = function() end
+      panel:init_buffer()
+
+      -- The re-stop runs on window entry so plugins that re-attach their
+      -- parser get stopped again.  A structural check avoids relying on
+      -- scheduled-callback timing.
+      local autocmds = vim.api.nvim_get_autocmds({
+        buffer = panel.bufid,
+        event = "BufWinEnter",
+      })
+      eq(true, #autocmds > 0)
+
+      panel:destroy()
+    end)
+  end)
+
   describe("subclass contracts", function()
     -- The actual panels used by the two view types must inherit the same
     -- interface.

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -410,6 +410,18 @@ function Panel:buf_loaded()
   return self.bufid and api.nvim_buf_is_loaded(self.bufid)
 end
 
+---Stop any tree-sitter parser that external plugins may have attached to
+---a panel buffer. Panel content is rendered manually (extmarks from
+---`diffview:///panels/...` namespaces) and must not be parsed as code.
+---Without this guard, plugins like `render-markdown.nvim` start a
+---markdown parser on arbitrary filetypes, producing spurious italic
+---spans on `_word_` patterns in file paths and commit subjects.
+---@param bufid integer
+local function stop_external_treesitter(bufid)
+  if not api.nvim_buf_is_valid(bufid) then return end
+  pcall(vim.treesitter.stop, bufid)
+end
+
 function Panel:init_buffer()
   local bn = api.nvim_create_buf(false, false)
 
@@ -440,6 +452,18 @@ function Panel:init_buffer()
       modeline = false,
     })
   end)
+
+  stop_external_treesitter(bn)
+
+  -- Re-stop when a plugin re-attaches as the buffer enters a window.
+  -- `vim.schedule` defers to after all other `BufWinEnter` handlers.
+  api.nvim_create_autocmd("BufWinEnter", {
+    group = Panel.au.group,
+    buffer = bn,
+    callback = function()
+      vim.schedule(function() stop_external_treesitter(bn) end)
+    end,
+  })
 
   self:update_components()
   self:render()


### PR DESCRIPTION
Fixes a bug where pairs of underscores in a filename in the file history panel are parsed as markdown and result in their removal and the display of intervening text as italics, if a plugin such as [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) is installed.