### PR TITLE
fix(layout): align `diff1_inline` diff computation with side-by-side layouts

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -548,7 +548,11 @@ diffopt                                         *diffview-config-diffopt*
 
         `linematch` pairs added/deleted lines within a hunk so intra-line
         |hl-DiffText| highlighting becomes meaningful (VSCode-style). A value
-        of `60` is typical; `0` disables it.
+        of `60` is typical; `0` disables it. Note: `linematch` is honoured by
+        the side-by-side layouts (diff2, diff3, diff4) but not by the
+        `diff1_inline` layout, which pairs lines positionally inside each
+        hunk and so cannot make use of linematch's similarity-based
+        reordering.
 
         Example: >lua
                 diffopt = { algorithm = "histogram", linematch = 60 }
@@ -829,6 +833,16 @@ view.inline                                     *diffview-config-view.inline*
         Type: `table`, Default: (see defaults)
 
         Options that apply to the `diff1_inline` layout.
+
+        Note: this layout pairs lines positionally inside each diff hunk and
+        therefore does not consult |'diffopt'|'s `linematch` setting. The
+        whitespace flags (`iwhite`, `iwhiteall`, `iwhiteeol`, `iblank`),
+        `algorithm`, and `indent-heuristic` are honoured for hunk
+        computation. Intraline |hl-DiffText| on paired lines (and the
+        inline strikethrough deletions in the `"overleaf"` style) always
+        reflect the actual character differences, independent of those
+        ignore flags. `icase` is not honoured because |vim.diff()| does not
+        accept a case-insensitive option.
 
         Fields: ~
             {style} ("unified"|"overleaf")

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -156,6 +156,13 @@ end
 -- `) return ... end` as inserted, instead of recognizing `)` as the
 -- end of the common prefix and treating the rest as pure addition.
 -- Same remedy as the outer line-level diff in `render()`.
+--
+-- `'diffopt'`'s `ignore_*` whitespace/blank-line flags are deliberately
+-- not forwarded here. Those flags only decide which lines are paired as
+-- modifications by the outer hunk diff; once a pair is formed, the
+-- intraline highlight reflects the actual character differences so the
+-- reader can see exactly what changed. This matches how |hl-DiffText|
+-- works in the built-in side-by-side diff.
 ---@param a_units string[]
 ---@param b_units string[]
 ---@return integer[][]
@@ -718,6 +725,10 @@ end
 ---@field algorithm? string
 ---@field linematch? integer
 ---@field indent_heuristic? boolean
+---@field ignore_whitespace? boolean
+---@field ignore_whitespace_change? boolean
+---@field ignore_whitespace_change_at_eol? boolean
+---@field ignore_blank_lines? boolean
 ---@field style? "unified"|"overleaf" Default: `"unified"`.
 
 ---@class InlineDiffStyle
@@ -771,13 +782,22 @@ function M.render(bufnr, old_lines, new_lines, opts)
   local new = #new_lines > 0 and table.concat(new_lines, "\n") .. "\n" or ""
 
   local diff_opts = { result_type = "indices" }
-  -- Only forward `algorithm`, `linematch`, and `indent_heuristic` when
+  -- Only forward each `vim.diff` option (`algorithm`, `linematch`,
+  -- `indent_heuristic`, and the `ignore_*` whitespace/blank-line flags) when
   -- explicitly set so vim.diff's own defaults apply otherwise. This mirrors
   -- how `'diffopt'` toggles flags/options by presence/absence rather than
   -- forcing fallback values here.
   if opts.algorithm ~= nil then diff_opts.algorithm = opts.algorithm end
   if opts.linematch ~= nil then diff_opts.linematch = opts.linematch end
   if opts.indent_heuristic ~= nil then diff_opts.indent_heuristic = opts.indent_heuristic end
+  if opts.ignore_whitespace ~= nil then diff_opts.ignore_whitespace = opts.ignore_whitespace end
+  if opts.ignore_whitespace_change ~= nil then
+    diff_opts.ignore_whitespace_change = opts.ignore_whitespace_change
+  end
+  if opts.ignore_whitespace_change_at_eol ~= nil then
+    diff_opts.ignore_whitespace_change_at_eol = opts.ignore_whitespace_change_at_eol
+  end
+  if opts.ignore_blank_lines ~= nil then diff_opts.ignore_blank_lines = opts.ignore_blank_lines end
 
   local hunks = vim.diff(old, new, diff_opts)
 

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -22,6 +22,15 @@ local M = {}
 ---`indent_heuristic` is always set to an explicit boolean so its absence from
 ---`'diffopt'` forces `vim.diff` to disable the heuristic instead of falling
 ---back to whatever default the vim.diff implementation currently uses.
+---
+---`linematch` is intentionally not forwarded. In `result_type = "indices"`
+---mode it splits a single modify-hunk into smaller hunks that pair lines by
+---similarity rather than by position — e.g. an old `-- foo = X, -- comment`
+---line gets paired with a new `-- bar = Y, -- comment` line further down
+---because both share the `-- ` prefix and a `, -- ` separator, even though
+---the natural (positional) pair is the new uncommented `foo = X` line. The
+---inline renderer pairs lines positionally inside each hunk, so a non-zero
+---linematch causes deletions to render anchored against the wrong new line.
 ---@return InlineDiffOpts
 local function effective_diffopt()
   local out = { indent_heuristic = false }
