### PR TITLE
fix(layout): refresh inline diff during insert-mode edits

### DIFF
--- a/lua/diffview/debounce.lua
+++ b/lua/diffview/debounce.lua
@@ -12,6 +12,9 @@ local M = {}
 ---@class ManagedFn : Closeable
 ---@operator call : unknown ...
 
+---@class CancellableFn : ManagedFn
+---@field cancel fun() # Drop any pending execution without releasing the handle.
+
 ---@param ... uv_handle_t
 function M.try_close(...)
   local args = { ... }
@@ -25,18 +28,27 @@ function M.try_close(...)
   end
 end
 
+---@param timer uv_timer_t
+---@param fn function
+---@param extra? table<string, function> # Additional methods exposed on the returned handle.
 ---@return ManagedFn
-local function wrap(timer, fn)
+local function wrap(timer, fn, extra)
+  local methods = {
+    close = function()
+      timer:stop()
+      M.try_close(timer)
+    end,
+  }
+  if extra then
+    for k, v in pairs(extra) do
+      methods[k] = v
+    end
+  end
   return setmetatable({}, {
     __call = function(_, ...)
       fn(...)
     end,
-    __index = {
-      close = function()
-        timer:stop()
-        M.try_close(timer)
-      end,
-    },
+    __index = methods,
   })
 end
 
@@ -65,7 +77,7 @@ end
 ---@param ms integer Timeout in ms
 ---@param rush_first boolean If the managed fn is called and it's not recovering from a debounce: call the fn immediately.
 ---@param fn function Function to debounce
----@return ManagedFn # Debounced function.
+---@return CancellableFn # Debounced function.
 function M.debounce_trailing(ms, rush_first, fn)
   local timer = assert(uv.new_timer())
   local lock = false
@@ -91,9 +103,15 @@ function M.debounce_trailing(ms, rush_first, fn)
         end)
       end
     end)
-  end)
+  end, {
+    cancel = function()
+      timer:stop()
+      lock = false
+      args = nil
+    end,
+  })
 
-  return debounced_fn
+  return debounced_fn --[[@as CancellableFn ]]
 end
 
 ---Throttles a function on the leading edge.

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -1,4 +1,5 @@
 local async = require("diffview.async")
+local debounce = require("diffview.debounce")
 local lazy = require("diffview.lazy")
 local Diff1 = require("diffview.scene.layouts.diff_1").Diff1
 local Layout = require("diffview.scene.layout").Layout
@@ -42,10 +43,16 @@ end
 ---autocmds scoped to `{ group = ..., buffer = bufnr }`.
 local repaint_augroup = api.nvim_create_augroup("diffview_inline_repaint", { clear = false })
 
+---Debounce delay (ms) for `TextChangedI`-driven repaints. Long enough to
+---coalesce bursts of keystrokes into a single diff pass, short enough that
+---the deletion markers feel responsive while the user is still typing.
+local INSERT_REPAINT_DEBOUNCE_MS = 150
+
 ---@class Diff1Inline : Diff1
 ---@field a_file vcs.File? Old-side file used only to compute the diff (never rendered in a window).
 ---@field _cached_old_lines string[]? Old-side content captured on first render; reused by repaints so each keystroke-level refresh doesn't re-fetch from disk.
 ---@field _repaint_bufnr integer? Buffer id the repaint autocmds are attached to (nil when no autocmds are installed).
+---@field _repaint_debounced CancellableFn? Trailing-edge debounced `_repaint` used for the insert-mode `TextChangedI` hook.
 local Diff1Inline = oop.create_class("Diff1Inline", Diff1)
 
 ---@class Diff1Inline.init.Opt : Diff1.init.Opt
@@ -159,26 +166,44 @@ function Diff1Inline:_repaint()
   inline_diff.render(bufnr, old_lines, new_lines, render_opts())
 end
 
