### PR TITLE
feat(layout): add `diff1_inline` unified diff view

### DIFF
--- a/TIPS.md
+++ b/TIPS.md
@@ -64,6 +64,41 @@ Common questions, useful patterns, and known compatibility issues.
 
 ## Diff Display
 
+- **Inline (unified) diff:**
+  - Use the `diff1_inline` layout to display diffs in a single window, with
+    deletions rendered as virtual lines above the corresponding position
+    and intra-line changes highlighted with `DiffText`.
+  - To make it the default view: `view.default.layout = "diff1_inline"`.
+    The layout is automatically appended to `view.cycle_layouts.default`
+    if missing, so `g<C-x>` cycles back to it without extra config.
+  - To cycle through it alongside side-by-side layouts, list them all
+    explicitly:
+    ```lua
+    require("diffview").setup({
+      view = {
+        cycle_layouts = {
+          default = { "diff2_horizontal", "diff1_inline" },
+        },
+      },
+    })
+    ```
+  - Navigate hunks with `]c`/`[c` (mapped to `next_inline_hunk` and
+    `prev_inline_hunk`).
+  - Inline is not available in the merge tool (it needs a 2-way diff).
+- **Overleaf-style inline diff (strikethrough for deletions):**
+  - Set `view.inline.style = "overleaf"` to render deleted characters as
+    inline virtual text with strikethrough, next to the added characters
+    they were replaced by. Whole-line deletions are also shown with a
+    strikethrough instead of a plain delete background.
+    ```lua
+    require("diffview").setup({
+      view = {
+        default = { layout = "diff1_inline" },
+        inline = { style = "overleaf" },
+      },
+    })
+    ```
+  - Customise the look with `:hi DiffviewDiffDeleteInline gui=...`.
 - **Better diff display (changes shown as add+delete instead of modification):**
   - Set Neovim's `diffopt` to use a better algorithm:
     - `vim.opt.diffopt:append { "algorithm:histogram" }`

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -638,6 +638,7 @@ persist_selections                              *diffview-config-persist_selecti
 view.x.layout                                   *diffview-config-view.x.layout*
         Type: >
             "diff1_plain"
+                | "diff1_inline"
                 | "diff2_horizontal"
                 | "diff2_vertical"
                 | "diff3_horizontal"
@@ -686,6 +687,22 @@ view.x.layout                                   *diffview-config-view.x.layout*
                 │              │
                 │              │
                 │      B       │
+                │              │
+                │              │
+                └──────────────┘
+
+            {diff1_inline}
+                Available for: diff_view, file_history_view
+
+                A single-window unified ("inline") diff. The new-side content
+                is shown in one buffer; deletions are rendered as virtual
+                lines and intra-line changes are highlighted with
+                |hl-DiffText|. Not applicable to merge conflicts.
+
+                ┌──────────────┐
+                │              │
+                │              │
+                │     B +/-    │
                 │              │
                 │              │
                 └──────────────┘
@@ -798,6 +815,35 @@ view.cycle_layouts                              *diffview-config-view.cycle_layo
                     { "diff3_horizontal", "diff3_vertical",
                       "diff3_mixed", "diff4_mixed", "diff1_plain" }
 <
+
+view.inline                                     *diffview-config-view.inline*
+        Type: `table`, Default: (see defaults)
+
+        Options that apply to the `diff1_inline` layout.
+
+        Fields: ~
+            {style} ("unified"|"overleaf")
+                Rendering style. Default: `"unified"`.
+
+                • `"unified"`: proper unified diff (git/GitHub style) —
+                  old lines for each hunk (pure deletion or modification)
+                  shown above as virtual lines; modified new lines get a
+                  |hl-DiffChange| line background with added chars
+                  highlighted via |hl-DiffText|.
+                • `"overleaf"`: Overleaf-editor style. Deleted chars on
+                  modified lines are rendered inline as strikethrough
+                  virtual text where they used to be; added chars get
+                  |hl-DiffText|. No block-level echo or line background
+                  on paired modifications — the char-level rendering is
+                  the whole presentation. Pure/overflow deletions still
+                  appear as virt_lines (with strikethrough).
+
+                Highlight groups used: ~
+                    • |hl-DiffAdd|, |hl-DiffChange|, |hl-DiffText|,
+                      |hl-DiffDelete| via their `Diffview*` variants.
+                    • `DiffviewDiffDeleteInline` for overleaf-mode
+                      deletions (default: `DiffDelete` colours +
+                      `strikethrough`; override with |:hi| to customise).
 
 file_panel                                      *diffview-config-file_panel*
         Type: `table`, Default: (see defaults)
@@ -1434,6 +1480,14 @@ next_conflict                                   *diffview-actions-next_conflict*
             If the current file contains any conflicts, the action returns a
             |diffview.ConflictCount| table.
 
+next_inline_hunk                                *diffview-actions-next_inline_hunk*
+        Contexts: `diff_view`, `file_history_view`
+
+        Moves the cursor to the next change in the `diff1_inline` layout.
+        Default-mapped to `]c` on `diff1_inline` buffers. Native `]c` relies
+        on diff mode, which the inline view disables, so this walks the
+        renderer's cached hunks instead.
+
 next_entry                                      *diffview-actions-next_entry*
         Contexts: `view`, `panel`
 
@@ -1473,6 +1527,13 @@ prev_conflict                                   *diffview-actions-prev_conflict*
         Return: ~
             If the current file contains any conflicts, the action returns a
             |diffview.ConflictCount| table.
+
+prev_inline_hunk                                *diffview-actions-prev_inline_hunk*
+        Contexts: `diff_view`, `file_history_view`
+
+        Moves the cursor to the previous change in the `diff1_inline` layout.
+        Default-mapped to `[c` on `diff1_inline` buffers. See
+        |diffview-actions-next_inline_hunk|.
 
 prev_entry                                      *diffview-actions-prev_entry*
         Contexts: `view`, `panel`

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -53,6 +53,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
       -- Configure the layout and behavior of different types of views.
       -- Available layouts:
       --  'diff1_plain'
+      --    |'diff1_inline'
       --    |'diff2_horizontal'
       --    |'diff2_vertical'
       --    |'diff3_horizontal'
