### PR TITLE
revert(panel): restore `w` as multi-file selection toggle

### DIFF
--- a/TIPS.md
+++ b/TIPS.md
@@ -236,24 +236,6 @@ require("diffview").setup({
 })
 ```
 
-If your leader key is `<space>`, then while your cursor is in the file panel
-buffer the panel's multi-file selection toggle (bound to `<space>` by default)
-will intercept `<leader>` sequences there. Remap or disable this buffer-local
-binding to avoid that conflict:
-
-```lua
-local actions = require("diffview.actions")
-require("diffview").setup({
-  keymaps = {
-    file_panel = {
-      { { "n", "x" }, "<space>", false },
-      { { "n", "x" }, "w", actions.toggle_select_entry,
-        { desc = "Toggle file selection" } },
-    },
-  },
-})
-```
-
 ## Platform Notes
 
 - **MSYS2/Cygwin on Windows:**

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -2006,22 +2006,9 @@ o                       Open the diff for the selected file entry.
 <2-LeftMouse>
 
                                                 *diffview-maps-toggle_select_entry*
-<Space>                 Toggle file selection for multi-file operations.
+w                       Toggle file selection for multi-file operations.
                         Works on directories and in visual mode.
 
-                        If `<Space>` conflicts with your leader key, you can
-                        remap it via `keymaps.file_panel`: >lua
-                            local actions = require("diffview.actions")
-                            require("diffview").setup({
-                              keymaps = {
-                                file_panel = {
-                                  { { "n", "x" }, "<space>", false },
-                                  { { "n", "x" }, "w", actions.toggle_select_entry,
-                                    { desc = "Toggle file selection" } },
-                                },
-                              },
-                            })
-<
                                                 *diffview-maps-clear_select_entries*
 C                       Clear all file selections.
 

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -229,7 +229,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
         { "n", "o",              actions.select_entry,                   { desc = "Open the diff for the selected entry" } },
         { "n", "l",              actions.select_entry,                   { desc = "Open the diff for the selected entry" } },
         { "n", "<2-LeftMouse>",  actions.select_entry,                   { desc = "Open the diff for the selected entry" } },
-        { { "n", "x" }, "<space>", actions.toggle_select_entry,          { desc = "Toggle file selection for multi-file operations" } },
+        { { "n", "x" }, "w",    actions.toggle_select_entry,            { desc = "Toggle file selection for multi-file operations" } },
         { "n", "C",              actions.clear_select_entries,           { desc = "Clear all file selections" } },
         { "n", "-",              actions.toggle_stage_entry,             { desc = "Stage / unstage the selected entry" } },
         { "n", "s",              actions.toggle_stage_entry,             { desc = "Stage / unstage the selected entry" } },

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -279,7 +279,7 @@ M.defaults = {
       { "n",          "g?",   actions.help({ "view", "diff4" }),  { desc = "Open the help panel" } },
     },
     file_panel = utils.vec_join(common_panel_keymaps, common_nav_keymaps, {
-      { { "n", "x" }, "<space>", actions.toggle_select_entry,          { desc = "Toggle file selection for multi-file operations" } },
+      { { "n", "x" }, "w",    actions.toggle_select_entry,            { desc = "Toggle file selection for multi-file operations" } },
       { "n", "C",              actions.clear_select_entries,           { desc = "Clear all file selections" } },
       { "n", "-",              actions.toggle_stage_entry,             { desc = "Stage / unstage the selected entry" } },
       { "n", "s",              actions.toggle_stage_entry,             { desc = "Stage / unstage the selected entry" } },


### PR DESCRIPTION
Closes #124.

See #66 for context.