----Install buffer-scoped autocmds that repaint on edits. Fires on exit
----from insert mode and on any normal-mode text change (d/p/x/c/u/<C-r>
----…), but NOT on every insert-mode keystroke (`TextChangedI` is
----intentionally excluded — per-keystroke diffs would be too heavy).
----Idempotent: if autocmds are already installed for this buffer, this
----is a no-op.
+---Install buffer-scoped autocmds that repaint on edits. Fires on any
+---normal-mode text change (d/p/x/c/u/<C-r> …), on exit from insert mode,
+---and on insert-mode changes via a trailing-edge debounced handler so
+---bursts of keystrokes coalesce into a single diff pass instead of
+---re-running the full diff on every character. The immediate
+---`InsertLeave`/`TextChanged` handler drops any pending debounced call
+---before repainting, so a `TextChangedI` followed promptly by
+---`InsertLeave` doesn't queue a redundant second repaint. Idempotent:
+---if autocmds are already installed for this buffer, this is a no-op.
 ---@param self Diff1Inline
 ---@param bufnr integer
 local function register_repaint_autocmds(self, bufnr)
   if self._repaint_bufnr == bufnr then return end
   -- Different buffer than last time (or first install): clear any prior
-  -- registration before attaching to the new one.
+  -- registration before attaching to the new one, and close any pending
+  -- debounce timer so it doesn't fire against the old buffer.
   if self._repaint_bufnr and api.nvim_buf_is_valid(self._repaint_bufnr) then
     pcall(api.nvim_clear_autocmds, { group = repaint_augroup, buffer = self._repaint_bufnr })
   end
+  if self._repaint_debounced then self._repaint_debounced:close() end
   self._repaint_bufnr = bufnr
+  self._repaint_debounced = debounce.debounce_trailing(
+    INSERT_REPAINT_DEBOUNCE_MS,
+    false,
+    function() self:_repaint() end
+  )
   api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
     group = repaint_augroup,
     buffer = bufnr,
-    callback = function() self:_repaint() end,
+    callback = function()
+      if self._repaint_debounced then self._repaint_debounced:cancel() end
+      self:_repaint()
+    end,
+  })
+  api.nvim_create_autocmd("TextChangedI", {
+    group = repaint_augroup,
+    buffer = bufnr,
+    callback = function() self._repaint_debounced() end,
   })
 end
 
@@ -239,6 +264,10 @@ end
 function Diff1Inline:teardown_render()
   if self._repaint_bufnr and api.nvim_buf_is_valid(self._repaint_bufnr) then
     pcall(api.nvim_clear_autocmds, { group = repaint_augroup, buffer = self._repaint_bufnr })
+  end
+  if self._repaint_debounced then
+    self._repaint_debounced:close()
+    self._repaint_debounced = nil
   end
   self._repaint_bufnr = nil
   self._cached_old_lines = nil

--- a/lua/diffview/tests/functional/debounce_spec.lua
+++ b/lua/diffview/tests/functional/debounce_spec.lua
@@ -35,6 +35,44 @@ describe("diffview.debounce", function()
       assert.is_false(in_fast_event)
       fn.close()
     end))