@@ -29,10 +38,16 @@ local function effective_diffopt()
     local key, val = v:match("^([%w_-]+):(.+)$")
     if key == "algorithm" then
       out.algorithm = val
-    elseif key == "linematch" then
-      out.linematch = tonumber(val)
     elseif v == "indent-heuristic" then
       out.indent_heuristic = true
+    elseif v == "iwhite" then
+      out.ignore_whitespace_change = true
+    elseif v == "iwhiteall" then
+      out.ignore_whitespace = true
+    elseif v == "iwhiteeol" then
+      out.ignore_whitespace_change_at_eol = true
+    elseif v == "iblank" then
+      out.ignore_blank_lines = true
     end
   end
   return out
@@ -366,4 +381,10 @@ function Diff1Inline:destroy()
 end
 
 M.Diff1Inline = Diff1Inline
+
+M._test = {
+  effective_diffopt = effective_diffopt,
+  render_opts = render_opts,
+}
+
 return M

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -370,6 +370,97 @@ describe("diffview.layout symbols", function()
   )
 end)
 
+describe("diffview.scene.layouts.diff_1_inline diffopt forwarding", function()
+  local Diff1Inline_mod = require("diffview.scene.layouts.diff_1_inline")
+  local effective_diffopt = Diff1Inline_mod._test.effective_diffopt
+  local inline_diff = require("diffview.scene.inline_diff")
+  local api = vim.api
+
+  local orig_diffopt
+
+  before_each(function() orig_diffopt = vim.deepcopy(vim.opt.diffopt:get()) end)
+
+  after_each(function() vim.opt.diffopt = vim.deepcopy(orig_diffopt) end)
+
+  ---Reset `'diffopt'` to a fixed baseline so each test starts from the same
+  ---state regardless of what the Neovim default (or a prior test) left behind.
+  ---@param entries string[]
+  local function set_diffopt(entries) vim.opt.diffopt = entries end
+
+  it("maps iwhite to ignore_whitespace_change", function()
+    set_diffopt({ "iwhite" })
+    eq(true, effective_diffopt().ignore_whitespace_change)
+  end)
+
+  it("maps iwhiteall to ignore_whitespace", function()
+    set_diffopt({ "iwhiteall" })
+    eq(true, effective_diffopt().ignore_whitespace)
+  end)
+
+  it("maps iwhiteeol to ignore_whitespace_change_at_eol", function()
+    set_diffopt({ "iwhiteeol" })
+    eq(true, effective_diffopt().ignore_whitespace_change_at_eol)
+  end)
+
+  it("maps iblank to ignore_blank_lines", function()
+    set_diffopt({ "iblank" })
+    eq(true, effective_diffopt().ignore_blank_lines)
+  end)
+
+  it("does not forward icase (vim.diff has no case-insensitive option)", function()
+    set_diffopt({ "icase" })
+    local opts = effective_diffopt()
+    assert.is_nil(opts.ignore_case)
+  end)
+
+  it("maps algorithm:<name> to algorithm", function()
+    set_diffopt({ "algorithm:patience" })
+    eq("patience", effective_diffopt().algorithm)
+  end)
+
+  it("sets indent_heuristic to false when absent from 'diffopt'", function()
+    set_diffopt({ "internal" })
+    eq(false, effective_diffopt().indent_heuristic)
+  end)
+
+  it("sets indent_heuristic to true when 'indent-heuristic' is in 'diffopt'", function()
+    set_diffopt({ "indent-heuristic" })
+    eq(true, effective_diffopt().indent_heuristic)
+  end)
+
+  it("never forwards linematch even when set in 'diffopt'", function()
+    set_diffopt({ "linematch:60", "iblank" })
+    local opts = effective_diffopt()
+    assert.is_nil(opts.linematch)
+    -- Sanity-check that other entries still parse (confirms the loop ran).
+    eq(true, opts.ignore_blank_lines)
+  end)
+
+  it("leaves ignore flags nil when 'diffopt' has no corresponding entry", function()
+    set_diffopt({ "internal" })
+    local opts = effective_diffopt()
+    assert.is_nil(opts.ignore_whitespace)
+    assert.is_nil(opts.ignore_whitespace_change)
+    assert.is_nil(opts.ignore_whitespace_change_at_eol)
+    assert.is_nil(opts.ignore_blank_lines)
+  end)
+
+  it("changes inline diff output when iwhiteall is enabled", function()
+    local bufnr = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, { "foo  bar" })
+
+    set_diffopt({ "internal" })
+    inline_diff.render(bufnr, { "foo bar" }, { "foo  bar" }, effective_diffopt())
+    assert.is_true(#(inline_diff.get_hunks(bufnr) or {}) > 0)
+
+    set_diffopt({ "internal", "iwhiteall" })
+    inline_diff.render(bufnr, { "foo bar" }, { "foo  bar" }, effective_diffopt())
+    eq(0, #(inline_diff.get_hunks(bufnr) or {}))
+
+    pcall(api.nvim_buf_delete, bufnr, { force = true })
+  end)
+end)
+
 describe("diffview.layout.set_file_for", function()
   it("sets the file on the window and tags it with the symbol", function()
     local stored_file


### PR DESCRIPTION
Forward the whitespace flags (`iwhite`, `iwhiteall`, `iwhiteeol`, `iblank`) to `vim.diff` and drop `linematch`, which mis-anchors deletions in the inline renderer by pairing lines by similarity rather than position.