@@ -86,6 +87,13 @@ DEFAULT CONFIG                                  *diffview.defaults*
       cycle_layouts = {
         default = { "diff2_horizontal", "diff2_vertical" },
         merge_tool = { "diff3_horizontal", "diff3_vertical", "diff3_mixed", "diff4_mixed", "diff1_plain" },
+      },
+      -- Options that apply to the `diff1_inline` layout.
+      inline = {
+        -- Rendering style. "unified" shows a proper unified diff with old
+        -- lines as virt_lines above; "overleaf" renders deleted chars on
+        -- modified lines as inline strikethrough virt_text.
+        style = "unified",
       },
     },
     file_panel = {
@@ -185,6 +193,14 @@ DEFAULT CONFIG                                  *diffview.defaults*
       diff1 = {
         -- Mappings in single window diff layouts
         { "n", "g?", actions.help({ "view", "diff1" }), { desc = "Open the help panel" } },
+      },
+      diff1_inline = {
+        -- Mappings in the `diff1_inline` unified diff layout. Native `]c`/`[c`
+        -- don't work here because the window has `diff=false`, so we provide
+        -- equivalents that walk the renderer's cached hunks.
+        { "n", "]c",  actions.next_inline_hunk,                            { desc = "Jump to the next inline-diff hunk" } },
+        { "n", "[c",  actions.prev_inline_hunk,                            { desc = "Jump to the previous inline-diff hunk" } },
+        { "n", "g?",  actions.help({ "view", "diff1", "diff1_inline" }),   { desc = "Open the help panel" } },
       },
       diff2 = {
         -- Mappings in 2-way diff layouts

--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -14,6 +14,7 @@ local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 local vcs_utils = lazy.require("diffview.vcs.utils") ---@module "diffview.vcs.utils"
 
 local Diff1 = lazy.access("diffview.scene.layouts.diff_1", "Diff1") ---@type Diff1|LazyModule
+local Diff1Inline = lazy.access("diffview.scene.layouts.diff_1_inline", "Diff1Inline") ---@type Diff1Inline|LazyModule
 local Diff2Hor = lazy.access("diffview.scene.layouts.diff_2_hor", "Diff2Hor") ---@type Diff2Hor|LazyModule
 local Diff2Ver = lazy.access("diffview.scene.layouts.diff_2_ver", "Diff2Ver") ---@type Diff2Ver|LazyModule
 local Diff3 = lazy.access("diffview.scene.layouts.diff_3", "Diff3") ---@type Diff3|LazyModule
@@ -37,6 +38,18 @@ local M = setmetatable({}, {
 })
 
 M.compat = {}
+
+---Return the view's main window and its file's bufnr if both are valid,
+---otherwise nil. Use this at the top of any action that reads or modifies the
+---currently-displayed file buffer.
+---@param view StandardView?
+---@return Window? main
+---@return integer? bufnr
+local function get_valid_main(view)
+  local main = view and view.cur_layout and view.cur_layout:get_main_win()
+  if not (main and main:is_valid() and main.file and main.file:is_valid()) then return end
+  return main, main.file.bufnr
+end
 
 ---@return FileEntry?
 ---@return integer[]? cursor
@@ -224,13 +237,12 @@ function M.jumpto_conflict(num, use_delta)
 
   if view and view:instanceof(StandardView.__get()) then
     ---@cast view StandardView
-    local main = view.cur_layout:get_main_win()
-    local curfile = main.file
+    local main, bufnr = get_valid_main(view)
 
-    if main:is_valid() and curfile:is_valid() then
+    if main then
       local next_idx
       local conflicts, cur, cur_idx = vcs_utils.parse_conflicts(
-        api.nvim_buf_get_lines(curfile.bufnr, 0, -1, false),
+        api.nvim_buf_get_lines(bufnr, 0, -1, false),
         main.id
       )
 
@@ -282,6 +294,61 @@ end
 ---@return diffview.ConflictCount?
 function M.prev_conflict()
   return M.jumpto_conflict(-1, true)
+end
+
+---Move the cursor to an inline-diff hunk in the current `diff1_inline` window,
+---as picked by `picker(bufnr, cursor_row)`.
+---@param picker fun(bufnr: integer, cursor_row: integer): integer?
+local function jump_inline_hunk_by(picker)
+  local view = lib.get_current_view()
+  if not (view and view:instanceof(StandardView.__get())) then return end
+  ---@cast view StandardView
+
+  local main, bufnr = get_valid_main(view)
+  if not main then return end
+
+  local cur = api.nvim_win_get_cursor(main.id)[1] - 1
+  local row = picker(bufnr, cur)
+  if row then
+    api.nvim_win_set_cursor(main.id, { row + 1, 0 })
+  end
+end
+
+---Jump to the next inline-diff hunk in the current `diff1_inline` window.
+function M.next_inline_hunk()
+  jump_inline_hunk_by(require("diffview.scene.inline_diff").next_hunk_row)
+end
+
+---Jump to the previous inline-diff hunk in the current `diff1_inline` window.
+function M.prev_inline_hunk()
+  jump_inline_hunk_by(require("diffview.scene.inline_diff").prev_hunk_row)
+end
+
+---Jump the cursor to the first change in the view's main window after a file
+---is opened. Centralizes the per-layout dispatch (conflict / inline / native
+---`]c`) so it stays consistent across `DiffView` and `FileHistoryView`.
+---@param view StandardView
+function M.jump_to_first_change(view)
+  local main, bufnr = get_valid_main(view)
+  if not main then return end
+
+  api.nvim_win_call(main.id, function()
+    utils.set_cursor(0, 1, 0)
+
+    if view.cur_entry and view.cur_entry.kind == "conflicting" then
+      M.next_conflict()
+    elseif view.cur_layout.name == "diff1_inline" then
+      -- Inline view has `diff=false`, so native `]c` does nothing. Use the
+      -- renderer's cached hunks to land on the first change.
+      local rows = require("diffview.scene.inline_diff").hunk_anchor_rows(bufnr)
+      if rows[1] then api.nvim_win_set_cursor(main.id, { rows[1] + 1, 0 }) end
+    else
+      pcall(vim.cmd, "norm! ]c")
+    end
+    vim.cmd("norm! zz")
+  end)
+
+  view.cur_layout:sync_scroll()
 end
 
 ---Execute `cmd` for each target window in the current view. If no targets
@@ -392,11 +459,10 @@ end
 ---@param view DiffView
 ---@param target "ours"|"theirs"|"base"|"all"|"none"
 local function resolve_all_conflicts(view, target)
-  local main = view.cur_layout:get_main_win()
-  local curfile = main.file
+  local main, bufnr = get_valid_main(view)
 
-  if main:is_valid() and curfile:is_valid() then
-    local lines = api.nvim_buf_get_lines(curfile.bufnr, 0, -1, false)
+  if main then
+    local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
     local conflicts = vcs_utils.parse_conflicts(lines, main.id)
 
     if next(conflicts) then
@@ -421,7 +487,7 @@ local function resolve_all_conflicts(view, target)
         end
 
         content = content or {}
-        api.nvim_buf_set_lines(curfile.bufnr, first - 1, last, false, content)
+        api.nvim_buf_set_lines(bufnr, first - 1, last, false, content)
         offset = offset + (#content - (last - first) - 1)
       end
 
@@ -465,12 +531,11 @@ function M.conflict_choose(target)
 
     if view and view:instanceof(StandardView.__get()) then
       ---@cast view StandardView
-      local main = view.cur_layout:get_main_win()
-      local curfile = main.file
+      local main, bufnr = get_valid_main(view)
 
-      if main:is_valid() and curfile:is_valid() then
+      if main then
         local _, cur = vcs_utils.parse_conflicts(
-          api.nvim_buf_get_lines(curfile.bufnr, 0, -1, false),
+          api.nvim_buf_get_lines(bufnr, 0, -1, false),
           main.id
         )
 
@@ -488,7 +553,7 @@ function M.conflict_choose(target)
             )
           end
 
-          api.nvim_buf_set_lines(curfile.bufnr, cur.first - 1, cur.last, false, content or {})
+          api.nvim_buf_set_lines(bufnr, cur.first - 1, cur.last, false, content or {})
 
           utils.set_cursor(main.id, unpack({
             (content and #content or 0) + cur.first - 1,
@@ -538,6 +603,7 @@ end
 ---@type table<string, Layout>
 local layout_name_map = {
   diff1_plain = Diff1,
+  diff1_inline = Diff1Inline,
   diff2_horizontal = Diff2Hor,
   diff2_vertical = Diff2Ver,
   diff3_horizontal = Diff3Hor,
@@ -630,7 +696,7 @@ function M.cycle_layout()
 end
 
 ---Set a specific layout for the current view.
----@param layout_name string One of: diff1_plain, diff2_horizontal, diff2_vertical, diff3_horizontal, diff3_vertical, diff3_mixed, diff4_mixed
+---@param layout_name string One of: diff1_plain, diff1_inline, diff2_horizontal, diff2_vertical, diff3_horizontal, diff3_vertical, diff3_mixed, diff4_mixed
 function M.set_layout(layout_name)
   return function()
     local layout_class = layout_name_map[layout_name]

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -6,6 +6,7 @@ local actions = require("diffview.actions")
 local lazy = require("diffview.lazy")
 
 local Diff1 = lazy.access("diffview.scene.layouts.diff_1", "Diff1") ---@type Diff1|LazyModule
+local Diff1Inline = lazy.access("diffview.scene.layouts.diff_1_inline", "Diff1Inline") ---@type Diff1Inline|LazyModule
 local Diff2 = lazy.access("diffview.scene.layouts.diff_2", "Diff2") ---@type Diff2|LazyModule
 local Diff2Hor = lazy.access("diffview.scene.layouts.diff_2_hor", "Diff2Hor") ---@type Diff2Hor|LazyModule
 local Diff2Ver = lazy.access("diffview.scene.layouts.diff_2_ver", "Diff2Ver") ---@type Diff2Ver|LazyModule
@@ -150,6 +151,14 @@ M.defaults = {
       default = { "diff2_horizontal", "diff2_vertical" },
       merge_tool = { "diff3_horizontal", "diff3_vertical", "diff3_mixed", "diff4_mixed", "diff1_plain" },
     },
+    -- Options specific to the `diff1_inline` layout.
+    inline = {
+      -- Rendering style. "unified": proper unified diff — old lines shown
+      -- above modifications as virt_lines, added chars highlighted in place.
+      -- "overleaf": deleted chars on modified lines rendered inline as
+      -- strikethrough virtual text (Overleaf-editor style); no block echo.
+      style = "unified",
+    },
   },
   file_panel = {
     listing_style = "tree",
@@ -239,6 +248,14 @@ M.defaults = {
     diff1 = {
       -- Mappings in single window diff layouts
       { "n", "g?", actions.help({ "view", "diff1" }), { desc = "Open the help panel" } },
+    },
+    diff1_inline = {
+      -- Mappings in the `diff1_inline` unified diff layout. Native `]c`/`[c`
+      -- don't work here because the window has `diff=false`, so we provide
+      -- equivalents that walk the renderer's cached hunks.
+      { "n", "]c",  actions.next_inline_hunk,                            { desc = "Jump to the next inline-diff hunk" } },
+      { "n", "[c",  actions.prev_inline_hunk,                            { desc = "Jump to the previous inline-diff hunk" } },
+      { "n", "g?",  actions.help({ "view", "diff1", "diff1_inline" }),   { desc = "Open the help panel" } },
     },
     diff2 = {
       -- Mappings in 2-way diff layouts
@@ -426,6 +443,7 @@ function M.get_log_options(single_file, t, vcs)
 end
 
 ---@alias LayoutName "diff1_plain"
+---       | "diff1_inline"
 ---       | "diff2_horizontal"
 ---       | "diff2_vertical"
 ---       | "diff3_horizontal"
@@ -435,6 +453,7 @@ end
 
 local layout_map = {
   diff1_plain = Diff1,
+  diff1_inline = Diff1Inline,
   diff2_horizontal = Diff2Hor,
   diff2_vertical = Diff2Ver,
   diff3_horizontal = Diff3Hor,
@@ -454,7 +473,10 @@ end
 ---@param layout Layout
 ---@return table?
 function M.get_layout_keymaps(layout)
-  if layout:instanceof(Diff1.__get()) then
+  -- Check Diff1Inline before Diff1 since it's a subclass.
+  if layout:instanceof(Diff1Inline.__get()) then
+    return M._config.keymaps.diff1_inline
+  elseif layout:instanceof(Diff1.__get()) then
     return M._config.keymaps.diff1
   elseif layout:instanceof(Diff2.__get()) then
     return M._config.keymaps.diff2
@@ -664,7 +686,7 @@ function M.setup(user_config)
   do
     -- Validate layouts
     local view = M._config.view
-    local standard_layouts = { "diff1_plain", "diff2_horizontal", "diff2_vertical", -1 }
+    local standard_layouts = { "diff1_plain", "diff1_inline", "diff2_horizontal", "diff2_vertical", -1 }
     local merge_layouts = {
       "diff1_plain",
       "diff3_horizontal",
@@ -719,6 +741,25 @@ function M.setup(user_config)
       if layout and layout ~= -1 and not vim.tbl_contains(list, layout) then
         table.insert(list, layout)
       end
+    end
+
+    -- Validate `view.inline`. A nil style (e.g. user passed `view.inline = {}`)
+    -- silently falls back to the default; only an explicit invalid value errors.
+    -- Reject non-table values (mirrors the `view.cycle_layouts` guard above).
+    if view.inline ~= nil and type(view.inline) ~= "table" then
+      utils.warn("Invalid value for 'view.inline'. Must be a table.")
+      view.inline = utils.tbl_deep_clone(M.defaults.view.inline)
+    end
+    view.inline = view.inline or {}
+    local valid_inline_styles = { "unified", "overleaf" }
+    if view.inline.style == nil then
+      view.inline.style = M.defaults.view.inline.style
+    elseif not vim.tbl_contains(valid_inline_styles, view.inline.style) then
+      utils.err(("Invalid inline style '%s' for 'view.inline.style'! Must be one of (%s)."):format(
+        view.inline.style,
+        fmt_enum(valid_inline_styles)
+      ))
+      view.inline.style = M.defaults.view.inline.style
     end
   end
 

--- a/lua/diffview/hl.lua
+++ b/lua/diffview/hl.lua
@@ -101,9 +101,7 @@ function M.get_hl(name, no_trans)
   else
     local id = api.nvim_get_hl_id_by_name(name)
 
-    if id then
-      hl = api.nvim_get_hl(0, { id = id, link = false })
-    end
+    if id then hl = api.nvim_get_hl(0, { id = id, link = false }) end
   end
 
   if hl then
@@ -179,9 +177,7 @@ function M.get_style(groups, no_trans)
         if hl[attr] then table.insert(res, attr) end
       end
 
-      if #res > 0 then
-        return table.concat(res, ",")
-      end
+      if #res > 0 then return table.concat(res, ",") end
     end
   end
 end
@@ -219,15 +215,11 @@ function M.hi(groups, opt)
     if opt.explicit then
       def_spec = M.hi_spec_to_def_map(opt)
     else
-      def_spec = M.hi_spec_to_def_map(
-        vim.tbl_extend("force", M.get_hl(group, true) or {}, opt)
-      )
+      def_spec = M.hi_spec_to_def_map(vim.tbl_extend("force", M.get_hl(group, true) or {}, opt))
     end
 
     for k, v in pairs(def_spec) do
-      if v == "NONE" then
-        def_spec[k] = nil
-      end
+      if v == "NONE" then def_spec[k] = nil end
     end
 
     api.nvim_set_hl(0, group, def_spec)
@@ -269,9 +261,7 @@ function M.hi_clear(groups)
     return
   end
 
-  if type(groups) ~= "table" then
-    groups = { groups }
-  end
+  if type(groups) ~= "table" then groups = { groups } end
 
   for _, g in ipairs(groups) do
     api.nvim_set_hl(0, g, {})
@@ -339,16 +329,12 @@ local git_status_hl_map = {
   ["!"] = "DiffviewStatusIgnored",
 }
 
-function M.get_git_hl(status)
-  return git_status_hl_map[status]
-end
+function M.get_git_hl(status) return git_status_hl_map[status] end
 
 ---Get the configured status icon for a git status letter.
 ---@param status string Git status letter (e.g., "M", "A", "D").
 ---@return string
-function M.get_status_icon(status)
-  return config.get_config().status_icons[status] or status
-end
+function M.get_status_icon(status) return config.get_config().status_icons[status] or status end
 
 function M.get_colors()
   return {
@@ -429,15 +415,28 @@ function M.update_diff_hl()
   if config.get_config().enhanced_diff_hl then
     M.hi_link("DiffviewDiffDelete", "DiffviewDiffDeleteDim")
   end
+
+  -- Used by the `diff1_inline` layout in "overleaf" style to render deletions
+  -- as strikethrough virtual text. Inherits fg/bg from `DiffviewDiffDelete`
+  -- (resolving through its link chain) so that users who customize diffview's
+  -- deletion colours pick up the change here too, and so `enhanced_diff_hl`
+  -- mode — which relinks `DiffviewDiffDelete` to `DiffviewDiffDeleteDim` —
+  -- is honoured. Runs AFTER the relink above so the final state is read.
+  local del_fg = M.get_fg("DiffviewDiffDelete", true) or "NONE"
+  local del_bg = M.get_bg("DiffviewDiffDelete", true) or "NONE"
+  M.hi("DiffviewDiffDeleteInline", {
+    fg = del_fg,
+    bg = del_bg,
+    style = "strikethrough",
+    default = true,
+  })
 end
 
 function M.setup()
   -- Ensure diff highlights are defined by loading the diff syntax if needed.
   -- Some colorschemes don't set diffAdded/diffRemoved/diffChanged until the
   -- diff filetype is encountered.
-  if vim.fn.hlexists("diffAdded") == 0 then
-    vim.cmd("runtime! syntax/diff.vim")
-  end
+  if vim.fn.hlexists("diffAdded") == 0 then vim.cmd("runtime! syntax/diff.vim") end
 
   for name, v in pairs(M.get_hl_groups()) do
     v = vim.tbl_extend("force", v, { default = true })

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -91,7 +91,7 @@ end
 
 ---@param force? boolean
 function FileEntry:destroy(force)
-  for _, f in ipairs(self.layout:files()) do
+  for _, f in ipairs(self.layout:owned_files()) do
     f:destroy(force)
   end
 
@@ -100,7 +100,7 @@ end
 
 ---@param new_head Rev
 function FileEntry:update_heads(new_head)
-  for _, file in ipairs(self.layout:files()) do
+  for _, file in ipairs(self.layout:owned_files()) do
     if file.rev.track_head then
       file:dispose_buffer()
       file.rev = new_head
@@ -112,7 +112,7 @@ end
 function FileEntry:set_active(flag)
   self.active = flag
 
-  for _, f in ipairs(self.layout:files()) do
+  for _, f in ipairs(self.layout:owned_files()) do
     f.active = flag
   end
 end
@@ -121,9 +121,17 @@ end
 function FileEntry:convert_layout(target_layout)
   if not self.revs then return end
 
+  -- Let the old layout drop any buffer-level render state before it's
+  -- replaced; the new layout reuses the same files/buffers, so leftover
+  -- visuals (e.g. inline-diff extmarks) would otherwise persist.
+  if self.layout.teardown_render then self.layout:teardown_render() end
+
   local get_data
 
-  for _, file in ipairs(self.layout:files()) do
+  -- Scan `owned_files()` rather than `files()` so non-window files
+  -- (e.g. `Diff1Inline.a_file`) still contribute a `get_data` producer
+  -- when converting away from a layout that owns them.
+  for _, file in ipairs(self.layout:owned_files()) do
     if file.get_data then
       get_data = file.get_data
       break
@@ -143,10 +151,10 @@ function FileEntry:convert_layout(target_layout)
   end
 
   self.layout = target_layout({
-    a = utils.tbl_access(self.layout, "a.file") or create_file(self.revs.a, "a"),
-    b = utils.tbl_access(self.layout, "b.file") or create_file(self.revs.b, "b"),
-    c = utils.tbl_access(self.layout, "c.file") or create_file(self.revs.c, "c"),
-    d = utils.tbl_access(self.layout, "d.file") or create_file(self.revs.d, "d"),
+    a = self.layout:get_file_for("a") or create_file(self.revs.a, "a"),
+    b = self.layout:get_file_for("b") or create_file(self.revs.b, "b"),
+    c = self.layout:get_file_for("c") or create_file(self.revs.c, "c"),
+    d = self.layout:get_file_for("d") or create_file(self.revs.d, "d"),
   })
   self:update_merge_context()
 end
@@ -170,10 +178,12 @@ function FileEntry:validate_stage_buffers(stat)
 
             if new_hash and new_hash ~= f.blob_hash then
               if is_modified then
-                utils.warn((
-                  "A file was changed in the index since you started editing it!"
-                  .. " Be careful not to lose any staged changes when writing to this buffer: %s"
-                ):format(api.nvim_buf_get_name(f.bufnr)))
+                utils.warn(
+                  (
+                    "A file was changed in the index since you started editing it!"
+                    .. " Be careful not to lose any staged changes when writing to this buffer: %s"
+                  ):format(api.nvim_buf_get_name(f.bufnr))
+                )
               else
                 f:dispose_buffer()
               end
@@ -194,7 +204,11 @@ end
 ---@param ctx? vcs.MergeContext
 function FileEntry:update_merge_context(ctx)
   ctx = ctx or self.merge_ctx
-  if ctx then self.merge_ctx = ctx else return end
+  if ctx then
+    self.merge_ctx = ctx
+  else
+    return
+  end
 
   local layout = self.layout --[[@as Diff4 ]]
 
@@ -205,9 +219,7 @@ function FileEntry:update_merge_context(ctx)
     )
   end
 
-  if layout.b then
-    layout.b.file.winbar = " LOCAL (Working tree)"
-  end
+  if layout.b then layout.b.file.winbar = " LOCAL (Working tree)" end
 
   if layout.c and ctx.theirs.hash then
     layout.c.file.winbar = (" THEIRS (Incoming changes) %s %s"):format(
@@ -235,9 +247,7 @@ function FileEntry.update_index_stat(adapter, stat)
   stat = stat or pl:stat(pl:join(adapter.ctx.toplevel, "index"))
 
   if stat then
-    if not fstat_cache[adapter.ctx.toplevel] then
-      fstat_cache[adapter.ctx.toplevel] = {}
-    end
+    if not fstat_cache[adapter.ctx.toplevel] then fstat_cache[adapter.ctx.toplevel] = {} end
 
     fstat_cache[adapter.ctx.toplevel].index = {
       mtime = stat.mtime.sec,
@@ -261,10 +271,7 @@ function FileEntry.with_layout(layout_class, opt)
       commit = opt.commit,
       get_data = opt.get_data,
       rev = rev,
-      nulled = utils.sate(
-        opt.nulled,
-        try_should_null(layout_class, rev, opt.status, symbol)
-      ),
+      nulled = utils.sate(opt.nulled, try_should_null(layout_class, rev, opt.status, symbol)),
     }) --[[@as vcs.File ]]
   end
 
@@ -295,7 +302,7 @@ function FileEntry.new_null_entry(adapter)
     nulled = true,
     layout = Diff1({
       b = File.NULL_FILE,
-    })
+    }),
   })
 end
 

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -1,0 +1,908 @@
+-- Inline diff renderer for the `diff1_inline` layout.
+--
+-- The inline strikethrough rendering for deleted characters in the
+-- "overleaf" style is adapted from the sample code shared by
+-- @tienlonghungson in issue #109:
+-- <https://github.com/dlyongemallo/diffview.nvim/issues/109>
+-- which was itself modified from inlinediff-nvim:
+-- <https://github.com/YouSame2/inlinediff-nvim>
+--
+-- The hunk dispatch, style architecture, unified-diff rendering,
+-- hybrid word/char intraline tokenization, navigation, and caching are
+-- original to this implementation.
+
+local api = vim.api
+
+local M = {}
+
+M.ns = api.nvim_create_namespace("diffview_inline_diff")
+
+-- Iterate over UTF-8 characters in `s`. Each step yields the character
+-- substring, its 0-indexed byte offset, and its byte length. Pure-Lua O(n)
+-- traversal: avoids the quadratic cost of `vim.fn.strcharpart(s, i, 1)` in
+-- a per-character loop, which matters on long modified lines.
+-- TODO: if the plugin's minimum Neovim version is raised to 0.12, replace
+-- this decoder with `vim.str_utf_pos(s)`, which returns the byte start
+-- positions of each UTF-8 character in a single call.
+---@param s string
+---@return fun(): string?, integer?, integer?
+local function utf8_iter(s)
+  local len = #s
+  local pos = 1
+  return function()
+    if pos > len then return nil end
+    local b = s:byte(pos)
+    local char_len
+    if b < 0x80 then
+      char_len = 1
+    elseif b < 0xC2 then
+      -- Stray continuation byte or overlong lead; fall back to a single byte
+      -- so malformed input still makes forward progress.
+      char_len = 1
+    elseif b < 0xE0 then
+      char_len = 2
+    elseif b < 0xF0 then
+      char_len = 3
+    elseif b < 0xF8 then
+      char_len = 4
+    else
+      char_len = 1
+    end
+    local remaining = len - pos + 1
+    if char_len > remaining then char_len = remaining end
+    local ch = s:sub(pos, pos + char_len - 1)
+    local start = pos - 1
+    pos = pos + char_len
+    return ch, start, char_len
+  end
+end
+
+-- Classify a byte as a word byte: ASCII alphanumeric, underscore, or any
+-- non-ASCII byte (multi-byte UTF-8 sequences are bucketed as word bytes so
+-- non-Latin scripts tokenize as word runs rather than per-character).
+---@param b integer
+---@return boolean
+local function is_word_byte(b)
+  return b >= 0x80
+    or (b >= 0x30 and b <= 0x39)
+    or (b >= 0x41 and b <= 0x5A)
+    or (b >= 0x61 and b <= 0x7A)
+    or b == 0x5F
+end
+
+-- Classify a UTF-8 character as word-like. Any multi-byte character is
+-- word-like; single-byte characters consult `is_word_byte`.
+---@param ch string
+---@return boolean
+local function is_word_char(ch)
+  if ch == "" then return false end
+  if #ch > 1 then return true end
+  return is_word_byte(ch:byte(1))
+end
+
+-- True when `s` is a word token (a maximal word-char run produced by
+-- `tokenize`). Tokens are either an all-word-char run or a single
+-- non-word char, so the first byte determines the class.
+---@param s string
+---@return boolean
+local function is_word_token(s) return s ~= "" and is_word_byte(s:byte(1)) end
+
+-- Tokenize `s` for word-level intraline diffing. Each maximal run of word
+-- characters forms one token; each non-word character becomes its own
+-- token. Returns the token list and a parallel byte-range map.
+--
+-- Per-character tokenization was tried first, but `vim.diff --minimal`
+-- matches coincidental letters between dissimilar lines (e.g.
+-- "something." and "any tracked metric." share 't', 'e', 'm', 'i', '.')
+-- and splits the diff into small hunks. Rendered in overleaf style those
+-- fragments interleave deleted and inserted text into unreadable
+-- character-level noise. Word tokens sidestep that failure mode: a
+-- shared word is meaningful context, a shared letter is not.
+---@param s string
+---@return string[] tokens
+---@return { byte: integer, byte_len: integer }[] byte_map
+local function tokenize(s)
+  local tokens, byte_map = {}, {}
+  local word_start, word_bytes
+  for ch, byte_pos, char_len in utf8_iter(s) do
+    if is_word_char(ch) then
+      if word_start then
+        tokens[#tokens] = tokens[#tokens] .. ch
+        word_bytes = word_bytes + char_len
+      else
+        tokens[#tokens + 1] = ch
+        word_start, word_bytes = byte_pos, char_len
+      end
+    else
+      if word_start then
+        byte_map[#byte_map + 1] = { byte = word_start, byte_len = word_bytes }
+        word_start = nil
+      end
+      tokens[#tokens + 1] = ch
+      byte_map[#byte_map + 1] = { byte = byte_pos, byte_len = char_len }
+    end
+  end
+  if word_start then byte_map[#byte_map + 1] = { byte = word_start, byte_len = word_bytes } end
+  return tokens, byte_map
+end
+
+-- Decompose `s` into UTF-8 characters with byte offsets. Used to refine a
+-- 1:1 word-token replacement into per-character sub-hunks, preserving
+-- typo-level precision (e.g. `recieve` → `receive` highlights only the
+-- moved `i`).
+---@param s string
+---@return string[] chars
+---@return { byte: integer, byte_len: integer }[] byte_map
+local function split_chars(s)
+  local chars, byte_map = {}, {}
+  for ch, byte_pos, char_len in utf8_iter(s) do
+    chars[#chars + 1] = ch
+    byte_map[#byte_map + 1] = { byte = byte_pos, byte_len = char_len }
+  end
+  return chars, byte_map
+end
+
+-- Diff two unit arrays (tokens or chars) using `vim.diff`. Units are
+-- joined with newlines so each unit maps to one "line" in vim.diff's
+-- output; indices in the returned hunks are 1-based positions into the
+-- input arrays.
+--
+-- Appending a trailing newline to both joined strings is essential.
+-- Without it, `vim.diff` treats the final unit as an incomplete line
+-- and can spuriously classify a matching trailing unit as
+-- deleted+reinserted when one side has many more units after the
+-- common run — e.g. `"function...(status)"` vs the same line with
+-- `" return ... end"` appended would report `)` as deleted and
+-- `) return ... end` as inserted, instead of recognizing `)` as the
+-- end of the common prefix and treating the rest as pure addition.
+-- Same remedy as the outer line-level diff in `render()`.
+---@param a_units string[]
+---@param b_units string[]
+---@return integer[][]
+local function diff_units(a_units, b_units)
+  if #a_units == 0 or #b_units == 0 then return {} end
+  local a = table.concat(a_units, "\n") .. "\n"
+  local b = table.concat(b_units, "\n") .. "\n"
+  return vim.diff(a, b, {
+    result_type = "indices",
+    algorithm = "minimal",
+    ctxlen = 0,
+    linematch = 0,
+    indent_heuristic = false,
+  }) or {}
+end
+
+-- Skip intraline highlighting when a diff produces more than this many
+-- hunks. Applied to word-level hunks as the similarity gate (dissimilar
+-- lines cascade into many small word-level hunks) and to char-level
+-- sub-hunks inside a 1:1 word replacement (if refinement fragments,
+-- render the word as a whole instead).
+local INTRALINE_MAX_HUNKS = 3
+
+-- A 1:1 word replacement is safe to refine to char level only when the
+-- sub-diff won't interleave deleted and inserted chars into garbage. A
+-- single sub-hunk always renders cleanly (one anchor, one span). Two or
+-- three sub-hunks are fine when the words genuinely overlap, signalled
+-- by a shared prefix or suffix of at least two chars (e.g. `recieve`
+-- vs `receive` shares `rec` + `ve`). Without that overlap, a lone
+-- coincidental match (e.g. the single `r` in `param`/`return`)
+-- fragments the diff and renders as `[pa]r[am]eturn` — worse than
+-- falling back to a whole-word `[param]return` replacement.
+---@param old_chars string[]
+---@param new_chars string[]
+---@param n_hunks integer
+---@return boolean
+local function refinement_safe(old_chars, new_chars, n_hunks)
+  if n_hunks == 0 or n_hunks > INTRALINE_MAX_HUNKS then return false end
+  if n_hunks == 1 then return true end
+
+  local pre = 0
+  while pre < #old_chars and pre < #new_chars and old_chars[pre + 1] == new_chars[pre + 1] do
+    pre = pre + 1
+  end
+  if pre >= 2 then return true end
+
+  local suf = 0
+  while
+    suf < #old_chars - pre
+    and suf < #new_chars - pre
+    and old_chars[#old_chars - suf] == new_chars[#new_chars - suf]
+  do
+    suf = suf + 1
+  end
+  return suf >= 2
+end
+
+-- Render a single intraline diff hunk as extmarks. Units (tokens or
+-- characters) are located via `byte_map` with positions relative to the
+-- span's origin at `base_byte`; `span_byte_len` is the byte length of
+-- the span (the full line for word-level hunks, a single token for
+-- refined char-level sub-hunks) and serves as the deletion-anchor
+-- fallback when an index falls off the map.
+---@param bufnr integer
+---@param new_row integer
+---@param base_byte integer
+---@param span_byte_len integer
+---@param byte_map { byte: integer, byte_len: integer }[]
+---@param new_start integer
+---@param new_count integer
+---@param del_text string Joined deleted units ("" if none).
+---@param inline_del boolean
+local function render_hunk(
+  bufnr,
+  new_row,
+  base_byte,
+  span_byte_len,
+  byte_map,
+  new_start,
+  new_count,
+  del_text,
+  inline_del
+)
+  if new_count > 0 then
+    -- A hunk is a contiguous range, so emit one extmark spanning all units
+    -- rather than one per unit (avoids thousands of extmarks on long lines).
+    local first = byte_map[new_start]
+    local last = byte_map[new_start + new_count - 1]
+    if first and last then
+      api.nvim_buf_set_extmark(bufnr, M.ns, new_row, base_byte + first.byte, {
+        end_col = base_byte + last.byte + last.byte_len,
+        hl_group = "DiffviewDiffText",
+        priority = 200,
+      })
+    else
+      -- Defensive fallback when byte_map can't resolve both ends — should
+      -- not happen with a well-formed UTF-8 string but handle it so partial
+      -- highlighting still appears.
+      for k = new_start, new_start + new_count - 1 do
+        local info = byte_map[k]
+        if info then
+          api.nvim_buf_set_extmark(bufnr, M.ns, new_row, base_byte + info.byte, {
+            end_col = base_byte + info.byte + info.byte_len,
+            hl_group = "DiffviewDiffText",
+            priority = 200,
+          })
+        end
+      end
+    end
+  end
+
+  if inline_del and del_text ~= "" then
+    local anchor_col
+    if new_count > 0 then
+      -- Replacement: anchor before the first added unit.
+      anchor_col = base_byte + ((byte_map[new_start] and byte_map[new_start].byte) or span_byte_len)
+    elseif new_start < 1 then
+      -- Pure deletion at the start of the span.
+      anchor_col = base_byte
+    else
+      -- Pure deletion mid/end: anchor after the context unit at new_start.
+      local info = byte_map[new_start]
+      anchor_col = base_byte + (info and (info.byte + info.byte_len) or span_byte_len)
+    end
+
+    api.nvim_buf_set_extmark(bufnr, M.ns, new_row, anchor_col, {
+      virt_text = { { del_text, "DiffviewDiffDeleteInline" } },
+      virt_text_pos = "inline",
+      priority = 200,
+    })
+  end
+end
+
+-- Highlight changed ranges on a paired line. Uses a hybrid
+-- word/char-level diff: hunks are computed at word granularity to avoid
+-- coincidental-letter fragmentation, and 1:1 word-token replacements are
+-- refined with a per-character sub-diff so typo-level precision is
+-- preserved (e.g. `recieve` → `receive` highlights only the moved `i`
+-- rather than the whole word).
+--
+-- When `inline_del` is true, additionally emit inline virtual text for
+-- deleted units (the "overleaf" style). Bails out when the word-level
+-- diff is too fragmented (a signal that the paired lines aren't really
+-- related).
+---@param bufnr integer
+---@param new_row integer 0-indexed row in `bufnr`.
+---@param old_line string
+---@param new_line string
+---@param inline_del boolean Render deleted units as inline virt_text.
+---@return "ok"|"noop"|"skipped" # `ok`: rendered; `noop`: identical (nothing to do); `skipped`: fragmented, caller may want to fall back.
+local function render_char_highlights(bufnr, new_row, old_line, new_line, inline_del)
+  if old_line == new_line then return "noop" end
+  -- Blank-to-nonblank (or vice versa) has no meaningful char-level diff, but
+  -- the lines differ: signal `skipped` so the caller's fallback path still
+  -- renders a line highlight / echoes the old line in overleaf style.
+  if old_line == "" or new_line == "" then return "skipped" end
+
+  local old_tokens = tokenize(old_line)
+  local new_tokens, new_map = tokenize(new_line)
+  local hunks = diff_units(old_tokens, new_tokens)
+  if #hunks == 0 then return "noop" end
+  if #hunks > INTRALINE_MAX_HUNKS then return "skipped" end
+
+  local new_line_len = #new_line
+
+  for _, h in ipairs(hunks) do
+    local old_start, old_count, new_start, new_count = h[1], h[2], h[3], h[4]
+
+    -- Try char-level refinement by diffing the concatenation of the old
+    -- tokens in this hunk against the concatenation of the new tokens.
+    -- This covers:
+    --   - typo-style 1:1 word replacements (`recieve` → `receive`),
+    --   - mid-word edits split across token boundaries
+    --     (`statusend` → `status end`: delete the word, insert
+    --     word+space+word — concat diff sees one inserted space),
+    --   - punctuation swaps (`,` → `;`: one sub-hunk, clean).
+    -- The `refinement_safe` guard rejects concatenations whose char-level
+    -- diff is fragmented without genuine overlap (e.g. `something` vs
+    -- `any tracked metric` shares only coincidental letters and falls
+    -- back to word-level whole-token rendering).
+    local refined = false
+    if old_count > 0 and new_count > 0 then
+      local old_parts = {}
+      for k = old_start, old_start + old_count - 1 do
+        old_parts[#old_parts + 1] = old_tokens[k] or ""
+      end
+      local new_parts = {}
+      for k = new_start, new_start + new_count - 1 do
+        new_parts[#new_parts + 1] = new_tokens[k] or ""
+      end
+      local old_concat = table.concat(old_parts)
+      local new_concat = table.concat(new_parts)
+
+      if old_concat ~= "" and new_concat ~= "" and old_concat ~= new_concat then
+        local old_chars = split_chars(old_concat)
+        local new_chars, new_char_map = split_chars(new_concat)
+        local sub_hunks = diff_units(old_chars, new_chars)
+
+        if refinement_safe(old_chars, new_chars, #sub_hunks) then
+          refined = true
+          local region_start = new_map[new_start]
+          local region_end = new_map[new_start + new_count - 1]
+          local region_base = region_start.byte
+          local region_len = (region_end.byte + region_end.byte_len) - region_base
+
+          for _, sh in ipairs(sub_hunks) do
+            local sos, soc, sns, snc = sh[1], sh[2], sh[3], sh[4]
+            local del_text = ""
+            if inline_del and soc > 0 then
+              local parts = {}
+              for k = sos, sos + soc - 1 do
+                parts[#parts + 1] = old_chars[k] or ""
+              end
+              del_text = table.concat(parts)
+            end
+            render_hunk(
+              bufnr,
+              new_row,
+              region_base,
+              region_len,
+              new_char_map,
+              sns,
+              snc,
+              del_text,
+              inline_del
+            )
+          end
+        end
+      end
+    end
+
+    if not refined then
+      local del_text = ""
+      if inline_del and old_count > 0 then
+        local parts = {}
+        for k = old_start, old_start + old_count - 1 do
+          parts[#parts + 1] = old_tokens[k] or ""
+        end
+        del_text = table.concat(parts)
+      end
+      render_hunk(
+        bufnr,
+        new_row,
+        0,
+        new_line_len,
+        new_map,
+        new_start,
+        new_count,
+        del_text,
+        inline_del
+      )
+    end
+  end
+
+  return "ok"
+end
+
+-- Attach a block of deleted lines as virtual lines near `new_start`.
+---@param bufnr integer
+---@param old_lines string[]
+---@param old_from integer 1-based start index into `old_lines`.
+---@param old_to integer 1-based end index (inclusive).
+---@param new_start integer Line position in new content (0 = before first line).
+---@param anchor_row? integer 0-indexed row to attach to; default `new_start - 1`.
+---@param above? boolean Default: `new_start == 0`.
+---@param del_hl? string Highlight group for the deleted text. Default: `DiffviewDiffDelete`.
+local function render_deleted_block(
+  bufnr,
+  old_lines,
+  old_from,
+  old_to,
+  new_start,
+  anchor_row,
+  above,
+  del_hl
+)
+  del_hl = del_hl or "DiffviewDiffDelete"
+  local virt_lines = {}
+  for k = old_from, old_to do
+    virt_lines[#virt_lines + 1] = {
+      { old_lines[k] or "", del_hl },
+    }
+  end
+
+  if #virt_lines == 0 then return end
+
+  local row = anchor_row
+  if row == nil then row = new_start == 0 and 0 or new_start - 1 end
+
+  if above == nil then above = new_start == 0 end
+
+  local line_count = api.nvim_buf_line_count(bufnr)
+  if line_count == 0 then return end
+
+  if row >= line_count then row = line_count - 1 end
+
+  api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {
+    virt_lines = virt_lines,
+    virt_lines_above = above,
+    priority = 100,
+  })
+end
+
+-- Per-buffer cache of hunks so ]c/[c navigation can find them without
+-- re-scanning extmarks. Keyed by bufnr; cleared by `M.clear` and by a
+-- buffer-lifecycle autocmd so externally-wiped buffers don't leak entries.
+---@type table<integer, integer[][]>
+M._hunks_by_buf = {}
+
+-- Track which buffers already have a cleanup autocmd so we don't register
+-- duplicates across repeated render passes on the same buffer.
+---@type table<integer, true>
+local cache_cleanup_registered = {}
+
+local cache_cleanup_augroup =
+  api.nvim_create_augroup("diffview_inline_diff_hunk_cache", { clear = true })
+
+-- Track buffers whose CursorMoved scroll-adjuster is already installed.
+---@type table<integer, true>
+local scroll_adjuster_registered = {}
+
+local scroll_adjuster_augroup =
+  api.nvim_create_augroup("diffview_inline_diff_scroll", { clear = true })
+
+---@param bufnr integer
+local function register_cache_cleanup(bufnr)
+  if cache_cleanup_registered[bufnr] or not api.nvim_buf_is_valid(bufnr) then return end
+
+  cache_cleanup_registered[bufnr] = true
+  api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
+    group = cache_cleanup_augroup,
+    buffer = bufnr,
+    once = true,
+    callback = function(args)
+      M._hunks_by_buf[args.buf] = nil
+      cache_cleanup_registered[args.buf] = nil
+      -- Buffer-scoped autocmds on the scroll-adjuster group are dropped by
+      -- Neovim when the buffer is wiped, so only the registration flag needs
+      -- resetting here.
+      scroll_adjuster_registered[args.buf] = nil
+    end,
+  })
+end
+
+-- Count virt_lines on a single row that match the `above` orientation.
+---@param bufnr integer
+---@param row integer 0-indexed.
+---@param above boolean
+---@return integer
+local function count_edge_virt_lines(bufnr, row, above)
+  local marks = api.nvim_buf_get_extmarks(bufnr, M.ns, { row, 0 }, { row, -1 }, { details = true })
+  local total = 0
+  for _, m in ipairs(marks) do
+    local d = m[4]
+    if d and d.virt_lines and (d.virt_lines_above or false) == above then
+      total = total + #d.virt_lines
+    end
+  end
+  return total
+end
+
+-- Bump `topline` just enough that virt_lines attached below the last
+-- buffer line are visible whenever the cursor sits on that line.
+-- Neovim's scroll computation does not count virt_lines, so motions
+-- that land at EOF (`G`, `:$`, `}`, `Shift-L`, `<C-End>`, …) leave the
+-- rendered deletions clipped below the viewport — the user sees them
+-- only after a manual `zz`/`zb`. Idempotent: when topline is already
+-- high enough, winrestview is not called (so WinScrolled doesn't
+-- re-fire and there's no feedback loop).
+---@param bufnr integer
+---@param winid integer
+function M.ensure_eof_virt_lines_visible(bufnr, winid)
+  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then return end
+  if api.nvim_win_get_buf(winid) ~= bufnr then return end
+
+  local last_row = api.nvim_buf_line_count(bufnr)
+  if last_row == 0 then return end
+  if api.nvim_win_get_cursor(winid)[1] ~= last_row then return end
+
+  local below = count_edge_virt_lines(bufnr, last_row - 1, false)
+  if below == 0 then return end
+
+  local height = api.nvim_win_get_height(winid)
+  -- Clamp `below` so we never ask for a topline past `last_row`: we can't
+  -- show more virt_lines below the cursor than a full window's worth.
+  local effective_below = math.min(below, math.max(height - 1, 0))
+  local min_topline = math.min(last_row, math.max(1, last_row - (height - 1 - effective_below)))
+
+  api.nvim_win_call(winid, function()
+    local view = vim.fn.winsaveview()
+    if view.topline < min_topline then
+      view.topline = min_topline
+      vim.fn.winrestview(view)
+    end
+  end)
+end
+
+-- Keep `topfill` in sync with the `virt_lines_above` count attached to
+-- line 1: when `topline == 1`, topfill should equal the BOF virt_lines
+-- count so the deletions render inside the viewport above line 1;
+-- otherwise topfill should be 0 so stale filler from a previous render
+-- doesn't leave an empty band at the top after BOF deletions go away
+-- (e.g. re-render with no leading hunks, or a layout switch).
+--
+-- Gated on `M._hunks_by_buf[bufnr]` so we only touch topfill while the
+-- buffer still hosts an inline diff — the CursorMoved autocmd that
+-- calls this function outlives the inline layout, and we don't want to
+-- fight diff-mode's own topfill on a buffer that's since switched
+-- layouts.
+--
+-- `topfill` is normally a diff-mode filler-rows count, but Neovim
+-- honours it for virt_lines_above on topline even when `'diff'` is off.
+---@param bufnr integer
+---@param winid integer
+function M.ensure_bof_virt_lines_visible(bufnr, winid)
+  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then return end
+  if api.nvim_win_get_buf(winid) ~= bufnr then return end
+  if M._hunks_by_buf[bufnr] == nil then return end
+
+  api.nvim_win_call(winid, function()
+    local view = vim.fn.winsaveview()
+    local desired = 0
+    if view.topline == 1 then desired = count_edge_virt_lines(bufnr, 0, true) end
+    if (view.topfill or 0) == desired then return end
+    view.topfill = desired
+    vim.fn.winrestview(view)
+  end)
+end
+
+---@param bufnr integer
+local function register_scroll_adjuster(bufnr)
+  if scroll_adjuster_registered[bufnr] or not api.nvim_buf_is_valid(bufnr) then return end
+
+  scroll_adjuster_registered[bufnr] = true
+  api.nvim_create_autocmd("CursorMoved", {
+    group = scroll_adjuster_augroup,
+    buffer = bufnr,
+    callback = function(args)
+      local winid = api.nvim_get_current_win()
+      M.ensure_eof_virt_lines_visible(args.buf, winid)
+      M.ensure_bof_virt_lines_visible(args.buf, winid)
+    end,
+  })
+end
+
+-- Clear all inline-diff extmarks from the buffer.
+---@param bufnr integer
+function M.clear(bufnr)
+  if bufnr and api.nvim_buf_is_valid(bufnr) then
+    api.nvim_buf_clear_namespace(bufnr, M.ns, 0, -1)
+  end
+  -- Note: keep `cache_cleanup_registered[bufnr]` set. The BufWipeout/BufDelete
+  -- autocmd installed by `register_cache_cleanup` is still pending and will
+  -- reset the flag when it fires. Clearing the flag here would cause the next
+  -- render pass to register a duplicate autocmd.
+  if bufnr then M._hunks_by_buf[bufnr] = nil end
+end
+
+-- Fully detach the inline diff from `bufnr`: clear extmarks and cached hunks
+-- (as `clear()` does), remove the CursorMoved scroll-adjuster autocmd so the
+-- buffer doesn't keep firing a now-useless handler after the inline view is
+-- torn down (e.g. layout switch, or closing the view while keeping the
+-- underlying file buffer alive), and reset any `topfill` that
+-- `ensure_bof_virt_lines_visible()` set on windows showing `bufnr` so
+-- teardown doesn't leave an empty filler band above line 1.
+---@param bufnr integer
+function M.detach(bufnr)
+  M.clear(bufnr)
+  if not bufnr then return end
+  if scroll_adjuster_registered[bufnr] then
+    scroll_adjuster_registered[bufnr] = nil
+    if api.nvim_buf_is_valid(bufnr) then
+      pcall(api.nvim_clear_autocmds, { group = scroll_adjuster_augroup, buffer = bufnr })
+    end
+  end
+  if not api.nvim_buf_is_valid(bufnr) then return end
+  for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+    if api.nvim_win_is_valid(winid) then
+      api.nvim_win_call(winid, function()
+        local view = vim.fn.winsaveview()
+        if (view.topfill or 0) ~= 0 then
+          view.topfill = 0
+          vim.fn.winrestview(view)
+        end
+      end)
+    end
+  end
+end
+
+-- Return the sorted list of 0-indexed rows where each hunk's cursor target
+-- should land. For add/change hunks this is the first modified new-side row;
+-- for pure deletions it's the row adjacent to the virt_lines anchor.
+---@param bufnr integer
+---@return integer[]
+function M.hunk_anchor_rows(bufnr)
+  local hunks = M._hunks_by_buf[bufnr]
+  if not hunks then return {} end
+
+  local rows = {}
+  local line_count = api.nvim_buf_is_valid(bufnr) and api.nvim_buf_line_count(bufnr) or 0
+  local seen = {}
+
+  for _, h in ipairs(hunks) do
+    local new_start, new_count = h[3], h[4]
+    local row
+    if new_count > 0 then
+      row = new_start - 1
+    else
+      -- Pure deletion: anchor at the line that holds the virt_lines.
+      row = new_start == 0 and 0 or new_start - 1
+    end
+    if row < 0 then row = 0 end
+    if line_count > 0 and row >= line_count then row = line_count - 1 end
+
+    if not seen[row] then
+      seen[row] = true
+      rows[#rows + 1] = row
+    end
+  end
+
+  table.sort(rows)
+  return rows
+end
+
+-- Find the row of the first hunk strictly after `cursor_row` (0-indexed).
+---@param bufnr integer
+---@param cursor_row integer
+---@return integer? row
+function M.next_hunk_row(bufnr, cursor_row)
+  for _, r in ipairs(M.hunk_anchor_rows(bufnr)) do
+    if r > cursor_row then return r end
+  end
+end
+
+-- Find the row of the last hunk strictly before `cursor_row` (0-indexed).
+---@param bufnr integer
+---@param cursor_row integer
+---@return integer? row
+function M.prev_hunk_row(bufnr, cursor_row)
+  local rows = M.hunk_anchor_rows(bufnr)
+  local prev
+  for _, r in ipairs(rows) do
+    if r < cursor_row then
+      prev = r
+    else
+      break
+    end
+  end
+  return prev
+end
+
+---@class InlineDiffOpts
+---@field algorithm? string
+---@field linematch? integer
+---@field indent_heuristic? boolean
+---@field style? "unified"|"overleaf" Default: `"unified"`.
+
+---@class InlineDiffStyle
+---@field del_hl string Highlight group for virt_line deletions.
+---@field inline_del boolean Render paired char-level deletions as inline virt_text.
+---@field echo_paired_old boolean Emit full old content as virt_lines above paired modifications.
+---@field change_line_hl? string Line highlight on paired modified rows, or `nil` to skip.
+
+---@type table<string, InlineDiffStyle>
+local STYLES = {
+  -- Proper unified diff: deletions visible as virt_lines above the new block.
+  unified = {
+    del_hl = "DiffviewDiffDelete",
+    inline_del = false,
+    echo_paired_old = true,
+    change_line_hl = "DiffviewDiffChange",
+  },
+  -- Overleaf style: deletions rendered inline as strikethrough virt_text so
+  -- the reader sees the change in flow. No block echo, no line hl — the
+  -- char-level rendering stands alone.
+  overleaf = {
+    del_hl = "DiffviewDiffDeleteInline",
+    inline_del = true,
+    echo_paired_old = false,
+    change_line_hl = nil,
+  },
+}
+
+-- Render a unified inline diff into `bufnr` using extmarks. The buffer is
+-- assumed to contain `new_lines`; deletions and char-level highlights are
+-- layered on top without modifying buffer contents.
+---@param bufnr integer
+---@param old_lines string[] Content of the old side.
+---@param new_lines string[] Content of the new side (matches `bufnr`).
+---@param opts? InlineDiffOpts
+function M.render(bufnr, old_lines, new_lines, opts)
+  opts = opts or {}
+  local style = STYLES[opts.style] or STYLES.unified
+  M.clear(bufnr)
+
+  if not api.nvim_buf_is_valid(bufnr) then return end
+  if api.nvim_buf_line_count(bufnr) == 0 then return end
+
+  -- Terminate with a trailing newline so `vim.diff` treats the last line as a
+  -- complete line. Without it, EOF additions/deletions get classified as
+  -- modifications of the adjacent line (e.g. `{old_last, e} -> {old_last}`
+  -- reports as a 2:1 modify rather than a pure delete of `e`), which both
+  -- hides the EOF hunk's real shape and echoes the unchanged adjacent line
+  -- as a spurious virt_line under the "unified" style.
+  local old = #old_lines > 0 and table.concat(old_lines, "\n") .. "\n" or ""
+  local new = #new_lines > 0 and table.concat(new_lines, "\n") .. "\n" or ""
+
+  local diff_opts = { result_type = "indices" }
+  -- Only forward `algorithm`, `linematch`, and `indent_heuristic` when
+  -- explicitly set so vim.diff's own defaults apply otherwise. This mirrors
+  -- how `'diffopt'` toggles flags/options by presence/absence rather than
+  -- forcing fallback values here.
+  if opts.algorithm ~= nil then diff_opts.algorithm = opts.algorithm end
+  if opts.linematch ~= nil then diff_opts.linematch = opts.linematch end
+  if opts.indent_heuristic ~= nil then diff_opts.indent_heuristic = opts.indent_heuristic end
+
+  local hunks = vim.diff(old, new, diff_opts)
+
+  if not hunks then return end
+
+  M._hunks_by_buf[bufnr] = hunks
+  register_cache_cleanup(bufnr)
+  register_scroll_adjuster(bufnr)
+
+  for _, h in ipairs(hunks) do
+    local old_start, old_count, new_start, new_count = h[1], h[2], h[3], h[4]
+
+    if old_count == 0 and new_count > 0 then
+      -- Pure addition: highlight the new lines.
+      for k = 0, new_count - 1 do
+        local row = new_start - 1 + k
+        api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {
+          line_hl_group = "DiffviewDiffAdd",
+          priority = 100,
+        })
+      end
+    elseif new_count == 0 and old_count > 0 then
+      -- Pure deletion: show the old lines as virtual lines.
+      render_deleted_block(
+        bufnr,
+        old_lines,
+        old_start,
+        old_start + old_count - 1,
+        new_start,
+        nil,
+        nil,
+        style.del_hl
+      )
+    elseif old_count > 0 and new_count > 0 then
+      -- Modification: unified and overleaf diverge on how deletions are
+      -- conveyed. Unified echoes the full old content as virt_lines above
+      -- (block-level unified diff); overleaf relies on char-level inline
+      -- strikethrough on the paired new rows and only uses virt_lines for
+      -- overflow old lines that don't pair with any new line.
+      local paired = math.min(old_count, new_count)
+
+      if style.echo_paired_old then
+        render_deleted_block(
+          bufnr,
+          old_lines,
+          old_start,
+          old_start + old_count - 1,
+          new_start,
+          new_start - 1,
+          true,
+          style.del_hl
+        )
+      elseif old_count > paired then
+        -- Overleaf: overflow old lines still get a virt_line above.
+        local anchor = new_start - 1 + paired - 1
+        render_deleted_block(
+          bufnr,
+          old_lines,
+          old_start + paired,
+          old_start + old_count - 1,
+          new_start,
+          anchor,
+          false,
+          style.del_hl
+        )
+      end
+
+      for k = 0, paired - 1 do
+        local row = new_start - 1 + k
+        local ol = old_lines[old_start + k] or ""
+        local nl = new_lines[new_start + k] or ""
+        local char_result = render_char_highlights(bufnr, row, ol, nl, style.inline_del)
+
+        -- Line highlight. Unified always applies it; overleaf applies it only
+        -- as a fallback when char-level rendering was skipped (fragmented
+        -- pairing) so the reader still sees that the line was modified.
+        local line_hl = style.change_line_hl
+        if not line_hl and char_result == "skipped" then line_hl = "DiffviewDiffChange" end
+        if line_hl then
+          api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {
+            line_hl_group = line_hl,
+            priority = 100,
+          })
+        end
+
+        -- Overleaf fallback: when char-level was skipped and we're not
+        -- already echoing old lines, show this paired old line above the
+        -- new one so the reader can see what changed.
+        if not style.echo_paired_old and char_result == "skipped" and ol ~= nl then
+          render_deleted_block(
+            bufnr,
+            old_lines,
+            old_start + k,
+            old_start + k,
+            new_start + k,
+            row,
+            true,
+            "DiffviewDiffDelete"
+          )
+        end
+      end
+
+      if new_count > paired then
+        for k = paired, new_count - 1 do
+          local row = new_start - 1 + k
+          api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {
+            line_hl_group = "DiffviewDiffAdd",
+            priority = 100,
+          })
+        end
+      end
+    end
+  end
+
+  -- Cover the case where the buffer was already showing its last/first
+  -- line (e.g. a refresh after the user navigated to either edge) — the
+  -- next CursorMoved might not fire until they move again.
+  local winid = vim.fn.bufwinid(bufnr)
+  if winid ~= -1 then
+    M.ensure_eof_virt_lines_visible(bufnr, winid)
+    M.ensure_bof_virt_lines_visible(bufnr, winid)
+  end
+end
+
+M._test = {
+  is_word_char = is_word_char,
+  is_word_token = is_word_token,
+  tokenize = tokenize,
+  split_chars = split_chars,
+  diff_units = diff_units,
+  refinement_safe = refinement_safe,
+  INTRALINE_MAX_HUNKS = INTRALINE_MAX_HUNKS,
+}
+
+return M

--- a/lua/diffview/scene/layout.lua
+++ b/lua/diffview/scene/layout.lua
@@ -60,9 +60,7 @@ Layout.use_entry = async.void(function(self, entry)
     self:set_file_for(sym, layout[sym].file)
   end
 
-  if self:is_valid() then
-    await(self:open_files())
-  end
+  if self:is_valid() then await(self:open_files()) end
 end)
 
 ---@abstract
@@ -76,6 +74,12 @@ function Layout:destroy()
     win:destroy()
   end
 end
+
+---Clear any render state the layout has layered on its buffers (e.g.
+---`diff1_inline`'s extmarks). Called before the layout is replaced via
+---`FileEntry:convert_layout`, since the buffers are reused by the new
+---layout and would otherwise retain stale visuals. Default: no-op.
+function Layout:teardown_render() end
 
 function Layout:clone()
   local clone = self.class({ emitter = self.emitter }) --[[@as Layout ]]
@@ -113,9 +117,7 @@ Layout.create_wins = async.void(function(self, pivot, win_specs, win_order)
   assert(api.nvim_win_is_valid(pivot), "Layout creation requires a valid window pivot!")
 
   for _, win in ipairs(self.windows) do
-    if win.id ~= pivot then
-      win:close(true)
-    end
+    if win.id ~= pivot then win:close(true) end
   end
 
   for _, spec in ipairs(win_specs) do
@@ -154,9 +156,7 @@ function Layout:use_windows(...)
     local win = wins[i]
     win.parent = self
 
-    if utils.vec_indexof(self.windows, win) == -1 then
-      table.insert(self.windows, win)
-    end
+    if utils.vec_indexof(self.windows, win) == -1 then table.insert(self.windows, win) end
   end
 end
 
@@ -182,36 +182,44 @@ function Layout:find_pivot()
   if vim.is_callable(self.pivot_producer) then
     local ret = self.pivot_producer()
 
-    if ret then
-      return ret
-    end
+    if ret then return ret end
   end
 
   vim.cmd("1windo belowright vsp")
 
   local pivot = api.nvim_get_current_win()
 
-  if api.nvim_win_is_valid(last_win) then
-    api.nvim_set_current_win(last_win)
-  end
+  if api.nvim_win_is_valid(last_win) then api.nvim_set_current_win(last_win) end
 
   return pivot
 end
 
 ---@return vcs.File[]
 function Layout:files()
-  return utils.tbl_fmap(self.windows, function(v)
-    return v.file
-  end)
+  return utils.tbl_fmap(self.windows, function(v) return v.file end)
+end
+
+---Return every file the layout is responsible for, including any files that
+---aren't attached to a window (e.g. `Diff1Inline.a_file`). Used by the file
+---entry teardown path so non-window files don't get orphaned.
+---@return vcs.File[]
+function Layout:owned_files() return self:files() end
+
+---Look up the file the layout assigns to `sym`. Default behaviour reads
+---`self[sym].file`; subclasses with files outside the window set can
+---override to expose them (used by `FileEntry:convert_layout`).
+---@param sym string
+---@return vcs.File?
+function Layout:get_file_for(sym)
+  local win = self[sym]
+  return win and win.file or nil
 end
 
 ---Check if the buffers for all the files in the layout are loaded.
 ---@return boolean
 function Layout:is_files_loaded()
   for _, f in ipairs(self:files()) do
-    if not f:is_valid() then
-      return false
-    end
+    if not f:is_valid() then return false end
   end
 
   return true
@@ -259,9 +267,7 @@ function Layout:recover(pivot)
   ---@cast pivot -?
 
   for _, win in ipairs(self.windows) do
-    if win.id ~= pivot then
-      pcall(api.nvim_win_close, win.id, true)
-    end
+    if win.id ~= pivot then pcall(api.nvim_win_close, win.id, true) end
   end
 
   self.windows = {}
@@ -273,17 +279,13 @@ end
 ---Check the validity of all composing layout windows.
 ---@return Layout.State
 function Layout:validate()
-  if not next(self.windows) then
-    return { valid = false }
-  end
+  if not next(self.windows) then return { valid = false } end
 
   local state = { valid = true }
 
   for _, win in ipairs(self.windows) do
     state[win] = win:is_valid()
-    if not state[win] then
-      state.valid = false
-    end
+    if not state[win] then state.valid = false end
   end
 
   return state
@@ -291,9 +293,7 @@ end
 
 ---Check the validity if the layout.
 ---@return boolean
-function Layout:is_valid()
-  return self:validate().valid
-end
+function Layout:is_valid() return self:validate().valid end
 
 ---@return boolean
 function Layout:is_nulled()
@@ -310,9 +310,7 @@ end
 function Layout:ensure()
   local state = self:validate()
 
-  if not state.valid then
-    self:recover()
-  end
+  if not state.valid then self:recover() end
 end
 
 ---Save window local options.
@@ -342,7 +340,9 @@ function Layout:sync_scroll()
 
   for _, win in ipairs(self.windows) do
     local lcount = api.nvim_buf_line_count(api.nvim_win_get_buf(win.id))
-    if lcount > max then target, max = win, lcount end
+    if lcount > max then
+      target, max = win, lcount
+    end
   end
 
   local main_win = self:get_main_win()
@@ -356,16 +356,12 @@ function Layout:sync_scroll()
         vim.cmd("norm! " .. api.nvim_replace_termcodes("<c-e><c-y>", true, true, true))
       end
 
-      if win.id ~= curwin then
-        api.nvim_exec_autocmds("WinLeave", { modeline = false })
-      end
+      if win.id ~= curwin then api.nvim_exec_autocmds("WinLeave", { modeline = false }) end
     end)
   end
 
   -- Cursor will sometimes move +- the value of 'scrolloff'
-  if target ~= nil then
-      api.nvim_win_set_cursor(target.id, cursor)
-  end
+  if target ~= nil then api.nvim_win_set_cursor(target.id, cursor) end
 end
 
 M.Layout = Layout

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -1,0 +1,255 @@
+local async = require("diffview.async")
+local lazy = require("diffview.lazy")
+local Diff1 = require("diffview.scene.layouts.diff_1").Diff1
+local Layout = require("diffview.scene.layout").Layout
+
+local await, pawait = async.await, async.pawait
+local oop = require("diffview.oop")
+
+local config = lazy.require("diffview.config") ---@module "diffview.config"
+local inline_diff = lazy.require("diffview.scene.inline_diff") ---@module "diffview.scene.inline_diff"
+
+local api = vim.api
+local M = {}
+
+---Parse the currently-effective `vim.opt.diffopt` (after Diffview's
+---`apply_diffopt` has merged any `view.diffopt` overrides) into the subset of
+---options the inline renderer cares about. Reading the global option means the
+---inline view honours both the user's existing `'diffopt'` and the per-view
+---overrides applied by `scene/view.lua:apply_diffopt`.
+---
+---`indent_heuristic` is always set to an explicit boolean so its absence from
+---`'diffopt'` forces `vim.diff` to disable the heuristic instead of falling
+---back to whatever default the vim.diff implementation currently uses.
+---@return InlineDiffOpts
+local function effective_diffopt()
+  local out = { indent_heuristic = false }
+  for _, v in ipairs(vim.opt.diffopt:get()) do
+    local key, val = v:match("^([%w_-]+):(.+)$")
+    if key == "algorithm" then
+      out.algorithm = val
+    elseif key == "linematch" then
+      out.linematch = tonumber(val)
+    elseif v == "indent-heuristic" then
+      out.indent_heuristic = true
+    end
+  end
+  return out
+end
+
+---The autocmd group for buffer-local repaint hooks. Shared across all
+---Diff1Inline instances; individual buffers are cleaned up by clearing
+---autocmds scoped to `{ group = ..., buffer = bufnr }`.
+local repaint_augroup = api.nvim_create_augroup("diffview_inline_repaint", { clear = false })
+
+---@class Diff1Inline : Diff1
+---@field a_file vcs.File? Old-side file used only to compute the diff (never rendered in a window).
+---@field _cached_old_lines string[]? Old-side content captured on first render; reused by repaints so each keystroke-level refresh doesn't re-fetch from disk.
+---@field _repaint_bufnr integer? Buffer id the repaint autocmds are attached to (nil when no autocmds are installed).
+local Diff1Inline = oop.create_class("Diff1Inline", Diff1)
+
+---@class Diff1Inline.init.Opt : Diff1.init.Opt
+---@field a vcs.File?
+
+Diff1Inline.name = "diff1_inline"
+Diff1Inline.symbols = { "b" }
+
+---@param opt Diff1Inline.init.Opt
+function Diff1Inline:init(opt)
+  self:super(opt)
+  self:_set_a_file(opt and opt.a or nil)
+end
+
+---Assign the old-side file, tagging `symbol = "a"` so `vcs.File:produce_data()`
+---resolves the left position when invoking a `get_data` producer.
+---@param file vcs.File?
+function Diff1Inline:_set_a_file(file)
+  self.a_file = file
+  if file then file.symbol = "a" end
+end
+
+---@override
+---@return Diff1Inline
+function Diff1Inline:clone()
+  local clone = Layout.clone(self) --[[@as Diff1Inline ]]
+  clone.a_file = self.a_file
+  return clone
+end
+
+---@override
+---@param self Diff1Inline
+---@param pivot integer?
+Diff1Inline.create = async.void(function(self, pivot)
+  await(self:create_wins(pivot, {
+    { "b", "aboveleft vsp" },
+  }, { "b" }))
+  await(self:_render_inline())
+end)
+
+---@override
+---@param self Diff1Inline
+---@param entry FileEntry
+Diff1Inline.use_entry = async.void(function(self, entry)
+  local src = entry.layout
+  assert(src:instanceof(self.class))
+
+  self:set_file_for("b", src.b.file)
+  self:_set_a_file(src.a_file)
+  -- File swap: invalidate cached old content so the next render re-fetches.
+  self._cached_old_lines = nil
+
+  if self:is_valid() then
+    await(self:open_files())
+    await(self:_render_inline())
+  end
+end)
+
+---Fetch the raw lines of the old-side file for diff computation.
+---@param self Diff1Inline
+---@param callback fun(lines: string[])
+Diff1Inline._load_old_lines = async.wrap(function(self, callback)
+  if not self.a_file or self.a_file.nulled or self.a_file.binary then
+    callback({})
+    return
+  end
+
+  if self.a_file:is_valid() then
+    callback(api.nvim_buf_get_lines(self.a_file.bufnr, 0, -1, false))
+    return
+  end
+
+  local ok, err, data = pawait(self.a_file.produce_data, self.a_file)
+  if not ok or err or not data then
+    callback({})
+    return
+  end
+
+  callback(data)
+end)
+
+---Build the options table forwarded to `inline_diff.render`. Merges the
+---effective global `'diffopt'` with the configured inline style.
+---@return InlineDiffOpts
+local function render_opts()
+  local opts = effective_diffopt()
+  local inline_opt = config.get_config().view.inline or {}
+  opts.style = inline_opt.style
+  return opts
+end
+
+---Re-paint extmarks against the buffer's current contents. Called from
+---`InsertLeave`/`TextChanged` autocmds so edits are reflected without a
+---full view rebuild: the old-side content is frozen (it comes from the
+---diff's left revision) and is cached by the initial `_render_inline`,
+---so a repaint only re-reads the new-side buffer and calls
+---`inline_diff.render` again.
+---@param self Diff1Inline
+function Diff1Inline:_repaint()
+  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then return end
+  local bufnr = self.b.file.bufnr
+  if not api.nvim_buf_is_valid(bufnr) then return end
+
+  -- The cache is populated at the end of the initial `_render_inline`. If
+  -- a repaint fires before that completes (e.g. a synthetic TextChanged
+  -- during buffer setup), skip rather than double-fetch from disk.
+  local old_lines = self._cached_old_lines
+  if old_lines == nil then return end
+
+  local new_lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  inline_diff.render(bufnr, old_lines, new_lines, render_opts())
+end
+
+---Install buffer-scoped autocmds that repaint on edits. Fires on exit
+---from insert mode and on any normal-mode text change (d/p/x/c/u/<C-r>
+---…), but NOT on every insert-mode keystroke (`TextChangedI` is
+---intentionally excluded — per-keystroke diffs would be too heavy).
+---Idempotent: if autocmds are already installed for this buffer, this
+---is a no-op.
+---@param self Diff1Inline
+---@param bufnr integer
+local function register_repaint_autocmds(self, bufnr)
+  if self._repaint_bufnr == bufnr then return end
+  -- Different buffer than last time (or first install): clear any prior
+  -- registration before attaching to the new one.
+  if self._repaint_bufnr and api.nvim_buf_is_valid(self._repaint_bufnr) then
+    pcall(api.nvim_clear_autocmds, { group = repaint_augroup, buffer = self._repaint_bufnr })
+  end
+  self._repaint_bufnr = bufnr
+  api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
+    group = repaint_augroup,
+    buffer = bufnr,
+    callback = function() self:_repaint() end,
+  })
+end
+
+---Apply inline-view winopts on the displayed window and render the unified
+---diff as extmarks on the new-side buffer.
+---@param self Diff1Inline
+Diff1Inline._render_inline = async.void(function(self)
+  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then return end
+
+  local bufnr = self.b.file.bufnr
+  local winid = self.b.id
+
+  -- Turn off native diff mode on this window so the unified extmark rendering
+  -- isn't fighting with diff folds/scrollbind.
+  pcall(api.nvim_set_option_value, "diff", false, { win = winid })
+  pcall(api.nvim_set_option_value, "scrollbind", false, { win = winid })
+  pcall(api.nvim_set_option_value, "cursorbind", false, { win = winid })
+  pcall(api.nvim_set_option_value, "foldmethod", "manual", { win = winid })
+  pcall(api.nvim_set_option_value, "foldenable", false, { win = winid })
+
+  local old_lines = self._cached_old_lines
+  if old_lines == nil then
+    old_lines = await(self:_load_old_lines())
+    await(async.scheduler())
+    if not (self.b and self.b:is_valid() and api.nvim_buf_is_valid(bufnr)) then return end
+    self._cached_old_lines = old_lines
+  end
+
+  local new_lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  inline_diff.render(bufnr, old_lines, new_lines, render_opts())
+  register_repaint_autocmds(self, bufnr)
+end)
+
+---@override
+---Diff1Inline owns `a_file` even though it isn't attached to a window, so
+---expose it through `owned_files()` so `FileEntry:destroy()` can tear it
+---down alongside the windowed files.
+---@return vcs.File[]
+function Diff1Inline:owned_files()
+  local out = Layout.files(self)
+  if self.a_file and not vim.tbl_contains(out, self.a_file) then out[#out + 1] = self.a_file end
+  return out
+end
+
+---@override
+---`convert_layout` looks up the file for each symbol via this method; expose
+---`a_file` under the `"a"` slot so converting to a 2-way layout reuses the
+---existing file instead of creating a fresh one (which would orphan the
+---old-side buffer).
+---@param sym string
+---@return vcs.File?
+function Diff1Inline:get_file_for(sym)
+  if sym == "a" then return self.a_file end
+  return Layout.get_file_for(self, sym)
+end
+
+---@override
+function Diff1Inline:teardown_render()
+  if self._repaint_bufnr and api.nvim_buf_is_valid(self._repaint_bufnr) then
+    pcall(api.nvim_clear_autocmds, { group = repaint_augroup, buffer = self._repaint_bufnr })
+  end
+  self._repaint_bufnr = nil
+  self._cached_old_lines = nil
+  if self.b and self.b.file and self.b.file.bufnr then inline_diff.detach(self.b.file.bufnr) end
+end
+
+---@override
+function Diff1Inline:destroy()
+  self:teardown_render()
+  Layout.destroy(self)
+end
+
+M.Diff1Inline = Diff1Inline
+return M

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -49,21 +49,7 @@ return function(view)
         end
       end
     end,
-    file_open_new = function(_, entry)
-      api.nvim_win_call(view.cur_layout:get_main_win().id, function()
-        utils.set_cursor(0, 1, 0)
-
-        if view.cur_entry and view.cur_entry.kind == "conflicting" then
-          actions.next_conflict()
-        else
-          -- Jump to first diff hunk for regular files.
-          pcall(vim.cmd, "norm! ]c")
-        end
-        vim.cmd("norm! zz")
-      end)
-
-      view.cur_layout:sync_scroll()
-    end,
+    file_open_new = function(_, entry) actions.jump_to_first_change(view) end,
     ---@diagnostic disable-next-line: unused-local
     files_updated = function(_, files)
       view.initialized = true

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -4,6 +4,7 @@ local lazy = require("diffview.lazy")
 local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
 local JobStatus = lazy.access("diffview.vcs.utils", "JobStatus") ---@type JobStatus|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
+local actions = lazy.require("diffview.actions") ---@module "diffview.actions"
 local config = lazy.require("diffview.config") ---@module "diffview.config"
 local lib = lazy.require("diffview.lib") ---@module "diffview.lib"
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
@@ -37,14 +38,7 @@ return function(view)
         end
       end
     end,
-    file_open_new = function(_, entry)
-      api.nvim_win_call(view.cur_layout:get_main_win().id, function()
-        utils.set_cursor(0, 1, 0)
-        pcall(vim.cmd, "norm! ]c")
-        vim.cmd("norm! zz")
-      end)
-      view.cur_layout:sync_scroll()
-    end,
+    file_open_new = function(_, entry) actions.jump_to_first_change(view) end,
     open_in_diffview = function()
       local file = view:infer_cur_file()
 

--- a/lua/diffview/tests/functional/config_options_spec.lua
+++ b/lua/diffview/tests/functional/config_options_spec.lua
@@ -124,3 +124,61 @@ describe("mark_placement", function()
     assert.equals("sign_column", conf.file_panel.mark_placement)
   end)
 end)
+
+describe("view.inline.style", function()
+  local original
+  local utils = require("diffview.utils")
+  local orig_err
+  local orig_warn
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+    orig_err = utils.err
+    orig_warn = utils.warn
+    utils.err = function() end
+    utils.warn = function() end
+  end)
+
+  after_each(function()
+    config.setup(original)
+    utils.err = orig_err
+    utils.warn = orig_warn
+  end)
+
+  it("defaults to 'unified'", function()
+    local conf = setup_with({})
+    assert.equals("unified", conf.view.inline.style)
+  end)
+
+  it("accepts 'overleaf'", function()
+    local conf = setup_with({ view = { inline = { style = "overleaf" } } })
+    assert.equals("overleaf", conf.view.inline.style)
+  end)
+
+  it("rejects unknown values and falls back to 'unified'", function()
+    local conf = setup_with({ view = { inline = { style = "bogus" } } })
+    assert.equals("unified", conf.view.inline.style)
+  end)
+
+  it("treats omitted style (e.g. view.inline = {}) as 'use default'", function()
+    local err_called = false
+    utils.err = function() err_called = true end
+
+    local conf = setup_with({ view = { inline = {} } })
+
+    assert.equals("unified", conf.view.inline.style)
+    assert.is_false(err_called, "omitting style should not produce a validation error")
+  end)
+
+  it("warns and falls back when view.inline is a non-table value", function()
+    local warned = false
+    utils.warn = function() warned = true end
+
+    -- A truthy non-table (e.g. user typo'd `view.inline = "overleaf"`) would
+    -- crash on `view.inline.style` without the type guard.
+    local conf = setup_with({ view = { inline = "overleaf" } })
+
+    assert.is_true(warned, "expected a warning about non-table view.inline")
+    assert.equals("unified", conf.view.inline.style)
+  end)
+end)

--- a/lua/diffview/tests/functional/cycle_layouts_spec.lua
+++ b/lua/diffview/tests/functional/cycle_layouts_spec.lua
@@ -176,6 +176,7 @@ describe("diffview.actions.set_layout name resolution", function()
   it("known layout names produce no error", function()
     local known_names = {
       "diff1_plain",
+      "diff1_inline",
       "diff2_horizontal",
       "diff2_vertical",
       "diff3_horizontal",
@@ -454,15 +455,15 @@ describe("diffview.actions.cycle_layout with custom config", function()
     local orig = vim.deepcopy(config.get_config())
     config.setup({
       view = {
-        default = { layout = "diff2_vertical" },
-        cycle_layouts = { default = { "diff2_horizontal" } },
+        default = { layout = "diff1_inline" },
+        cycle_layouts = { default = { "diff2_horizontal", "diff2_vertical" } },
       },
     })
 
     local resolved = config.get_config().view.cycle_layouts.default
     assert.is_true(
-      vim.tbl_contains(resolved, "diff2_vertical"),
-      "diff2_vertical should be auto-inserted into the default cycle"
+      vim.tbl_contains(resolved, "diff1_inline"),
+      "diff1_inline should be auto-inserted into the default cycle"
     )
 
     config.setup(orig)

--- a/lua/diffview/tests/functional/file_entry_spec.lua
+++ b/lua/diffview/tests/functional/file_entry_spec.lua
@@ -13,26 +13,51 @@ describe("diffview.scene.file_entry", function()
     local original_layout = entry.layout
 
     -- Must not error; null entries have no revs.
-    assert.has_no.errors(function()
-      entry:convert_layout(Diff2Hor)
-    end)
+    assert.has_no.errors(function() entry:convert_layout(Diff2Hor) end)
 
     assert.are.equal(original_layout, entry.layout)
+  end)
+
+  it("convert_layout calls teardown_render on the outgoing layout", function()
+    local teardown_calls = 0
+    local rev = GitRev(RevType.STAGE, 0)
+    local file_b = { bufnr = -1 }
+    local old_layout = {
+      files = function() return { file_b } end,
+      owned_files = function() return { file_b } end,
+      get_file_for = function(_, sym) return sym == "b" and file_b or nil end,
+      teardown_render = function() teardown_calls = teardown_calls + 1 end,
+    }
+
+    local entry = FileEntry({
+      adapter = { ctx = { toplevel = vim.uv.cwd() } },
+      path = "README.md",
+      oldpath = nil,
+      revs = { a = rev, b = rev },
+      layout = old_layout,
+      status = "M",
+      stats = {},
+      kind = "working",
+    })
+
+    local new_layout = {}
+    setmetatable(new_layout, {
+      __call = function() return { files = function() return {} end } end,
+    })
+
+    entry:convert_layout(new_layout)
+    eq(1, teardown_calls)
   end)
 
   it("does not treat should_null errors as truthy null markers", function()
     local captured
     local layout_class = setmetatable({
-      should_null = function()
-        error("boom")
-      end,
+      should_null = function() error("boom") end,
     }, {
       __call = function(_, opt)
         captured = opt
         return {
-          files = function()
-            return { opt.b }
-          end,
+          files = function() return { opt.b } end,
         }
       end,
     })
@@ -78,13 +103,15 @@ describe("diffview.scene.file_entry", function()
     it("does not error when merge context entries have nil hashes", function()
       local entry, _, file_stubs = make_entry_with_layout()
 
-      assert.has_no.errors(function()
-        entry:update_merge_context({
-          ours = {},
-          theirs = {},
-          base = {},
-        })
-      end)
+      assert.has_no.errors(
+        function()
+          entry:update_merge_context({
+            ours = {},
+            theirs = {},
+            base = {},
+          })
+        end
+      )
 
       -- Winbars for ours/theirs/base should remain unset.
       assert.is_nil(file_stubs.a.winbar)
@@ -117,13 +144,15 @@ describe("diffview.scene.file_entry", function()
     it("handles a mix of present and missing hashes", function()
       local entry, _, file_stubs = make_entry_with_layout()
 
-      assert.has_no.errors(function()
-        entry:update_merge_context({
-          ours = { hash = "abc123def456" },
-          theirs = {},
-          base = { hash = "def789abc012" },
-        })
-      end)
+      assert.has_no.errors(
+        function()
+          entry:update_merge_context({
+            ours = { hash = "abc123def456" },
+            theirs = {},
+            base = { hash = "def789abc012" },
+          })
+        end
+      )
 
       assert.truthy(file_stubs.a.winbar:find("OURS"))
       assert.is_nil(file_stubs.c.winbar)
@@ -135,24 +164,18 @@ describe("diffview.scene.file_entry", function()
     local seen = {}
     local layout_destroyed = false
 
+    local files_list = {
+      {
+        destroy = function(_, force) seen[#seen + 1] = force end,
+      },
+      {
+        destroy = function(_, force) seen[#seen + 1] = force end,
+      },
+    }
     local layout = {
-      files = function()
-        return {
-          {
-            destroy = function(_, force)
-              seen[#seen + 1] = force
-            end,
-          },
-          {
-            destroy = function(_, force)
-              seen[#seen + 1] = force
-            end,
-          },
-        }
-      end,
-      destroy = function()
-        layout_destroyed = true
-      end,
+      files = function() return files_list end,
+      owned_files = function() return files_list end,
+      destroy = function() layout_destroyed = true end,
     }
 
     local entry = FileEntry({

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -1,0 +1,913 @@
+local api = vim.api
+
+describe("diffview.scene.inline_diff", function()
+  local inline_diff = require("diffview.scene.inline_diff")
+  local created_bufs
+
+  local function fresh_buf(lines)
+    local bufnr = api.nvim_create_buf(false, true)
+    table.insert(created_bufs, bufnr)
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    return bufnr
+  end
+
+  local function extmarks(bufnr)
+    return api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, { details = true })
+  end
+
+  local function line_hls(marks)
+    local out = {}
+    for _, m in ipairs(marks) do
+      if m[4] and m[4].line_hl_group then
+        out[#out + 1] = { row = m[2], hl = m[4].line_hl_group }
+      end
+    end
+    table.sort(out, function(a, b) return a.row < b.row end)
+    return out
+  end
+
+  local function virt_line_counts(marks)
+    local out = {}
+    for _, m in ipairs(marks) do
+      if m[4] and m[4].virt_lines then
+        out[#out + 1] = {
+          row = m[2],
+          count = #m[4].virt_lines,
+          above = m[4].virt_lines_above or false,
+        }
+      end
+    end
+    table.sort(out, function(a, b) return a.row < b.row end)
+    return out
+  end
+
+  local function char_ranges(marks)
+    local out = {}
+    for _, m in ipairs(marks) do
+      if m[4] and m[4].hl_group == "DiffviewDiffText" then
+        out[#out + 1] = { row = m[2], start = m[3], finish = m[4].end_col }
+      end
+    end
+    table.sort(out, function(a, b)
+      if a.row == b.row then return a.start < b.start end
+      return a.row < b.row
+    end)
+    return out
+  end
+
+  local function inline_virt_texts(marks, hl)
+    local out = {}
+    for _, m in ipairs(marks) do
+      local d = m[4]
+      if d and d.virt_text and d.virt_text_pos == "inline" then
+        local chunk = d.virt_text[1]
+        if not hl or (chunk and chunk[2] == hl) then
+          out[#out + 1] = { row = m[2], col = m[3], text = chunk and chunk[1] or "" }
+        end
+      end
+    end
+    table.sort(out, function(a, b)
+      if a.row == b.row then return a.col < b.col end
+      return a.row < b.row
+    end)
+    return out
+  end
+
+  local function virt_line_hls(marks)
+    local out = {}
+    for _, m in ipairs(marks) do
+      if m[4] and m[4].virt_lines then
+        for _, line in ipairs(m[4].virt_lines) do
+          out[#out + 1] = line[1] and line[1][2] or nil
+        end
+      end
+    end
+    return out
+  end
+
+  before_each(function() created_bufs = {} end)
+
+  after_each(function()
+    for _, b in ipairs(created_bufs) do
+      pcall(api.nvim_buf_delete, b, { force = true })
+    end
+  end)
+
+  describe("render", function()
+    it("marks pure-addition hunks with DiffviewDiffAdd", function()
+      local bufnr = fresh_buf({ "line one", "line two", "line three", "line four" })
+      inline_diff.render(bufnr, { "line one", "line four" }, {
+        "line one",
+        "line two",
+        "line three",
+        "line four",
+      })
+
+      local hls = line_hls(extmarks(bufnr))
+      assert.are.same({
+        { row = 1, hl = "DiffviewDiffAdd" },
+        { row = 2, hl = "DiffviewDiffAdd" },
+      }, hls)
+      assert.are.same({}, virt_line_counts(extmarks(bufnr)))
+    end)
+
+    it("renders pure deletions as virt_lines attached to the right row", function()
+      local bufnr = fresh_buf({ "a", "d" })
+      inline_diff.render(bufnr, { "a", "b", "c", "d" }, { "a", "d" })
+
+      local vls = virt_line_counts(extmarks(bufnr))
+      -- Deletion between new line 1 ("a") and new line 2 ("d") -> row 0, below.
+      assert.are.same({ { row = 0, count = 2, above = false } }, vls)
+      -- No line highlights expected for pure deletion.
+      assert.are.same({}, line_hls(extmarks(bufnr)))
+    end)
+
+    it("anchors top-of-file deletions above line 0", function()
+      local bufnr = fresh_buf({ "x", "y" })
+      inline_diff.render(bufnr, { "gone1", "gone2", "x", "y" }, { "x", "y" })
+
+      local vls = virt_line_counts(extmarks(bufnr))
+      assert.are.same({ { row = 0, count = 2, above = true } }, vls)
+    end)
+
+    it("anchors end-of-file deletions below the last line", function()
+      -- Regression: without a trailing newline `vim.diff` treats the last
+      -- new line as unterminated and reports this as a modification hunk
+      -- (conflating the unchanged last line with the EOF deletion), which
+      -- both hid the deletion and echoed the unchanged line as a spurious
+      -- virt_line above. The EOF-deleted block should sit *below* the last
+      -- new-side row.
+      local bufnr = fresh_buf({ "a", "b" })
+      inline_diff.render(bufnr, { "a", "b", "gone1", "gone2" }, { "a", "b" })
+
+      local vls = virt_line_counts(extmarks(bufnr))
+      assert.are.same({ { row = 1, count = 2, above = false } }, vls)
+      -- No paired-modification line_hl — the last line is unchanged.
+      assert.are.same({}, line_hls(extmarks(bufnr)))
+    end)
+
+    it("marks end-of-file additions with DiffviewDiffAdd", function()
+      local bufnr = fresh_buf({ "a", "b", "added1", "added2" })
+      inline_diff.render(bufnr, { "a", "b" }, { "a", "b", "added1", "added2" })
+
+      local hls = line_hls(extmarks(bufnr))
+      assert.are.same({
+        { row = 2, hl = "DiffviewDiffAdd" },
+        { row = 3, hl = "DiffviewDiffAdd" },
+      }, hls)
+      -- No virt_lines for a pure addition.
+      assert.are.same({}, virt_line_counts(extmarks(bufnr)))
+    end)
+
+    it("marks modified lines with DiffChange and char-level DiffText", function()
+      local bufnr = fresh_buf({ "hello wonderful world" })
+      inline_diff.render(bufnr, { "hello world" }, { "hello wonderful world" })
+
+      local hls = line_hls(extmarks(bufnr))
+      assert.are.same({ { row = 0, hl = "DiffviewDiffChange" } }, hls)
+
+      -- Expect at least one char-level DiffText range covering "wonderful ".
+      local ranges = char_ranges(extmarks(bufnr))
+      assert.is_true(#ranges > 0, "expected DiffviewDiffText extmarks")
+
+      -- Unified style echoes the old line above the modification.
+      local vls = virt_line_counts(extmarks(bufnr))
+      assert.are.same({ { row = 0, count = 1, above = true } }, vls)
+    end)
+
+    it("shows old lines as virt_lines above modification hunks", function()
+      -- Pick a 1:1 modification so vim.diff doesn't split into separate
+      -- modify + pure-delete hunks.
+      local bufnr = fresh_buf({ "first changed", "second" })
+      inline_diff.render(bufnr, { "first", "second" }, { "first changed", "second" })
+
+      local hls = line_hls(extmarks(bufnr))
+      local vls = virt_line_counts(extmarks(bufnr))
+
+      assert.are.same({ { row = 0, hl = "DiffviewDiffChange" } }, hls)
+      -- Old line "first" appears above the first paired row.
+      assert.are.same({ { row = 0, count = 1, above = true } }, vls)
+    end)
+
+    it("handles overflow-addition within a modification hunk", function()
+      local bufnr = fresh_buf({ "one changed", "extra" })
+      inline_diff.render(bufnr, { "one" }, { "one changed", "extra" })
+
+      local hls = line_hls(extmarks(bufnr))
+      assert.are.same({
+        { row = 0, hl = "DiffviewDiffChange" },
+        { row = 1, hl = "DiffviewDiffAdd" },
+      }, hls)
+    end)
+
+    it("treats an empty old side as pure addition across the whole buffer", function()
+      local bufnr = fresh_buf({ "first", "second", "third" })
+      inline_diff.render(bufnr, {}, { "first", "second", "third" })
+
+      local hls = line_hls(extmarks(bufnr))
+      assert.are.same({
+        { row = 0, hl = "DiffviewDiffAdd" },
+        { row = 1, hl = "DiffviewDiffAdd" },
+        { row = 2, hl = "DiffviewDiffAdd" },
+      }, hls)
+      assert.are.same({}, virt_line_counts(extmarks(bufnr)))
+    end)
+
+    it("bails out cleanly on an empty buffer", function()
+      -- fresh_buf({}) yields a buffer with no lines; Neovim's default empty
+      -- buffer always has one empty line, but render should be safe either way.
+      local bufnr = fresh_buf({})
+      inline_diff.render(bufnr, { "old" }, api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      assert.is_table(extmarks(bufnr))
+    end)
+
+    it("clear() removes previously-rendered marks", function()
+      local bufnr = fresh_buf({ "a", "b", "c" })
+      inline_diff.render(bufnr, {}, { "a", "b", "c" })
+      assert.is_true(#extmarks(bufnr) > 0)
+
+      inline_diff.clear(bufnr)
+      assert.are.equal(0, #extmarks(bufnr))
+    end)
+
+    it("is idempotent across repeated calls", function()
+      local bufnr = fresh_buf({ "one", "two changed", "three" })
+      inline_diff.render(bufnr, { "one", "two", "three" }, {
+        "one",
+        "two changed",
+        "three",
+      })
+      local first = #extmarks(bufnr)
+
+      inline_diff.render(bufnr, { "one", "two", "three" }, {
+        "one",
+        "two changed",
+        "three",
+      })
+      local second = #extmarks(bufnr)
+
+      assert.are.equal(first, second)
+    end)
+  end)
+
+  describe("overleaf style", function()
+    it("emits inline virt_text for char-level deletions on paired lines", function()
+      local bufnr = fresh_buf({ "hello world" })
+      inline_diff.render(bufnr, { "hello brave world" }, { "hello world" }, { style = "overleaf" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.is_true(#inlines > 0, "expected at least one inline deletion virt_text")
+      -- The deleted run should be on the modified line and contain "brave".
+      local any = false
+      for _, v in ipairs(inlines) do
+        if v.text:find("brave") then any = true end
+      end
+      assert.is_true(any, "expected deleted text to contain 'brave'")
+    end)
+
+    it("still emits DiffText hl on added chars in overleaf style", function()
+      local bufnr = fresh_buf({ "hello brave new world" })
+      inline_diff.render(
+        bufnr,
+        { "hello world" },
+        { "hello brave new world" },
+        { style = "overleaf" }
+      )
+
+      local ranges = char_ranges(extmarks(bufnr))
+      assert.is_true(#ranges > 0, "expected DiffviewDiffText extmarks on added chars")
+    end)
+
+    it("uses DiffviewDiffDeleteInline hl for whole-line deletions", function()
+      local bufnr = fresh_buf({ "a", "c" })
+      inline_diff.render(bufnr, { "a", "b", "c" }, { "a", "c" }, { style = "overleaf" })
+
+      local hls = virt_line_hls(extmarks(bufnr))
+      assert.are.same({ "DiffviewDiffDeleteInline" }, hls)
+    end)
+
+    it("uses DiffviewDiffDelete hl in default unified style", function()
+      local bufnr = fresh_buf({ "a", "c" })
+      inline_diff.render(bufnr, { "a", "b", "c" }, { "a", "c" })
+
+      local hls = virt_line_hls(extmarks(bufnr))
+      assert.are.same({ "DiffviewDiffDelete" }, hls)
+    end)
+
+    it("does NOT emit inline deletion virt_text in unified style", function()
+      local bufnr = fresh_buf({ "hello world" })
+      inline_diff.render(bufnr, { "hello brave world" }, { "hello world" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.are.equal(0, #inlines)
+    end)
+
+    it("falls back to unified for unknown style values", function()
+      local bufnr = fresh_buf({ "a", "c" })
+      inline_diff.render(bufnr, { "a", "b", "c" }, { "a", "c" }, { style = "bogus" })
+
+      local hls = virt_line_hls(extmarks(bufnr))
+      assert.are.same({ "DiffviewDiffDelete" }, hls)
+    end)
+
+    it("does not echo old paired lines as virt_lines (no double-rendering)", function()
+      local bufnr = fresh_buf({ "first changed", "second" })
+      inline_diff.render(
+        bufnr,
+        { "first", "second" },
+        { "first changed", "second" },
+        { style = "overleaf" }
+      )
+
+      -- No block virt_lines for the paired modification in overleaf.
+      assert.are.same({}, virt_line_counts(extmarks(bufnr)))
+    end)
+
+    it("does not apply DiffChange line_hl on paired modified rows", function()
+      local bufnr = fresh_buf({ "first changed", "second" })
+      inline_diff.render(
+        bufnr,
+        { "first", "second" },
+        { "first changed", "second" },
+        { style = "overleaf" }
+      )
+
+      local hls = line_hls(extmarks(bufnr))
+      for _, h in ipairs(hls) do
+        assert.are_not.equal("DiffviewDiffChange", h.hl)
+      end
+    end)
+
+    it("still emits virt_lines for overflow old lines within a modification", function()
+      -- Modification: 2 old paired with 1 new, so 1 unpaired old overflow.
+      -- Use unrelated content to force a single 2:1 modification hunk rather
+      -- than a 1:1 modify + pure-delete split.
+      local bufnr = fresh_buf({ "alpha" })
+      inline_diff.render(bufnr, { "xyz", "pqr" }, { "alpha" }, { style = "overleaf" })
+
+      local hls = virt_line_hls(extmarks(bufnr))
+      -- Whatever vim.diff produces, any virt_lines emitted must be in the
+      -- overleaf deletion hl group.
+      for _, h in ipairs(hls) do
+        assert.are.equal("DiffviewDiffDeleteInline", h)
+      end
+    end)
+  end)
+
+  describe("hunk navigation", function()
+    -- Set up a buffer with three discontiguous hunks: pure add at top,
+    -- change in the middle, and pure deletion at the end.
+    local function buf_with_hunks()
+      local new = {
+        "added one",
+        "added two",
+        "context",
+        "middle changed",
+        "context",
+        "context",
+      }
+      local old = {
+        "context",
+        "middle",
+        "context",
+        "context",
+        "trailing-old",
+      }
+      local bufnr = fresh_buf(new)
+      inline_diff.render(bufnr, old, new)
+      return bufnr
+    end
+
+    it("returns anchor rows sorted, one per hunk", function()
+      local bufnr = buf_with_hunks()
+      local rows = inline_diff.hunk_anchor_rows(bufnr)
+      assert.is_true(#rows >= 2, "expected multiple hunks")
+      for i = 2, #rows do
+        assert.is_true(rows[i] > rows[i - 1], "rows must be strictly increasing")
+      end
+    end)
+
+    it("next_hunk_row returns the first row strictly after the cursor", function()
+      local bufnr = buf_with_hunks()
+      local rows = inline_diff.hunk_anchor_rows(bufnr)
+      -- From the top, next_hunk from -1 should be the first anchor.
+      assert.are.equal(rows[1], inline_diff.next_hunk_row(bufnr, -1))
+      -- From row[1], next should be rows[2].
+      if #rows >= 2 then assert.are.equal(rows[2], inline_diff.next_hunk_row(bufnr, rows[1])) end
+    end)
+
+    it("next_hunk_row returns nil past the last hunk", function()
+      local bufnr = buf_with_hunks()
+      local rows = inline_diff.hunk_anchor_rows(bufnr)
+      assert.is_nil(inline_diff.next_hunk_row(bufnr, rows[#rows]))
+    end)
+
+    it("prev_hunk_row returns nil before the first hunk", function()
+      local bufnr = buf_with_hunks()
+      local rows = inline_diff.hunk_anchor_rows(bufnr)
+      assert.is_nil(inline_diff.prev_hunk_row(bufnr, rows[1]))
+    end)
+
+    it("prev_hunk_row returns the last row strictly before the cursor", function()
+      local bufnr = buf_with_hunks()
+      local rows = inline_diff.hunk_anchor_rows(bufnr)
+      if #rows >= 2 then
+        assert.are.equal(rows[1], inline_diff.prev_hunk_row(bufnr, rows[2]))
+        -- From well past the last hunk, prev is the last one.
+        assert.are.equal(rows[#rows], inline_diff.prev_hunk_row(bufnr, rows[#rows] + 100))
+      end
+    end)
+
+    it("clear() also drops the cached hunks", function()
+      local bufnr = buf_with_hunks()
+      assert.is_true(#inline_diff.hunk_anchor_rows(bufnr) > 0)
+      inline_diff.clear(bufnr)
+      assert.are.same({}, inline_diff.hunk_anchor_rows(bufnr))
+    end)
+
+    it("drops cached hunks when the buffer is wiped externally", function()
+      local bufnr = buf_with_hunks()
+      assert.is_not_nil(inline_diff._hunks_by_buf[bufnr])
+
+      -- Simulate a foreign owner deleting the buffer without calling clear().
+      api.nvim_buf_delete(bufnr, { force = true })
+
+      -- The buffer id may be reused; just confirm the stale entry is gone.
+      assert.is_nil(inline_diff._hunks_by_buf[bufnr])
+    end)
+
+    it("detach() removes the CursorMoved scroll-adjuster autocmd", function()
+      local bufnr = buf_with_hunks()
+      local before = api.nvim_get_autocmds({
+        group = "diffview_inline_diff_scroll",
+        buffer = bufnr,
+      })
+      assert.is_true(#before > 0, "render should have installed the scroll adjuster")
+
+      inline_diff.detach(bufnr)
+
+      local after = api.nvim_get_autocmds({
+        group = "diffview_inline_diff_scroll",
+        buffer = bufnr,
+      })
+      assert.are.equal(0, #after)
+      assert.are.same({}, inline_diff.hunk_anchor_rows(bufnr))
+      assert.are.equal(0, #extmarks(bufnr))
+    end)
+
+    it("detach() followed by render reinstalls the scroll-adjuster autocmd", function()
+      local bufnr = buf_with_hunks()
+      inline_diff.detach(bufnr)
+
+      inline_diff.render(bufnr, { "a", "b" }, { "a", "b", "c" })
+
+      local autocmds = api.nvim_get_autocmds({
+        group = "diffview_inline_diff_scroll",
+        buffer = bufnr,
+      })
+      assert.are.equal(1, #autocmds)
+    end)
+
+    it("detach() resets topfill on windows displaying the buffer", function()
+      -- Regression: without resetting topfill, tearing down the inline layout
+      -- (e.g. layout switch) while `ensure_bof_virt_lines_visible` had raised
+      -- `topfill` leaves an empty filler band above line 1 in the viewport.
+      local new_lines = { "line 1", "line 2", "line 3" }
+      local old_lines = { "gone 1", "gone 2", "line 1", "line 2", "line 3" }
+      local bufnr = fresh_buf(new_lines)
+      inline_diff.render(bufnr, old_lines, new_lines)
+
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      api.nvim_win_set_cursor(win, { 1, 0 })
+      vim.fn.winrestview({ topline = 1, topfill = 0 })
+      inline_diff.ensure_bof_virt_lines_visible(bufnr, win)
+      assert.are.equal(2, vim.fn.winsaveview().topfill or 0)
+
+      inline_diff.detach(bufnr)
+
+      assert.are.equal(0, vim.fn.winsaveview().topfill or 0)
+    end)
+  end)
+
+  describe("helpers", function()
+    local h = inline_diff._test
+
+    it("split_chars decomposes multi-byte characters with byte ranges", function()
+      local chars, m = h.split_chars("a\xc3\xa9b")
+      assert.are.same({ "a", "\xc3\xa9", "b" }, chars)
+      assert.are.equal(3, #m)
+      assert.are.equal(0, m[1].byte)
+      assert.are.equal(1, m[1].byte_len)
+      assert.are.equal(1, m[2].byte)
+      assert.are.equal(2, m[2].byte_len)
+      assert.are.equal(3, m[3].byte)
+      assert.are.equal(1, m[3].byte_len)
+    end)
+
+    it("tokenize groups word-char runs and splits non-word chars individually", function()
+      local tokens, m = h.tokenize("hello, world!")
+      assert.are.same({ "hello", ",", " ", "world", "!" }, tokens)
+      assert.are.equal(5, #m)
+      assert.are.equal(0, m[1].byte)
+      assert.are.equal(5, m[1].byte_len)
+      assert.are.equal(5, m[2].byte)
+      assert.are.equal(1, m[2].byte_len)
+      assert.are.equal(7, m[4].byte)
+      assert.are.equal(5, m[4].byte_len)
+    end)
+
+    it("tokenize keeps multi-byte letters inside their word run", function()
+      -- "café" = 'c','a','f','é' → one word token spanning 5 bytes.
+      local tokens, m = h.tokenize("caf\xc3\xa9")
+      assert.are.same({ "caf\xc3\xa9" }, tokens)
+      assert.are.equal(0, m[1].byte)
+      assert.are.equal(5, m[1].byte_len)
+    end)
+
+    it("is_word_token distinguishes word runs from punctuation tokens", function()
+      assert.is_true(h.is_word_token("foo"))
+      assert.is_true(h.is_word_token("_x"))
+      assert.is_true(h.is_word_token("\xc3\xa9"))
+      assert.is_false(h.is_word_token(","))
+      assert.is_false(h.is_word_token(" "))
+      assert.is_false(h.is_word_token(""))
+    end)
+
+    it("diff_units returns [] when either side is empty", function()
+      assert.are.same({}, h.diff_units({}, { "a" }))
+      assert.are.same({}, h.diff_units({ "a" }, {}))
+    end)
+
+    it(
+      "INTRALINE_MAX_HUNKS is a positive integer",
+      function() assert.is_true(h.INTRALINE_MAX_HUNKS >= 1) end
+    )
+
+    it("refinement_safe admits single-hunk sub-diffs regardless of overlap", function()
+      -- One hunk cannot interleave, so even unrelated words (foo/bar) are safe.
+      assert.is_true(h.refinement_safe({ "f", "o", "o" }, { "b", "a", "r" }, 1))
+    end)
+
+    it("refinement_safe admits multi-hunk sub-diffs with a shared prefix", function()
+      -- "recieve" / "receive" share prefix "rec" and suffix "ve".
+      assert.is_true(
+        h.refinement_safe(
+          { "r", "e", "c", "i", "e", "v", "e" },
+          { "r", "e", "c", "e", "i", "v", "e" },
+          2
+        )
+      )
+    end)
+
+    it("refinement_safe rejects multi-hunk sub-diffs with no substantial overlap", function()
+      -- "param" / "return" share only a coincidental 'r'; refining would
+      -- interleave the deleted and inserted chars.
+      assert.is_false(
+        h.refinement_safe({ "p", "a", "r", "a", "m" }, { "r", "e", "t", "u", "r", "n" }, 2)
+      )
+    end)
+
+    it(
+      "refinement_safe rejects when hunk count exceeds the limit",
+      function() assert.is_false(h.refinement_safe({ "a" }, { "b" }, h.INTRALINE_MAX_HUNKS + 1)) end
+    )
+  end)
+
+  describe("similarity gate", function()
+    local function text_extmarks(bufnr)
+      local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, { details = true })
+      local out = { hl = 0, inline = 0 }
+      for _, m in ipairs(marks) do
+        local d = m[4]
+        if d.hl_group == "DiffviewDiffText" then out.hl = out.hl + 1 end
+        if d.virt_text and d.virt_text_pos == "inline" then out.inline = out.inline + 1 end
+      end
+      return out
+    end
+
+    it("renders char-level highlights for similar paired lines", function()
+      local bufnr = fresh_buf({ "hello brave world" })
+      inline_diff.render(bufnr, { "hello world" }, { "hello brave world" })
+      local t = text_extmarks(bufnr)
+      assert.is_true(t.hl > 0, "expected DiffText on added chars for similar lines")
+    end)
+
+    it("skips char-level highlights when lines are too dissimilar (unified)", function()
+      -- Two sentences sharing only the first clause; the divergent tails are
+      -- completely different content that would otherwise produce fragmented
+      -- char-level hunks.
+      local old = "This is a plain, singular window. This is available in case"
+      local new = "This is a plain, singular window with no diff rendering —"
+      local bufnr = fresh_buf({ new })
+      inline_diff.render(bufnr, { old }, { new })
+      local t = text_extmarks(bufnr)
+      assert.are.equal(0, t.hl, "expected no DiffText fragments on dissimilar pairing")
+    end)
+
+    it("skips inline deletions in overleaf for dissimilar pairings", function()
+      local old = "This is a plain, singular window. This is available in case"
+      local new = "This is a plain, singular window with no diff rendering —"
+      local bufnr = fresh_buf({ new })
+      inline_diff.render(bufnr, { old }, { new }, { style = "overleaf" })
+      local t = text_extmarks(bufnr)
+      assert.are.equal(0, t.inline, "expected no inline deletion virt_text on dissimilar pairing")
+    end)
+
+    it("falls back to block echo + line_hl in overleaf when char-level skips", function()
+      -- When overleaf's char-level rendering is gated off, the paired
+      -- modification would otherwise be invisible. Verify the fallback
+      -- emits a DiffChange line_hl and a virt_line with the old content.
+      local old = "This is a plain, singular window. This is available in case"
+      local new = "This is a plain, singular window with no diff rendering —"
+      local bufnr = fresh_buf({ new })
+      inline_diff.render(bufnr, { old }, { new }, { style = "overleaf" })
+
+      local hls = line_hls(extmarks(bufnr))
+      assert.are.same({ { row = 0, hl = "DiffviewDiffChange" } }, hls)
+
+      local vls = virt_line_hls(extmarks(bufnr))
+      assert.are.same({ "DiffviewDiffDelete" }, vls)
+    end)
+  end)
+
+  describe("intraline tokenization", function()
+    -- Regression: per-character diffing matched coincidental letters
+    -- ('t', 'e', 'm', 'i', '.') between "something." and "any tracked
+    -- metric." and fragmented the change into interleaved per-char
+    -- virt_text in overleaf. Word-level tokens keep the deleted word as
+    -- a single strikethrough unit before the added phrase.
+    it("renders multi-word replacements without char interleaving (overleaf)", function()
+      local old = "# Print the log, showing only passes that changed something."
+      local new = "# Print the log, showing only passes that changed any tracked metric."
+      local bufnr = fresh_buf({ new })
+      inline_diff.render(bufnr, { old }, { new }, { style = "overleaf" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.are.equal(1, #inlines, "expected a single inline deletion virt_text")
+      assert.are.equal("something", inlines[1].text)
+      -- Anchor sits before "any" in the new line.
+      local anchor_at = ("# Print the log, showing only passes that changed "):len()
+      assert.are.equal(anchor_at, inlines[1].col)
+    end)
+
+    it("refines 1:1 word replacements with char-level precision", function()
+      -- "recieve" → "receive" is one word-level 1:1 pair, so the sub-diff
+      -- kicks in. DiffText highlights should cover only the moved letter
+      -- rather than the whole word.
+      local bufnr = fresh_buf({ "receive" })
+      inline_diff.render(bufnr, { "recieve" }, { "receive" })
+
+      local ranges = char_ranges(extmarks(bufnr))
+      assert.is_true(#ranges > 0, "expected char-level DiffText inside the word")
+      for _, r in ipairs(ranges) do
+        assert.is_true(
+          r.finish - r.start < #"receive",
+          "each highlight should be narrower than the full word"
+        )
+      end
+    end)
+
+    it("emits char-level inline deletions inside a 1:1 word replacement (overleaf)", function()
+      local bufnr = fresh_buf({ "receive" })
+      inline_diff.render(bufnr, { "recieve" }, { "receive" }, { style = "overleaf" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.is_true(#inlines >= 1, "expected inline deletion from char-level refinement")
+      for _, v in ipairs(inlines) do
+        assert.is_true(
+          #v.text < #"recieve",
+          "refined inline deletions must be sub-word, not the whole old word"
+        )
+      end
+    end)
+
+    it("treats multi-word replacements atomically (no intra-word refinement)", function()
+      -- Replacing one word with multiple words is not a 1:1 pair, so the
+      -- whole deleted word sits before the added tokens as a single
+      -- strikethrough run rather than being split char-by-char.
+      local bufnr = fresh_buf({ "any tracked metric" })
+      inline_diff.render(bufnr, { "something" }, { "any tracked metric" }, { style = "overleaf" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.are.equal(1, #inlines)
+      assert.are.equal("something", inlines[1].text)
+    end)
+
+    it("keeps punctuation swaps as atomic token hunks", function()
+      -- A single-char punctuation change (is_word_token=false) must not
+      -- trigger char-level refinement — the hunk stays at token level.
+      local bufnr = fresh_buf({ "a; b" })
+      inline_diff.render(bufnr, { "a, b" }, { "a; b" }, { style = "overleaf" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.are.equal(1, #inlines)
+      assert.are.equal(",", inlines[1].text)
+    end)
+
+    it("ensure_eof_virt_lines_visible bumps topline so trailing deletions fit", function()
+      -- Build a buffer large enough that `G` lands line N at the bottom of
+      -- the window with virt_lines_below clipped. After adjustment, topline
+      -- must rise enough that the 3 trailing virt_lines fit below the cursor.
+      local new_lines = {}
+      for i = 1, 20 do
+        new_lines[i] = "line " .. i
+      end
+      local old_lines = {}
+      for i = 1, 23 do
+        old_lines[i] = "line " .. i
+      end
+
+      local bufnr = fresh_buf(new_lines)
+      inline_diff.render(bufnr, old_lines, new_lines)
+
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      pcall(api.nvim_win_set_height, win, 13)
+      api.nvim_win_set_cursor(win, { 20, 0 })
+
+      local height = api.nvim_win_get_height(win)
+      -- Force an initial topline that clips the EOF virt_lines (cursor sits
+      -- at the very bottom row).
+      vim.fn.winrestview({ topline = 20 - height + 1 })
+      local before = vim.fn.winsaveview().topline
+
+      inline_diff.ensure_eof_virt_lines_visible(bufnr, win)
+      local after = vim.fn.winsaveview().topline
+
+      assert.is_true(after > before, "topline should have risen to reveal EOF virt_lines")
+      -- 3 virt_lines below line 20 in a 13-row window: cursor must sit at
+      -- row height - below = 10, so topline = 20 - 10 + 1 = 11.
+      assert.are.equal(11, after)
+    end)
+
+    it(
+      "ensure_eof_virt_lines_visible is a no-op when the cursor is not on the last line",
+      function()
+        local bufnr = fresh_buf({ "a", "b", "c" })
+        inline_diff.render(bufnr, { "a", "b", "c", "d", "e" }, { "a", "b", "c" })
+
+        local win = api.nvim_get_current_win()
+        api.nvim_win_set_buf(win, bufnr)
+        api.nvim_win_set_cursor(win, { 1, 0 })
+
+        local before = vim.fn.winsaveview().topline
+        inline_diff.ensure_eof_virt_lines_visible(bufnr, win)
+        assert.are.equal(before, vim.fn.winsaveview().topline)
+      end
+    )
+
+    it("ensure_eof_virt_lines_visible is a no-op when there are no EOF virt_lines", function()
+      local bufnr = fresh_buf({ "a", "b", "c" })
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      api.nvim_win_set_cursor(win, { 3, 0 })
+
+      local before = vim.fn.winsaveview().topline
+      inline_diff.ensure_eof_virt_lines_visible(bufnr, win)
+      assert.are.equal(before, vim.fn.winsaveview().topline)
+    end)
+
+    it("ensure_bof_virt_lines_visible sets topfill so leading deletions render", function()
+      -- 3 deleted lines before the first surviving line. `virt_lines_above`
+      -- on row 0 are clipped at `topline=1` unless `topfill` is set.
+      local new_lines = { "line 1", "line 2", "line 3" }
+      local old_lines = { "gone 1", "gone 2", "gone 3", "line 1", "line 2", "line 3" }
+      local bufnr = fresh_buf(new_lines)
+      inline_diff.render(bufnr, old_lines, new_lines)
+
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      api.nvim_win_set_cursor(win, { 1, 0 })
+      vim.fn.winrestview({ topline = 1, topfill = 0 })
+      assert.are.equal(0, vim.fn.winsaveview().topfill or 0)
+
+      inline_diff.ensure_bof_virt_lines_visible(bufnr, win)
+      assert.are.equal(3, vim.fn.winsaveview().topfill or 0)
+    end)
+
+    it("ensure_bof_virt_lines_visible is a no-op when topline is not 1", function()
+      local new_lines = {}
+      for i = 1, 10 do
+        new_lines[i] = "line " .. i
+      end
+      local old_lines = { "gone 1", "gone 2" }
+      for i = 1, 10 do
+        old_lines[#old_lines + 1] = "line " .. i
+      end
+      local bufnr = fresh_buf(new_lines)
+      inline_diff.render(bufnr, old_lines, new_lines)
+
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      api.nvim_win_set_cursor(win, { 5, 0 })
+      vim.fn.winrestview({ topline = 3, topfill = 0 })
+
+      inline_diff.ensure_bof_virt_lines_visible(bufnr, win)
+      assert.are.equal(0, vim.fn.winsaveview().topfill or 0)
+    end)
+
+    it("ensure_bof_virt_lines_visible is a no-op when there are no BOF virt_lines", function()
+      local bufnr = fresh_buf({ "a", "b", "c" })
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      api.nvim_win_set_cursor(win, { 1, 0 })
+
+      local before = vim.fn.winsaveview().topfill or 0
+      inline_diff.ensure_bof_virt_lines_visible(bufnr, win)
+      assert.are.equal(before, vim.fn.winsaveview().topfill or 0)
+    end)
+
+    it("ensure_bof_virt_lines_visible clears stale topfill when BOF deletions go away", function()
+      -- Regression: topfill is window state, so a render that previously set
+      -- it (for BOF virt_lines above line 1) needs to clear it on a later
+      -- render where those deletions are gone; otherwise the viewport shows
+      -- an empty filler band above line 1.
+      local new_lines = { "line 1", "line 2", "line 3" }
+      local old_lines = { "gone 1", "gone 2", "line 1", "line 2", "line 3" }
+      local bufnr = fresh_buf(new_lines)
+      inline_diff.render(bufnr, old_lines, new_lines)
+
+      local win = api.nvim_get_current_win()
+      api.nvim_win_set_buf(win, bufnr)
+      api.nvim_win_set_cursor(win, { 1, 0 })
+      vim.fn.winrestview({ topline = 1, topfill = 0 })
+      inline_diff.ensure_bof_virt_lines_visible(bufnr, win)
+      assert.are.equal(2, vim.fn.winsaveview().topfill or 0)
+
+      -- Re-render with no BOF deletions; topfill must fall back to 0.
+      inline_diff.render(bufnr, new_lines, new_lines)
+      vim.fn.winrestview({ topline = 1, topfill = 2 })
+      inline_diff.ensure_bof_virt_lines_visible(bufnr, win)
+      assert.are.equal(0, vim.fn.winsaveview().topfill or 0)
+    end)
+
+    it("does not spuriously mark the trailing token as deleted when paired line grows", function()
+      -- Regression: a 3-line function collapsed to 1 line pairs the first
+      -- old line with the new single-line version. The old line ends at
+      -- `)`; the new line has `)` at the same position and a long tail
+      -- appended. Without a trailing newline in `diff_units` input,
+      -- vim.diff flagged `)` as deleted+reinserted, emitting a spurious
+      -- `)` strikethrough virt_text on the paired row.
+      local old = "function M.get_status_icon(status)"
+      local new = "function M.get_status_icon(status) return "
+        .. "config.get_config().status_icons[status] or status end"
+      local bufnr = fresh_buf({ new })
+      inline_diff.render(bufnr, { old }, { new }, { style = "overleaf" })
+
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.are.equal(
+        0,
+        #inlines,
+        "pure addition after a shared prefix should emit no inline deletions"
+      )
+      -- The appended tail is highlighted as added.
+      local ranges = char_ranges(extmarks(bufnr))
+      assert.is_true(#ranges > 0, "expected DiffText on the appended tail")
+    end)
+
+    it("refines a 1:N hunk where a word is split by inserted whitespace", function()
+      -- Regression: `statusend` → `status end` was rendering as
+      -- `[statusend]status end` (whole old word shown deleted, whole new
+      -- phrase shown inserted), when the ideal display is a highlight on
+      -- the inserted space — `status` and `end` are common substrings.
+      -- The concat-based refinement path handles this as a single-hunk
+      -- char-level insert.
+      local bufnr = fresh_buf({ "status end" })
+      inline_diff.render(bufnr, { "statusend" }, { "status end" }, { style = "overleaf" })
+
+      -- No inline deletion virt_text — nothing was "deleted" at char level.
+      local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+      assert.are.equal(0, #inlines)
+
+      -- The single added character (the space) is highlighted.
+      local ranges = char_ranges(extmarks(bufnr))
+      assert.are.equal(1, #ranges)
+      assert.are.equal(6, ranges[1].start)
+      assert.are.equal(7, ranges[1].finish)
+    end)
+
+    it(
+      "falls back to atomic word delete for 1:1 pairs with only a coincidental letter match",
+      function()
+        -- Regression: `param` and `return` share only a single `r`, so the
+        -- char-level refinement produced two hunks whose fragments rendered
+        -- as `---@[pa]r[am]eturn new stringboolean`. Multi-hunk refinement
+        -- without a substantial shared prefix/suffix must fall back to
+        -- word-level rendering so the old word stays intact.
+        local old = "---@param new string"
+        local new = "---@return boolean"
+        local bufnr = fresh_buf({ new })
+        inline_diff.render(bufnr, { old }, { new }, { style = "overleaf" })
+
+        local inlines = inline_virt_texts(extmarks(bufnr), "DiffviewDiffDeleteInline")
+        local texts = {}
+        for _, v in ipairs(inlines) do
+          texts[#texts + 1] = v.text
+        end
+        table.sort(texts)
+        assert.are.same({ "new string", "param" }, texts)
+      end
+    )
+  end)
+end)

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -43,21 +43,64 @@ describe("diffview.layout null detection", function()
 end)
 
 describe("diffview.layout symbols", function()
-  it("Diff1 declares symbols { 'b' }", function()
-    eq({ "b" }, Diff1.symbols)
+  it("Diff1 declares symbols { 'b' }", function() eq({ "b" }, Diff1.symbols) end)
+
+  it("Diff1Inline inherits Diff1 and keeps symbols { 'b' }", function()
+    -- Class-level relationship check avoids relying on the constructor's
+    -- handling of empty/missing init args.
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+    eq({ "b" }, Diff1Inline.symbols)
+    eq(Diff1, Diff1Inline.super_class)
   end)
 
-  it("Diff2 declares symbols { 'a', 'b' }", function()
-    eq({ "a", "b" }, Diff2.symbols)
+  it("Diff1Inline exposes a_file via owned_files and get_file_for('a')", function()
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+
+    -- Drive the methods directly on a bare instance so we don't exercise the
+    -- full constructor (see other Diff1Inline tests for rationale).
+    local inst = setmetatable({}, { __index = Diff1Inline })
+    inst.windows = { { file = { id = "b_file" } } }
+    inst.a_file = { id = "a_file" }
+    inst.b = inst.windows[1]
+
+    eq(inst.a_file, inst:get_file_for("a"))
+    eq(inst.b.file, inst:get_file_for("b"))
+    eq({ inst.b.file, inst.a_file }, inst:owned_files())
+
+    inst.a_file = nil
+    eq({ inst.b.file }, inst:owned_files())
+    assert.is_nil(inst:get_file_for("a"))
   end)
 
-  it("Diff3 declares symbols { 'a', 'b', 'c' }", function()
-    eq({ "a", "b", "c" }, Diff3.symbols)
+  it("Diff1Inline:teardown_render clears inline-diff extmarks from the b buffer", function()
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+    local inline_diff = require("diffview.scene.inline_diff")
+    local api = vim.api
+
+    local bufnr = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, { "added", "context" })
+    inline_diff.render(bufnr, { "context" }, { "added", "context" })
+    assert.is_true(#api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {}) > 0)
+
+    local inst = setmetatable({}, { __index = Diff1Inline })
+    inst.b = { file = { bufnr = bufnr } }
+    inst:teardown_render()
+
+    eq(0, #api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {}))
+    pcall(api.nvim_buf_delete, bufnr, { force = true })
   end)
 
-  it("Diff4 declares symbols { 'a', 'b', 'c', 'd' }", function()
-    eq({ "a", "b", "c", "d" }, Diff4.symbols)
-  end)
+  it("Diff2 declares symbols { 'a', 'b' }", function() eq({ "a", "b" }, Diff2.symbols) end)
+
+  it(
+    "Diff3 declares symbols { 'a', 'b', 'c' }",
+    function() eq({ "a", "b", "c" }, Diff3.symbols) end
+  )
+
+  it(
+    "Diff4 declares symbols { 'a', 'b', 'c', 'd' }",
+    function() eq({ "a", "b", "c", "d" }, Diff4.symbols) end
+  )
 end)
 
 describe("diffview.layout.set_file_for", function()
@@ -130,59 +173,71 @@ describe("diffview.layout.create_wins", function()
     return layout
   end
 
-  it("issues vim.cmd calls in spec order", helpers.async_test(function()
-    local layout = mock_layout({ "b", "a", "c" })
-    async.await(layout:create_wins(1, {
-      { "b", "belowright sp" },
-      { "a", "aboveleft vsp" },
-      { "c", "aboveleft vsp" },
-    }, { "a", "b", "c" }))
+  it(
+    "issues vim.cmd calls in spec order",
+    helpers.async_test(function()
+      local layout = mock_layout({ "b", "a", "c" })
+      async.await(layout:create_wins(1, {
+        { "b", "belowright sp" },
+        { "a", "aboveleft vsp" },
+        { "c", "aboveleft vsp" },
+      }, { "a", "b", "c" }))
 
-    eq({ "belowright sp", "aboveleft vsp", "aboveleft vsp" }, cmds_recorded)
-  end))
+      eq({ "belowright sp", "aboveleft vsp", "aboveleft vsp" }, cmds_recorded)
+    end)
+  )
 
-  it("builds self.windows in win_order, not creation order", helpers.async_test(function()
-    local layout = mock_layout({ "a", "b", "c" })
-    async.await(layout:create_wins(1, {
-      { "b", "belowright sp" },
-      { "a", "aboveleft vsp" },
-      { "c", "aboveleft vsp" },
-    }, { "a", "b", "c" }))
+  it(
+    "builds self.windows in win_order, not creation order",
+    helpers.async_test(function()
+      local layout = mock_layout({ "a", "b", "c" })
+      async.await(layout:create_wins(1, {
+        { "b", "belowright sp" },
+        { "a", "aboveleft vsp" },
+        { "c", "aboveleft vsp" },
+      }, { "a", "b", "c" }))
 
-    -- Windows should be ordered a, b, c regardless of creation order.
-    eq(layout.a, layout.windows[1])
-    eq(layout.b, layout.windows[2])
-    eq(layout.c, layout.windows[3])
-  end))
+      -- Windows should be ordered a, b, c regardless of creation order.
+      eq(layout.a, layout.windows[1])
+      eq(layout.b, layout.windows[2])
+      eq(layout.c, layout.windows[3])
+    end)
+  )
 
-  it("Diff4Mixed uses different creation order than window order", helpers.async_test(function()
-    -- Diff4Mixed creates b, a, d, c but windows should be a, b, c, d.
-    local layout = mock_layout({ "a", "b", "c", "d" })
-    async.await(layout:create_wins(1, {
-      { "b", "belowright sp" },
-      { "a", "aboveleft vsp" },
-      { "d", "aboveleft vsp" },
-      { "c", "aboveleft vsp" },
-    }, { "a", "b", "c", "d" }))
+  it(
+    "Diff4Mixed uses different creation order than window order",
+    helpers.async_test(function()
+      -- Diff4Mixed creates b, a, d, c but windows should be a, b, c, d.
+      local layout = mock_layout({ "a", "b", "c", "d" })
+      async.await(layout:create_wins(1, {
+        { "b", "belowright sp" },
+        { "a", "aboveleft vsp" },
+        { "d", "aboveleft vsp" },
+        { "c", "aboveleft vsp" },
+      }, { "a", "b", "c", "d" }))
 
-    eq(layout.a, layout.windows[1])
-    eq(layout.b, layout.windows[2])
-    eq(layout.c, layout.windows[3])
-    eq(layout.d, layout.windows[4])
-    eq({ "belowright sp", "aboveleft vsp", "aboveleft vsp", "aboveleft vsp" }, cmds_recorded)
-  end))
+      eq(layout.a, layout.windows[1])
+      eq(layout.b, layout.windows[2])
+      eq(layout.c, layout.windows[3])
+      eq(layout.d, layout.windows[4])
+      eq({ "belowright sp", "aboveleft vsp", "aboveleft vsp", "aboveleft vsp" }, cmds_recorded)
+    end)
+  )
 
-  it("assigns window IDs from nvim_get_current_win to each symbol", helpers.async_test(function()
-    local layout = mock_layout({ "a", "b" })
-    async.await(layout:create_wins(1, {
-      { "a", "aboveleft vsp" },
-      { "b", "aboveleft vsp" },
-    }, { "a", "b" }))
+  it(
+    "assigns window IDs from nvim_get_current_win to each symbol",
+    helpers.async_test(function()
+      local layout = mock_layout({ "a", "b" })
+      async.await(layout:create_wins(1, {
+        { "a", "aboveleft vsp" },
+        { "b", "aboveleft vsp" },
+      }, { "a", "b" }))
 
-    -- IDs should be 101 and 102 (starting from next_win_id = 100 + 1).
-    eq(101, layout.a.id)
-    eq(102, layout.b.id)
-  end))
+      -- IDs should be 101 and 102 (starting from next_win_id = 100 + 1).
+      eq(101, layout.a.id)
+      eq(102, layout.b.id)
+    end)
+  )
 end)
 
 describe("diffview.layout.create_wins integration", function()
@@ -200,66 +255,68 @@ describe("diffview.layout.create_wins integration", function()
       layout[s] = { set_id = function(self, id) self.id = id end, close = function() end, id = nil }
     end
     -- Override create_post to skip file loading (no files to open).
-    layout.create_post = async.void(function(self)
-      vim.opt.equalalways = self.state.save_equalalways
-    end)
+    layout.create_post = async.void(
+      function(self) vim.opt.equalalways = self.state.save_equalalways end
+    )
     return layout
   end
 
-  it("creates real window splits and produces valid window IDs", helpers.async_test(function()
-    local pivot = vim.api.nvim_get_current_win()
-    assert.True(vim.api.nvim_win_is_valid(pivot))
+  it(
+    "creates real window splits and produces valid window IDs",
+    helpers.async_test(function()
+      local pivot = vim.api.nvim_get_current_win()
+      assert.True(vim.api.nvim_win_is_valid(pivot))
 
-    local layout = real_layout({ "a", "b" })
-    async.await(layout:create_wins(pivot, {
-      { "a", "aboveleft vsp" },
-      { "b", "aboveleft vsp" },
-    }, { "a", "b" }))
+      local layout = real_layout({ "a", "b" })
+      async.await(layout:create_wins(pivot, {
+        { "a", "aboveleft vsp" },
+        { "b", "aboveleft vsp" },
+      }, { "a", "b" }))
 
-    -- The pivot should have been closed.
-    assert.False(vim.api.nvim_win_is_valid(pivot))
+      -- The pivot should have been closed.
+      assert.False(vim.api.nvim_win_is_valid(pivot))
 
-    -- Both windows should be valid and distinct.
-    assert.True(vim.api.nvim_win_is_valid(layout.a.id))
-    assert.True(vim.api.nvim_win_is_valid(layout.b.id))
-    assert.are_not.equal(layout.a.id, layout.b.id)
+      -- Both windows should be valid and distinct.
+      assert.True(vim.api.nvim_win_is_valid(layout.a.id))
+      assert.True(vim.api.nvim_win_is_valid(layout.b.id))
+      assert.are_not.equal(layout.a.id, layout.b.id)
 
-    eq(layout.a, layout.windows[1])
-    eq(layout.b, layout.windows[2])
-    eq(2, #layout.windows)
+      eq(layout.a, layout.windows[1])
+      eq(layout.b, layout.windows[2])
+      eq(2, #layout.windows)
 
-    -- Clean up: close extra windows, keeping at least one.
-    local wins = vim.api.nvim_tabpage_list_wins(0)
-    for i = 2, #wins do
-      if vim.api.nvim_win_is_valid(wins[i]) then
-        vim.api.nvim_win_close(wins[i], true)
+      -- Clean up: close extra windows, keeping at least one.
+      local wins = vim.api.nvim_tabpage_list_wins(0)
+      for i = 2, #wins do
+        if vim.api.nvim_win_is_valid(wins[i]) then vim.api.nvim_win_close(wins[i], true) end
       end
-    end
-  end))
+    end)
+  )
 
-  it("Diff3Mixed-style split: creation order differs from window order", helpers.async_test(function()
-    local pivot = vim.api.nvim_get_current_win()
-    local layout = real_layout({ "a", "b", "c" })
+  it(
+    "Diff3Mixed-style split: creation order differs from window order",
+    helpers.async_test(function()
+      local pivot = vim.api.nvim_get_current_win()
+      local layout = real_layout({ "a", "b", "c" })
 
-    async.await(layout:create_wins(pivot, {
-      { "b", "belowright sp" },
-      { "a", "aboveleft vsp" },
-      { "c", "aboveleft vsp" },
-    }, { "a", "b", "c" }))
+      async.await(layout:create_wins(pivot, {
+        { "b", "belowright sp" },
+        { "a", "aboveleft vsp" },
+        { "c", "aboveleft vsp" },
+      }, { "a", "b", "c" }))
 
-    for _, sym in ipairs({ "a", "b", "c" }) do
-      assert.True(vim.api.nvim_win_is_valid(layout[sym].id), sym .. " should be valid")
-    end
-
-    eq(layout.a, layout.windows[1])
-    eq(layout.b, layout.windows[2])
-    eq(layout.c, layout.windows[3])
-
-    local wins = vim.api.nvim_tabpage_list_wins(0)
-    for i = 2, #wins do
-      if vim.api.nvim_win_is_valid(wins[i]) then
-        vim.api.nvim_win_close(wins[i], true)
+      for _, sym in ipairs({ "a", "b", "c" }) do
+        assert.True(vim.api.nvim_win_is_valid(layout[sym].id), sym .. " should be valid")
       end
-    end
-  end))
+
+      eq(layout.a, layout.windows[1])
+      eq(layout.b, layout.windows[2])
+      eq(layout.c, layout.windows[3])
+
+      local wins = vim.api.nvim_tabpage_list_wins(0)
+      for i = 2, #wins do
+        if vim.api.nvim_win_is_valid(wins[i]) then vim.api.nvim_win_close(wins[i], true) end
+      end
+    end)
+  )
 end)


### PR DESCRIPTION
Single-window layout rendering unified diffs via extmark overlays. Style configurable via `view.inline.style` (`"unified"` default; `"overleaf"` for inline strikethrough deletions). `]c`/`[c` navigate hunks.

Char-level diff helpers adapted from @tienlonghungson's sample in #109, which was modified from YouSame2/inlinediff-nvim.

Closes #108 and #109.