+
+    it("cancel drops a pending trailing call", test_utils.async_test(function()
+      local count = 0
+      local fn = debounce.debounce_trailing(10, false, function()
+        count = count + 1
+      end)
+
+      fn()
+      fn.cancel()
+
+      await(async.timeout(50))
+      await(async.scheduler())
+
+      assert.equals(0, count)
+      fn.close()
+    end))
+
+    it("can be re-scheduled after cancel", test_utils.async_test(function()
+      local count = 0
+      local fn = debounce.debounce_trailing(10, false, function()
+        count = count + 1
+      end)
+
+      fn()
+      fn.cancel()
+
+      await(async.timeout(30))
+      await(async.scheduler())
+      assert.equals(0, count)
+
+      fn()
+
+      await(async.timeout(50))
+      await(async.scheduler())
+      assert.equals(1, count)
+
+      fn.close()
+    end))
   end)
 
   describe("throttle_trailing", function()

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -90,6 +90,110 @@ describe("diffview.layout symbols", function()
     pcall(api.nvim_buf_delete, bufnr, { force = true })
   end)
 
+  it("Diff1Inline:teardown_render closes the repaint debounce", function()
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+
+    local closed = false
+    local debounced = setmetatable({}, {
+      __call = function() end,
+      __index = {
+        close = function() closed = true end,
+        cancel = function() end,
+      },
+    })
+
+    local inst = setmetatable({}, { __index = Diff1Inline })
+    inst._repaint_debounced = debounced
+    inst._repaint_bufnr = nil
+    inst:teardown_render()
+
+    assert.is_true(closed)
+    assert.is_nil(inst._repaint_debounced)
+  end)
+
+  it(
+    "Diff1Inline InsertLeave cancels a pending debounced repaint",
+    helpers.async_test(function()
+      local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+      local api = vim.api
+
+      -- Shadow `_repaint` on the instance so we count calls without mutating
+      -- the class method shared with concurrent tests.
+      local repaint_count = 0
+
+      local bufnr = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, { "new content" })
+      local winid = api.nvim_get_current_win()
+
+      local inst = setmetatable({}, { __index = Diff1Inline })
+      inst.b = {
+        file = { bufnr = bufnr, is_valid = function() return true end },
+        is_valid = function() return true end,
+        id = winid,
+      }
+      inst._cached_old_lines = { "old content" }
+      inst._repaint = function() repaint_count = repaint_count + 1 end
+
+      async.await(inst:_render_inline())
+
+      -- `TextChangedI` schedules a debounced repaint; `InsertLeave` should
+      -- cancel it and fire the immediate repaint exactly once.
+      api.nvim_exec_autocmds("TextChangedI", { buffer = bufnr })
+      api.nvim_exec_autocmds("InsertLeave", { buffer = bufnr })
+
+      eq(1, repaint_count)
+
+      -- Wait past the debounce window (150ms). If the debounce hadn't been
+      -- cancelled, the trailing call would bump the counter to 2.
+      async.await(async.timeout(200))
+      async.await(async.scheduler())
+
+      eq(1, repaint_count)
+
+      inst:teardown_render()
+      pcall(api.nvim_buf_delete, bufnr, { force = true })
+    end)
+  )
+
+  it(
+    "Diff1Inline TextChangedI coalesces rapid edits into one repaint",
+    helpers.async_test(function()
+      local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+      local api = vim.api
+
+      local repaint_count = 0
+
+      local bufnr = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, { "new content" })
+      local winid = api.nvim_get_current_win()
+
+      local inst = setmetatable({}, { __index = Diff1Inline })
+      inst.b = {
+        file = { bufnr = bufnr, is_valid = function() return true end },
+        is_valid = function() return true end,
+        id = winid,
+      }
+      inst._cached_old_lines = { "old content" }
+      inst._repaint = function() repaint_count = repaint_count + 1 end
+
+      async.await(inst:_render_inline())
+
+      for _ = 1, 5 do
+        api.nvim_exec_autocmds("TextChangedI", { buffer = bufnr })
+      end
+
+      -- Wait past the debounce window so the trailing fire has a chance to
+      -- run (or not, if coalescing is broken).
+      async.await(async.timeout(200))
+      async.await(async.scheduler())
+
+      eq(1, repaint_count)
+
+      inst:teardown_render()
+      pcall(api.nvim_buf_delete, bufnr, { force = true })
+    end)
+  )
+
   it("Diff2 declares symbols { 'a', 'b' }", function() eq({ "a", "b" }, Diff2.symbols) end)
 
   it(


### PR DESCRIPTION
Add a debounced `TextChangedI` autocmd so per-keystroke edits coalesce into a single repaint instead of waiting for `InsertLeave`.