### PR TITLE
style: enforce LuaJIT syntax, switch `collapse_simple_statement` to "Never"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,26 @@ env:
   JJ_VERSION: "0.39.0"
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint (stylua)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache stylua binary
+        id: cache-stylua
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/stylua
+          key: stylua-2.4.1-luajit-linux-x86_64
+
+      - name: Install stylua (luajit feature)
+        if: steps.cache-stylua.outputs.cache-hit != 'true'
+        run: cargo install stylua --locked --version 2.4.1 --features luajit
+
+      - name: Check formatting
+        run: stylua --check lua/
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -4,7 +4,8 @@ local async = require("diffview.async")
 local lazy = require("diffview.lazy")
 
 local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
-local FileHistoryView = lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
+local FileHistoryView =
+  lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
 local HelpPanel = lazy.access("diffview.ui.panels.help_panel", "HelpPanel") ---@type HelpPanel|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
 local StandardView = lazy.access("diffview.scene.views.standard.standard_view", "StandardView") ---@type StandardView|LazyModule
@@ -30,11 +31,13 @@ local pl = lazy.access(utils, "path") ---@type PathLib
 
 local M = setmetatable({}, {
   __index = function(_, k)
-    utils.err((
-      "The action '%s' does not exist! "
-      .. "See ':h diffview-available-actions' for an overview of available actions."
-    ):format(k))
-  end
+    utils.err(
+      (
+        "The action '%s' does not exist! "
+        .. "See ':h diffview-available-actions' for an overview of available actions."
+      ):format(k)
+    )
+  end,
 })
 
 M.compat = {}
@@ -47,7 +50,9 @@ M.compat = {}
 ---@return integer? bufnr
 local function get_valid_main(view)
   local main = view and view.cur_layout and view.cur_layout:get_main_win()
-  if not (main and main:is_valid() and main.file and main.file:is_valid()) then return end
+  if not (main and main:is_valid() and main.file and main.file:is_valid()) then
+    return
+  end
   return main, main.file.bufnr
 end
 
@@ -56,7 +61,9 @@ end
 local function prepare_goto_file()
   local view = lib.get_current_view()
 
-  if view and not (view:instanceof(DiffView.__get()) or view:instanceof(FileHistoryView.__get())) then
+  if
+    view and not (view:instanceof(DiffView.__get()) or view:instanceof(FileHistoryView.__get()))
+  then
     return
   end
 
@@ -68,10 +75,7 @@ local function prepare_goto_file()
     -- Ensure file exists
     if not pl:readable(file.absolute_path) then
       utils.err(
-        string.format(
-          "File does not exist on disk: '%s'",
-          pl:relative(file.absolute_path, ".")
-        )
+        string.format("File does not exist on disk: '%s'", pl:relative(file.absolute_path, "."))
       )
       return
     end
@@ -90,7 +94,9 @@ end
 ---@param opts { cmd: string, target_tab?: boolean, target_tab_cmd?: string }
 local function open_goto_file(opts)
   local file, cursor = prepare_goto_file()
-  if not file then return end
+  if not file then
+    return
+  end
 
   local fpath = vim.fn.fnameescape(file.absolute_path)
 
@@ -100,7 +106,9 @@ local function open_goto_file(opts)
       api.nvim_set_current_tabpage(target_tab)
       file.layout:restore_winopts()
       vim.cmd(opts.target_tab_cmd .. " " .. fpath)
-      if cursor then utils.set_cursor(0, unpack(cursor)) end
+      if cursor then
+        utils.set_cursor(0, unpack(cursor))
+      end
       return
     end
   end
@@ -195,10 +203,8 @@ function M.diff_against_default_branch()
     -- Get an adapter for the current working directory.
     local err
     local cfile = pl:vim_expand("%")
-    local top_indicators = utils.vec_join(
-      vim.bo.buftype == "" and pl:absolute(cfile) or nil,
-      pl:realpath(".")
-    )
+    local top_indicators =
+      utils.vec_join(vim.bo.buftype == "" and pl:absolute(cfile) or nil, pl:realpath("."))
     err, adapter = require("diffview.vcs").get_adapter({ top_indicators = top_indicators })
     if err or not adapter then
       utils.err("Failed to get VCS adapter: " .. (err or "unknown error"))
@@ -241,10 +247,8 @@ function M.jumpto_conflict(num, use_delta)
 
     if main then
       local next_idx
-      local conflicts, cur, cur_idx = vcs_utils.parse_conflicts(
-        api.nvim_buf_get_lines(bufnr, 0, -1, false),
-        main.id
-      )
+      local conflicts, cur, cur_idx =
+        vcs_utils.parse_conflicts(api.nvim_buf_get_lines(bufnr, 0, -1, false), main.id)
 
       if #conflicts > 0 then
         if not use_delta then
@@ -268,10 +272,12 @@ function M.jumpto_conflict(num, use_delta)
 
         api.nvim_win_call(main.id, function()
           api.nvim_win_set_cursor(main.id, { next_conflict.first, 0 })
-          if curwin ~= main.id then view.cur_layout:sync_scroll() end
+          if curwin ~= main.id then
+            view.cur_layout:sync_scroll()
+          end
         end)
 
-        api.nvim_echo({{ ("Conflict [%d/%d]"):format(next_idx, #conflicts) }}, false, {})
+        api.nvim_echo({ { ("Conflict [%d/%d]"):format(next_idx, #conflicts) } }, false, {})
 
         return {
           total = #conflicts,
@@ -301,11 +307,15 @@ end
 ---@param picker fun(bufnr: integer, cursor_row: integer): integer?
 local function jump_inline_hunk_by(picker)
   local view = lib.get_current_view()
-  if not (view and view:instanceof(StandardView.__get())) then return end
+  if not (view and view:instanceof(StandardView.__get())) then
+    return
+  end
   ---@cast view StandardView
 
   local main, bufnr = get_valid_main(view)
-  if not main then return end
+  if not main then
+    return
+  end
 
   local cur = api.nvim_win_get_cursor(main.id)[1] - 1
   local row = picker(bufnr, cur)
@@ -330,7 +340,9 @@ end
 ---@param view StandardView
 function M.jump_to_first_change(view)
   local main, bufnr = get_valid_main(view)
-  if not main then return end
+  if not main then
+    return
+  end
 
   api.nvim_win_call(main.id, function()
     utils.set_cursor(0, 1, 0)
@@ -341,7 +353,9 @@ function M.jump_to_first_change(view)
       -- Inline view has `diff=false`, so native `]c` does nothing. Use the
       -- renderer's cached hunks to land on the first change.
       local rows = require("diffview.scene.inline_diff").hunk_anchor_rows(bufnr)
-      if rows[1] then api.nvim_win_set_cursor(main.id, { rows[1] + 1, 0 }) end
+      if rows[1] then
+        api.nvim_win_set_cursor(main.id, { rows[1] + 1, 0 })
+      end
     else
       pcall(vim.cmd, "norm! ]c")
     end
@@ -359,7 +373,9 @@ function M.view_windo(cmd)
   local fun
 
   if type(cmd) == "string" then
-    fun = function(_, _) vim.cmd(cmd) end
+    fun = function(_, _)
+      vim.cmd(cmd)
+    end
   else
     fun = cmd
   end
@@ -392,8 +408,10 @@ function M.scroll_view(distance)
   if distance % 1 == 0 then
     scroll_cmd = ([[exe "norm! %d%s"]]):format(distance, scroll_opr)
   else
-    scroll_cmd = ([[exe "norm! " . float2nr(winheight(0) * %f) . "%s"]])
-        :format(math.abs(distance), scroll_opr)
+    scroll_cmd = ([[exe "norm! " . float2nr(winheight(0) * %f) . "%s"]]):format(
+      math.abs(distance),
+      scroll_opr
+    )
   end
 
   return function()
@@ -452,7 +470,9 @@ local function diff_copy_target(kind)
       end
     end
 
-    if bufnr then return bufnr end
+    if bufnr then
+      return bufnr
+    end
   end
 end
 
@@ -475,9 +495,12 @@ local function resolve_all_conflicts(view, target)
         first = cur_conflict.first + offset
         last = cur_conflict.last + offset
 
-        if target == "ours" then content = cur_conflict.ours.content
-        elseif target == "theirs" then content = cur_conflict.theirs.content
-        elseif target == "base" then content = cur_conflict.base.content
+        if target == "ours" then
+          content = cur_conflict.ours.content
+        elseif target == "theirs" then
+          content = cur_conflict.theirs.content
+        elseif target == "base" then
+          content = cur_conflict.base.content
         elseif target == "all" then
           content = utils.vec_join(
             cur_conflict.ours.content,
@@ -491,10 +514,13 @@ local function resolve_all_conflicts(view, target)
         offset = offset + (#content - (last - first) - 1)
       end
 
-      utils.set_cursor(main.id, unpack({
-        (content and #content or 0) + first - 1,
-        content and content[1] and #content[#content] or 0
-      }))
+      utils.set_cursor(
+        main.id,
+        unpack({
+          (content and #content or 0) + first - 1,
+          content and content[1] and #content[#content] or 0,
+        })
+      )
 
       view.cur_layout:sync_scroll()
     end
@@ -506,12 +532,14 @@ function M.conflict_choose_all(target)
   return async.void(function()
     local view = lib.get_current_view() --[[@as DiffView ]]
 
-    if (view and view:instanceof(DiffView.__get())) then
+    if view and view:instanceof(DiffView.__get()) then
       ---@cast view DiffView
 
       if view.panel:is_focused() then
         local item = view:infer_cur_file(false) ---@cast item -DirData
-        if not item then return end
+        if not item then
+          return
+        end
 
         if not item.active then
           -- Open the entry
@@ -534,31 +562,31 @@ function M.conflict_choose(target)
       local main, bufnr = get_valid_main(view)
 
       if main then
-        local _, cur = vcs_utils.parse_conflicts(
-          api.nvim_buf_get_lines(bufnr, 0, -1, false),
-          main.id
-        )
+        local _, cur =
+          vcs_utils.parse_conflicts(api.nvim_buf_get_lines(bufnr, 0, -1, false), main.id)
 
         if cur then
           local content
 
-          if target == "ours" then content = cur.ours.content
-          elseif target == "theirs" then content = cur.theirs.content
-          elseif target == "base" then content = cur.base.content
+          if target == "ours" then
+            content = cur.ours.content
+          elseif target == "theirs" then
+            content = cur.theirs.content
+          elseif target == "base" then
+            content = cur.base.content
           elseif target == "all" then
-            content = utils.vec_join(
-              cur.ours.content,
-              cur.base.content,
-              cur.theirs.content
-            )
+            content = utils.vec_join(cur.ours.content, cur.base.content, cur.theirs.content)
           end
 
           api.nvim_buf_set_lines(bufnr, cur.first - 1, cur.last, false, content or {})
 
-          utils.set_cursor(main.id, unpack({
-            (content and #content or 0) + cur.first - 1,
-            content and content[1] and #content[#content] or 0
-          }))
+          utils.set_cursor(
+            main.id,
+            unpack({
+              (content and #content or 0) + cur.first - 1,
+              content and content[1] and #content[#content] or 0,
+            })
+          )
         end
       end
     end
@@ -576,7 +604,7 @@ function M.diffget(target)
       if api.nvim_get_mode().mode:match("^[vV]") then
         range = ("%d,%d"):format(unpack(utils.vec_sort({
           vim.fn.line("."),
-          vim.fn.line("v")
+          vim.fn.line("v"),
         })))
       end
 
@@ -597,15 +625,21 @@ end
 ---cached hunks and old-side content. No-op outside a `diff1_inline` layout.
 function M.diffget_inline()
   local view = lib.get_current_view()
-  if not (view and view:instanceof(StandardView.__get())) then return end
+  if not (view and view:instanceof(StandardView.__get())) then
+    return
+  end
   ---@cast view StandardView
 
   local layout = view.cur_layout
-  if not (layout and layout:instanceof(Diff1Inline.__get())) then return end
+  if not (layout and layout:instanceof(Diff1Inline.__get())) then
+    return
+  end
   ---@cast layout Diff1Inline
 
   local main = layout:get_main_win()
-  if not (main and main:is_valid()) then return end
+  if not (main and main:is_valid()) then
+    return
+  end
 
   local is_visual = api.nvim_get_mode().mode:match("^[vV" .. utils.t("<C-v>") .. "]") ~= nil
   local first, last
@@ -622,7 +656,9 @@ function M.diffget_inline()
 
   layout:diffget(first, last)
 
-  if is_visual then api.nvim_feedkeys(utils.t("<esc>"), "n", false) end
+  if is_visual then
+    api.nvim_feedkeys(utils.t("<esc>"), "n", false)
+  end
 end
 
 ---@param target "ours"|"theirs"|"base"|"local"
@@ -666,7 +702,8 @@ function M.cycle_layout()
 
   -- Use config or fall back to defaults.
   local default_standard = { Diff2Hor.__get(), Diff2Ver.__get() }
-  local default_merge_tool = { Diff3Hor.__get(), Diff3Ver.__get(), Diff3Mixed.__get(), Diff4Mixed.__get(), Diff1.__get() }
+  local default_merge_tool =
+    { Diff3Hor.__get(), Diff3Ver.__get(), Diff3Mixed.__get(), Diff4Mixed.__get(), Diff1.__get() }
 
   local resolved_standard = resolve_layouts(cycle_config.default)
   local resolved_merge_tool = resolve_layouts(cycle_config.merge_tool)
@@ -678,7 +715,9 @@ function M.cycle_layout()
 
   local view = lib.get_current_view()
 
-  if not view then return end
+  if not view then
+    return
+  end
 
   local layouts, files, cur_file
 
@@ -692,18 +731,18 @@ function M.cycle_layout()
     cur_file = view.cur_entry
 
     if cur_file then
-      layouts = cur_file.kind == "conflicting"
-          and layout_cycles.merge_tool
-          or layout_cycles.standard
-      files = cur_file.kind == "conflicting"
-          and view.files.conflicting
-          or utils.vec_join(view.panel.files.working, view.panel.files.staged)
+      layouts = cur_file.kind == "conflicting" and layout_cycles.merge_tool
+        or layout_cycles.standard
+      files = cur_file.kind == "conflicting" and view.files.conflicting
+        or utils.vec_join(view.panel.files.working, view.panel.files.staged)
     end
   else
     return
   end
 
-  if not files then return end
+  if not files then
+    return
+  end
 
   for _, entry in ipairs(files) do
     local cur_layout = entry.layout
@@ -721,13 +760,17 @@ function M.cycle_layout()
 
     cur_file.layout.emitter:once("files_opened", function()
       utils.set_cursor(main.id, unpack(pos))
-      if not was_focused then view.cur_layout:sync_scroll() end
+      if not was_focused then
+        view.cur_layout:sync_scroll()
+      end
     end)
 
     view:set_file(cur_file, false)
     main = view.cur_layout:get_main_win()
 
-    if was_focused then main:focus() end
+    if was_focused then
+      main:focus()
+    end
   end
 end
 
@@ -737,12 +780,18 @@ function M.set_layout(layout_name)
   return function()
     local layout_class = layout_name_map[layout_name]
     if not layout_class then
-      utils.err(("Unknown layout: '%s'. See ':h diffview-config-view.x.layout' for valid layouts."):format(layout_name))
+      utils.err(
+        ("Unknown layout: '%s'. See ':h diffview-config-view.x.layout' for valid layouts."):format(
+          layout_name
+        )
+      )
       return
     end
 
     local view = lib.get_current_view()
-    if not view then return end
+    if not view then
+      return
+    end
 
     local files, cur_file
 
@@ -754,15 +803,16 @@ function M.set_layout(layout_name)
       ---@cast view DiffView
       cur_file = view.cur_entry
       if cur_file then
-        files = cur_file.kind == "conflicting"
-            and view.files.conflicting
-            or utils.vec_join(view.panel.files.working, view.panel.files.staged)
+        files = cur_file.kind == "conflicting" and view.files.conflicting
+          or utils.vec_join(view.panel.files.working, view.panel.files.staged)
       end
     else
       return
     end
 
-    if not files then return end
+    if not files then
+      return
+    end
 
     local target_layout = layout_class.__get()
 
@@ -777,13 +827,17 @@ function M.set_layout(layout_name)
 
       cur_file.layout.emitter:once("files_opened", function()
         utils.set_cursor(main.id, unpack(pos))
-        if not was_focused then view.cur_layout:sync_scroll() end
+        if not was_focused then
+          view.cur_layout:sync_scroll()
+        end
       end)
 
       view:set_file(cur_file, false)
       main = view.cur_layout:get_main_win()
 
-      if was_focused then main:focus() end
+      if was_focused then
+        main:focus()
+      end
     end
   end
 end
@@ -827,18 +881,38 @@ do
         for _, win in ipairs(view.cur_layout.windows) do
           api.nvim_win_call(win.id, function()
             local ok, msg = pcall(vim.cmd, "norm! " .. fold_cmd)
-            if not ok then err = msg end
+            if not ok then
+              err = msg
+            end
           end)
         end
 
-        if err then api.nvim_err_writeln(err) end
+        if err then
+          api.nvim_err_writeln(err)
+        end
       end
     end
   end
 
   for _, fold_cmd in ipairs({
-    "za", "zA", "ze", "zE", "zo", "zc", "zO", "zC", "zr", "zm", "zR", "zM",
-    "zv", "zx", "zX", "zn", "zN", "zi",
+    "za",
+    "zA",
+    "ze",
+    "zE",
+    "zo",
+    "zc",
+    "zO",
+    "zC",
+    "zr",
+    "zm",
+    "zR",
+    "zM",
+    "zv",
+    "zx",
+    "zX",
+    "zn",
+    "zN",
+    "zi",
   }) do
     table.insert(M.compat.fold_cmds, {
       "n",

--- a/lua/diffview/api/init.lua
+++ b/lua/diffview/api/init.lua
@@ -23,8 +23,12 @@ M.selections = lazy.require("diffview.api.selections") ---@module "diffview.api.
 function M.set_revs(new_rev_arg, opts)
   opts = opts or {}
   local view = opts.view or lib.get_current_view()
-  if not view then return end
-  if not view.set_revs then return end
+  if not view then
+    return
+  end
+  if not view.set_revs then
+    return
+  end
   view:set_revs(new_rev_arg, opts)
 end
 

--- a/lua/diffview/api/selections.lua
+++ b/lua/diffview/api/selections.lua
@@ -17,7 +17,9 @@ local M = {}
 ---@param view View?
 ---@return DiffView?
 local function resolve_view(view)
-  if view then return view end
+  if view then
+    return view
+  end
   return lib.get_current_view()
 end
 
@@ -26,9 +28,13 @@ end
 ---@return FilePanel?
 local function get_panel(view)
   view = resolve_view(view)
-  if not view then return nil end
+  if not view then
+    return nil
+  end
   -- Only DiffView has a file panel with selections.
-  if not view.panel or not view.panel.selected_files then return nil end
+  if not view.panel or not view.panel.selected_files then
+    return nil
+  end
   return view.panel
 end
 
@@ -39,7 +45,9 @@ end
 ---@return { path: string, kind: vcs.FileKind }[]
 function M.get(view)
   local panel = get_panel(view)
-  if not panel then return {} end
+  if not panel then
+    return {}
+  end
   local result = {}
   for _, file in ipairs(panel:get_selected_files()) do
     result[#result + 1] = { path = file.path, kind = file.kind }
@@ -52,7 +60,9 @@ end
 ---@return string[]
 function M.get_paths(view)
   local panel = get_panel(view)
-  if not panel then return {} end
+  if not panel then
+    return {}
+  end
   local result = {}
   for _, file in ipairs(panel:get_selected_files()) do
     result[#result + 1] = file.path
@@ -67,7 +77,9 @@ end
 function M.is_selected(path, opts)
   opts = opts or {}
   local panel = get_panel(opts.view)
-  if not panel then return false end
+  if not panel then
+    return false
+  end
   -- A file may appear under multiple kinds (e.g. working + staged).
   -- Return true if *any* matching entry is selected.
   for _, file in panel.files:iter() do
@@ -86,7 +98,9 @@ end
 function M.select(paths, opts)
   opts = opts or {}
   local panel = get_panel(opts.view)
-  if not panel then return end
+  if not panel then
+    return
+  end
   local path_set = {}
   for _, p in ipairs(paths) do
     path_set[p] = true
@@ -108,7 +122,9 @@ end
 function M.deselect(paths, opts)
   opts = opts or {}
   local panel = get_panel(opts.view)
-  if not panel then return end
+  if not panel then
+    return
+  end
   local path_set = {}
   for _, p in ipairs(paths) do
     path_set[p] = true
@@ -133,7 +149,9 @@ end
 function M.set(paths, opts)
   opts = opts or {}
   local panel = get_panel(opts.view)
-  if not panel then return end
+  if not panel then
+    return
+  end
   local path_set = {}
   for _, p in ipairs(paths) do
     path_set[p] = true
@@ -160,7 +178,9 @@ end
 ---@param view View? View to operate on (defaults to current view).
 function M.clear(view)
   local panel = get_panel(view)
-  if not panel then return end
+  if not panel then
+    return
+  end
   panel:clear_selections()
 end
 
@@ -169,7 +189,9 @@ end
 ---@return boolean
 function M.any(view)
   local panel = get_panel(view)
-  if not panel then return false end
+  if not panel then
+    return false
+  end
   return panel:has_any_selections()
 end
 
@@ -178,7 +200,9 @@ end
 ---@return integer
 function M.count(view)
   local panel = get_panel(view)
-  if not panel then return 0 end
+  if not panel then
+    return 0
+  end
   return #panel:get_selected_files()
 end
 

--- a/lua/diffview/api/views/diff/diff_view.lua
+++ b/lua/diffview/api/views/diff/diff_view.lua
@@ -43,8 +43,7 @@ function CDiffView:init(opt)
 
   if err then
     utils.err(
-      ("Failed to create an adapter for the repository: %s")
-      :format(utils.str_quote(opt.git_root))
+      ("Failed to create an adapter for the repository: %s"):format(utils.str_quote(opt.git_root))
     )
     return
   end
@@ -140,19 +139,22 @@ function CDiffView:create_file_entries(files)
 
     for _, file_data in ipairs(v.files) do
       if v.kind == "conflicting" then
-        table.insert(entries[v.kind], FileEntry.with_layout(CDiffView.get_default_merge_layout(), {
-          adapter = self.adapter,
-          path = file_data.path,
-          oldpath = file_data.oldpath,
-          status = "U",
-          kind = "conflicting",
-          revs = {
-            a = Rev(RevType.STAGE, 2),
-            b = Rev(RevType.LOCAL),
-            c = Rev(RevType.STAGE, 3),
-            d = Rev(RevType.STAGE, 1),
-          },
-        }))
+        table.insert(
+          entries[v.kind],
+          FileEntry.with_layout(CDiffView.get_default_merge_layout(), {
+            adapter = self.adapter,
+            path = file_data.path,
+            oldpath = file_data.oldpath,
+            status = "U",
+            kind = "conflicting",
+            revs = {
+              a = Rev(RevType.STAGE, 2),
+              b = Rev(RevType.LOCAL),
+              c = Rev(RevType.STAGE, 3),
+              d = Rev(RevType.STAGE, 1),
+            },
+          })
+        )
       else
         local layout_class = CDiffView.get_default_layout()
 
@@ -179,22 +181,25 @@ function CDiffView:create_file_entries(files)
           })
         end
 
-        table.insert(entries[v.kind], FileEntry({
-          adapter = self.adapter,
-          path = file_data.path,
-          oldpath = file_data.oldpath,
-          status = file_data.status,
-          stats = file_data.stats,
-          kind = v.kind,
-          revs = {
-            a = v.left,
-            b = v.right,
-          },
-          layout = layout_class({
-            a = create_file(v.left, "a"),
-            b = create_file(v.right, "b"),
-          }),
-        }))
+        table.insert(
+          entries[v.kind],
+          FileEntry({
+            adapter = self.adapter,
+            path = file_data.path,
+            oldpath = file_data.oldpath,
+            status = file_data.status,
+            stats = file_data.stats,
+            kind = v.kind,
+            revs = {
+              a = v.left,
+              b = v.right,
+            },
+            layout = layout_class({
+              a = create_file(v.left, "a"),
+              b = create_file(v.right, "b"),
+            }),
+          })
+        )
       end
 
       if file_data.selected then

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -276,7 +276,9 @@ function M.scan(cmd_line, opt)
       argidx = #args + 1
       arg_lead = arg
       lead_quote = cur_quote
-      if h < opt.cur_pos then between = true end
+      if h < opt.cur_pos then
+        between = true
+      end
     end
 
     if char == "\\" then
@@ -391,7 +393,9 @@ end
 ---@param input_cmp boolean? Completion for |input()|.
 ---@return string[]
 function M.process_candidates(candidates, ctx, input_cmp)
-  if not candidates then return {} end
+  if not candidates then
+    return {}
+  end
 
   local cmd_lead = ""
   local ex_lead = (ctx.lead_quote or "") .. ctx.arg_lead

--- a/lua/diffview/async.lua
+++ b/lua/diffview/async.lua
@@ -20,7 +20,9 @@ M._handles = {}
 ---@alias AsyncKind "callback"|"void"
 
 local function dstring(object)
-  if not DiffviewGlobal.logger then return "" end
+  if not DiffviewGlobal.logger then
+    return ""
+  end
   dstring = DiffviewGlobal.logger.dstring
   return dstring(object)
 end
@@ -69,7 +71,9 @@ M.Waitable = Waitable
 
 ---@abstract
 ---@return any ... # Any values returned by the waitable
-function Waitable:await() oop.abstract_stub() end
+function Waitable:await()
+  oop.abstract_stub()
+end
 
 ---Schedule a callback to be invoked when this waitable has settled.
 ---@param callback function
@@ -142,17 +146,23 @@ end
 
 ---@return any ... # If the future has completed, this returns any returned values.
 function Future:get_returned()
-  if not self.return_values then return end
+  if not self.return_values then
+    return
+  end
   return unpack(self.return_values, 2, table.maxn(self.return_values))
 end
 
 ---@package
 ---@param ... any
 function Future:dprint(...)
-  if not DiffviewGlobal.logger then return end
+  if not DiffviewGlobal.logger then
+    return
+  end
   if DiffviewGlobal.debug_level >= 10 or M._watching[self] then
     local t = { self, "::", ... }
-    for i = 1, table.maxn(t) do t[i] = dstring(t[i]) end
+    for i = 1, table.maxn(t) do
+      t[i] = dstring(t[i])
+    end
     DiffviewGlobal.logger:debug(table.concat(t, " "))
   end
 end
@@ -182,7 +192,9 @@ end
 ---@package
 ---@param force? boolean
 function Future:raise(force)
-  if self.has_raised and not force then return end
+  if self.has_raised and not force then
+    return
+  end
   self.has_raised = true
   error(self.err)
 end
@@ -202,8 +214,7 @@ function Future:step(...)
     end
 
     local msg = fmt(
-      "The coroutine failed with this message: \n"
-        .. "\tcontext: cur_thread=%s co_thread=%s %s\n%s",
+      "The coroutine failed with this message: \n" .. "\tcontext: cur_thread=%s co_thread=%s %s\n%s",
       dstring(current_thread() or "main"),
       dstring(self.thread),
       func_info and fmt("co_func=%s:%d", func_info.short_src, func_info.linedefined) or "",
@@ -322,7 +333,9 @@ function Future:toplevel_await()
     end, 1)
 
     -- Respect interrupts
-    if status ~= -1 then break end
+    if status ~= -1 then
+      break
+    end
   end
 
   if not ok then
@@ -391,7 +404,9 @@ function M._run(func, opt)
     local function wrapped_cb(...)
       handle:set_done(true)
       handle.return_values = { true, ... }
-      if cur_cb then cur_cb(...) end
+      if cur_cb then
+        cur_cb(...)
+      end
 
       if handle.awaiting_cb then
         -- The thread was yielding for the callback: resume
@@ -515,10 +530,10 @@ M.join = M.void(function(tasks)
   for _, cur in ipairs(tasks) do
     if cur then
       if type(cur) == "function" then
-        futures[#futures+1] = cur()
+        futures[#futures + 1] = cur()
       else
         ---@cast cur Waitable
-        futures[#futures+1] = cur
+        futures[#futures + 1] = cur
       end
     end
   end
@@ -555,14 +570,12 @@ M.timeout = M.wrap(function(timeout, callback)
     return
   end
 
-  timer:start(
-    timeout,
-    0,
-    function()
-      if not timer:is_closing() then timer:close() end
-      callback()
+  timer:start(timeout, 0, function()
+    if not timer:is_closing() then
+      timer:close()
     end
-  )
+    callback()
+  end)
 end, 2)
 
 ---Yield until the Neovim API is available.

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -428,7 +428,7 @@ function M.get_log_options(single_file, t, vcs)
   local log_options
 
   if single_file then
-    log_options =  M._config.file_history_panel.log_options[vcs].single_file
+    log_options = M._config.file_history_panel.log_options[vcs].single_file
   else
     log_options = M._config.file_history_panel.log_options[vcs].multi_file
   end
@@ -511,9 +511,12 @@ end
 ---@param no_quote? boolean
 ---@return string
 local function fmt_enum(values, no_quote)
-  return table.concat(vim.tbl_map(function(v)
-    return (not no_quote and type(v) == "string") and ("'" .. v .. "'") or v
-  end, values), "|")
+  return table.concat(
+    vim.tbl_map(function(v)
+      return (not no_quote and type(v) == "string") and ("'" .. v .. "'") or v
+    end, values),
+    "|"
+  )
 end
 
 ---@param ... table
@@ -545,20 +548,17 @@ function M.extend_keymaps(...)
 
     for _, map in ipairs(ctx.subject) do
       for _, mode in ipairs(type(map[1]) == "table" and map[1] or { map[1] }) do
-        ctx.expanded[mode .. " " .. map[2]] = utils.vec_join(
-          mode,
-          map[2],
-          utils.vec_slice(map, 3)
-        )
+        ctx.expanded[mode .. " " .. map[2]] = utils.vec_join(mode, map[2], utils.vec_slice(map, 3))
       end
     end
   end
 
-  local merged = vim.tbl_extend("force", unpack(
-    vim.tbl_map(function(v)
+  local merged = vim.tbl_extend(
+    "force",
+    unpack(vim.tbl_map(function(v)
       return v.expanded
-    end, contexts)
-  ))
+    end, contexts))
+  )
 
   return vim.tbl_values(merged)
 end
@@ -566,11 +566,7 @@ end
 function M.setup(user_config)
   user_config = user_config or {}
 
-  M._config = vim.tbl_deep_extend(
-    "force",
-    utils.tbl_deep_clone(M.defaults),
-    user_config
-  )
+  M._config = vim.tbl_deep_extend("force", utils.tbl_deep_clone(M.defaults), user_config)
   ---@type EventEmitter
   M.user_emitter = EventEmitter()
 
@@ -584,15 +580,17 @@ function M.setup(user_config)
   local old_win_config_spec = { "position", "width", "height" }
   for _, panel_name in ipairs({ "file_panel", "file_history_panel" }) do
     local panel_config = M._config[panel_name]
-      ---@cast panel_config table
+    ---@cast panel_config table
     local notified = false
 
     for _, option in ipairs(old_win_config_spec) do
       if panel_config[option] ~= nil then
         if not notified then
           utils.warn(
-            ("'%s.{%s}' has been deprecated. See ':h diffview.changelog-136'.")
-            :format(panel_name, fmt_enum(old_win_config_spec, true))
+            ("'%s.{%s}' has been deprecated. See ':h diffview.changelog-136'."):format(
+              panel_name,
+              fmt_enum(old_win_config_spec, true)
+            )
           )
           notified = true
         end
@@ -617,7 +615,9 @@ function M.setup(user_config)
     }
     for _, name in ipairs(top_options) do
       if user_log_options[name] ~= nil then
-        utils.warn("Global config of 'file_panel.log_options' has been deprecated. See ':h diffview.changelog-271'.")
+        utils.warn(
+          "Global config of 'file_panel.log_options' has been deprecated. See ':h diffview.changelog-271'."
+        )
         break
       end
     end
@@ -633,8 +633,9 @@ function M.setup(user_config)
     for _, name in ipairs(option_names) do
       if user_log_options[name] ~= nil then
         utils.warn(
-          ("'file_history_panel.log_options.{%s}' has been deprecated. See ':h diffview.changelog-151'.")
-          :format(fmt_enum(option_names, true))
+          ("'file_history_panel.log_options.{%s}' has been deprecated. See ':h diffview.changelog-151'."):format(
+            fmt_enum(option_names, true)
+          )
         )
         break
       end
@@ -690,14 +691,15 @@ function M.setup(user_config)
   do
     -- Validate layouts
     local view = M._config.view
-    local standard_layouts = { "diff1_plain", "diff1_inline", "diff2_horizontal", "diff2_vertical", -1 }
+    local standard_layouts =
+      { "diff1_plain", "diff1_inline", "diff2_horizontal", "diff2_vertical", -1 }
     local merge_layouts = {
       "diff1_plain",
       "diff3_horizontal",
       "diff3_vertical",
       "diff3_mixed",
       "diff4_mixed",
-      -1
+      -1,
     }
     local valid_layouts = {
       default = standard_layouts,
@@ -707,11 +709,13 @@ function M.setup(user_config)
 
     for _, kind in ipairs(vim.tbl_keys(valid_layouts)) do
       if not vim.tbl_contains(valid_layouts[kind], view[kind].layout) then
-        utils.err(("Invalid layout name '%s' for 'view.%s'! Must be one of (%s)."):format(
-          view[kind].layout,
-          kind,
-          fmt_enum(valid_layouts[kind])
-        ))
+        utils.err(
+          ("Invalid layout name '%s' for 'view.%s'! Must be one of (%s)."):format(
+            view[kind].layout,
+            kind,
+            fmt_enum(valid_layouts[kind])
+          )
+        )
         view[kind].layout = M.defaults.view[kind].layout
       end
     end
@@ -767,10 +771,12 @@ function M.setup(user_config)
     if view.inline.style == nil then
       view.inline.style = M.defaults.view.inline.style
     elseif not vim.tbl_contains(valid_inline_styles, view.inline.style) then
-      utils.err(("Invalid inline style '%s' for 'view.inline.style'! Must be one of (%s)."):format(
-        view.inline.style,
-        fmt_enum(valid_inline_styles)
-      ))
+      utils.err(
+        ("Invalid inline style '%s' for 'view.inline.style'! Must be one of (%s)."):format(
+          view.inline.style,
+          fmt_enum(valid_inline_styles)
+        )
+      )
       view.inline.style = M.defaults.view.inline.style
     end
   end
@@ -778,11 +784,7 @@ function M.setup(user_config)
   for _, name in ipairs({ "single_file", "multi_file" }) do
     for _, vcs in ipairs({ "git", "hg" }) do
       local t = M._config.file_history_panel.log_options[vcs]
-      t[name] = vim.tbl_extend(
-        "force",
-        M.log_option_defaults[vcs],
-        t[name]
-      )
+      t[name] = vim.tbl_extend("force", M.log_option_defaults[vcs], t[name])
       for k, _ in pairs(t[name]) do
         if t[name][k] == "" then
           t[name][k] = nil
@@ -793,7 +795,7 @@ function M.setup(user_config)
 
   for event, callback in pairs(M._config.hooks) do
     if type(callback) == "function" then
-      M.user_emitter:on(event, function (_, ...)
+      M.user_emitter:on(event, function(_, ...)
         callback(...)
       end)
     end
@@ -812,10 +814,8 @@ function M.setup(user_config)
   -- Merge default and user keymaps
   for name, keymap in pairs(M._config.keymaps) do
     if type(name) == "string" and type(keymap) == "table" then
-      M._config.keymaps[name] = M.extend_keymaps(
-        keymap,
-        utils.tbl_access(user_config, { "keymaps", name }) or {}
-      )
+      M._config.keymaps[name] =
+        M.extend_keymaps(keymap, utils.tbl_access(user_config, { "keymaps", name }) or {})
     end
   end
 

--- a/lua/diffview/control.lua
+++ b/lua/diffview/control.lua
@@ -26,7 +26,9 @@ function Condvar:notify_all()
   local len = #self.handles
 
   for i, cb in ipairs(self.handles) do
-    if i > len then break end
+    if i > len then
+      break
+    end
     cb()
   end
 
@@ -36,7 +38,6 @@ function Condvar:notify_all()
     self.handles = {}
   end
 end
-
 
 ---@class SignalConsumer : Waitable
 ---@operator call : SignalConsumer
@@ -72,7 +73,6 @@ function SignalConsumer:get_name()
   return self.parent:get_name()
 end
 
-
 ---@class Signal : SignalConsumer
 ---@operator call : Signal
 ---@field package name string
@@ -92,13 +92,17 @@ end
 ---@override
 ---@param self Signal
 Signal.await = async.sync_void(function(self)
-  if self.emitted then return end
+  if self.emitted then
+    return
+  end
   await(self.cond)
 end)
 
 ---Send the signal.
 function Signal:send()
-  if self.emitted then return end
+  if self.emitted then
+    return
+  end
   self.emitted = true
 
   for _, listener in ipairs(self.listeners) do
@@ -115,7 +119,9 @@ end
 ---@param callback fun(signal: Signal)
 function Signal:listen(callback)
   self.listeners[#self.listeners + 1] = callback
-  if self.emitted then callback(self) end
+  if self.emitted then
+    callback(self)
+  end
 end
 
 ---@return SignalConsumer
@@ -137,7 +143,6 @@ end
 function Signal:get_name()
   return self.name
 end
-
 
 ---@class WorkPool : Waitable
 ---@operator call : WorkPool
@@ -180,7 +185,6 @@ WorkPool.await = async.sync_void(function(self)
   end
 end)
 
-
 ---@class Permit : diffview.Object
 ---@operator call : Permit
 ---@field parent Semaphore
@@ -203,7 +207,6 @@ function Permit:forget()
   end
 end
 
-
 ---@class Semaphore : diffview.Object
 ---@operator call : Semaphore
 ---@field initial_count integer
@@ -220,7 +223,9 @@ function Semaphore:init(permit_count)
 end
 
 function Semaphore:forget_one()
-  if self.permit_count == self.initial_count then return end
+  if self.permit_count == self.initial_count then
+    return
+  end
 
   if next(self.queue) then
     local next_contractee = table.remove(self.queue, 1)
@@ -242,7 +247,6 @@ Semaphore.acquire = async.wrap(function(self, callback)
 
   return callback(Permit({ parent = self }))
 end)
-
 
 ---@class CountDownLatch : Waitable
 ---@operator call : CountDownLatch
@@ -280,7 +284,9 @@ end
 
 ---@override
 function CountDownLatch:await()
-  if self.counter == 0 then return end
+  if self.counter == 0 then
+    return
+  end
   await(self.condvar)
 end
 

--- a/lua/diffview/debounce.lua
+++ b/lua/diffview/debounce.lua
@@ -150,7 +150,9 @@ function M.throttle_trailing(ms, rush_first, fn)
       args = utils.tbl_pack(...)
     end
 
-    if lock then return end
+    if lock then
+      return
+    end
 
     lock = true
 
@@ -191,7 +193,9 @@ function M.throttle_render(framerate, fn)
 
   throttled_fn = async.void(function(...)
     args = utils.tbl_pack(...)
-    if lock then return end
+    if lock then
+      return
+    end
 
     lock = true
     await(async.schedule_now())
@@ -273,4 +277,3 @@ function M.set_timeout(func, delay)
 end
 
 return M
-

--- a/lua/diffview/diff.lua
+++ b/lua/diffview/diff.lua
@@ -11,9 +11,9 @@ local M = {}
 
 ---@enum EditToken
 local EditToken = oop.enum({
-  NOOP    = 1,
-  DELETE  = 2,
-  INSERT  = 3,
+  NOOP = 1,
+  DELETE = 2,
+  INSERT = 3,
   REPLACE = 4,
 })
 
@@ -44,7 +44,9 @@ function Diff:init(a, b, eql_fn)
   end
 
   -- Fast path: skip the full algorithm when there is nothing to diff.
-  if a == b or (#a == 0 and #b == 0) then return end
+  if a == b or (#a == 0 and #b == 0) then
+    return
+  end
 
   for i = 1, #a do
     self.moda[i] = false

--- a/lua/diffview/events.lua
+++ b/lua/diffview/events.lua
@@ -33,7 +33,6 @@ function Event:stop_propagation()
   self.propagate = false
 end
 
-
 ---@class EventEmitter : diffview.Object
 ---@operator call : EventEmitter
 ---@field event_map table<any, Listener[]> # Registered events mapped to subscribed listeners.
@@ -127,10 +126,7 @@ function EventEmitter:off(callback, event_id)
   if event_id then
     all = { self.event_map[event_id] }
   else
-    all = utils.vec_join(
-      vim.tbl_values(self.event_map),
-      { self.any_listeners }
-    )
+    all = utils.vec_join(vim.tbl_values(self.event_map), { self.any_listeners })
   end
 
   for _, listeners in ipairs(all) do
@@ -169,14 +165,16 @@ local function filter_call(listeners, event, args)
   for i = 1, #listeners do
     local cur = listeners[i]
     local ret = cur.call(event, args)
-    local discard = (type(ret) == "boolean" and ret)
-        or cur.type == "once"
-        or cur.type == "any_once"
+    local discard = (type(ret) == "boolean" and ret) or cur.type == "once" or cur.type == "any_once"
 
-    if not discard then result[#result + 1] = cur end
+    if not discard then
+      result[#result + 1] = cur
+    end
 
     if not event.propagate then
-      for j = i + 1, #listeners do result[j] = listeners[j] end
+      for j = i + 1, #listeners do
+        result[j] = listeners[j]
+      end
       break
     end
   end

--- a/lua/diffview/ffi.lua
+++ b/lua/diffview/ffi.lua
@@ -14,7 +14,9 @@ end
 ---See: |api-fast|, |textlock|
 ---@return boolean
 function M.nvim_is_locked()
-  if vim.in_fast_event() then return true end
+  if vim.in_fast_event() then
+    return true
+  end
   return C.textlock > 0 or C.allbuf_lock > 0 or C.expr_map_lock > 0
 end
 

--- a/lua/diffview/health.lua
+++ b/lua/diffview/health.lua
@@ -34,7 +34,9 @@ function M.check()
 
   -- LuaJIT
   if not _G.jit then
-    health.error("Not running on LuaJIT! Non-JIT Lua runtimes are not officially supported by the plugin. Mileage may vary.")
+    health.error(
+      "Not running on LuaJIT! Non-JIT Lua runtimes are not officially supported by the plugin. Mileage may vary."
+    )
   end
 
   health.start("Checking plugin dependencies")
@@ -54,11 +56,12 @@ function M.check()
     end
   end
 
-  health.start("Checking VCS tools")
-
-  ;(function()
+  health.start("Checking VCS tools");
+  (function()
     if missing_essential then
-      health.warn("Cannot perform checks on external dependencies without all essential plugin dependencies installed!")
+      health.warn(
+        "Cannot perform checks on external dependencies without all essential plugin dependencies installed!"
+      )
       return
     end
 
@@ -74,7 +77,9 @@ function M.check()
 
     for _, kind in ipairs(adapter_kinds) do
       local bs = kind.class.bootstrap
-      if not bs.done then kind.class.run_bootstrap() end
+      if not bs.done then
+        kind.class.run_bootstrap()
+      end
 
       if bs.version_string then
         health.ok(fmt("%s found.", kind.name))

--- a/lua/diffview/hl.lua
+++ b/lua/diffview/hl.lua
@@ -101,13 +101,21 @@ function M.get_hl(name, no_trans)
   else
     local id = api.nvim_get_hl_id_by_name(name)
 
-    if id then hl = api.nvim_get_hl(0, { id = id, link = false }) end
+    if id then
+      hl = api.nvim_get_hl(0, { id = id, link = false })
+    end
   end
 
   if hl then
-    if hl.fg then hl.x_fg = string.format("#%06x", hl.fg) end
-    if hl.bg then hl.x_bg = string.format("#%06x", hl.bg) end
-    if hl.sp then hl.x_sp = string.format("#%06x", hl.sp) end
+    if hl.fg then
+      hl.x_fg = string.format("#%06x", hl.fg)
+    end
+    if hl.bg then
+      hl.x_bg = string.format("#%06x", hl.bg)
+    end
+    if hl.sp then
+      hl.x_sp = string.format("#%06x", hl.sp)
+    end
 
     return hl
   end
@@ -120,9 +128,13 @@ end
 function M.get_hl_attr(name, attr, no_trans)
   local hl = M.get_hl(name, no_trans)
 
-  if type(attr) == "string" then attr = hlattr[attr] end
+  if type(attr) == "string" then
+    attr = hlattr[attr]
+  end
 
-  if not (hl and attr) then return end
+  if not (hl and attr) then
+    return
+  end
 
   return hl[hlattr[attr]]
 end
@@ -134,12 +146,16 @@ end
 function M.get_fg(groups, no_trans)
   no_trans = not not no_trans
 
-  if type(groups) ~= "table" then groups = { groups } end
+  if type(groups) ~= "table" then
+    groups = { groups }
+  end
 
   for _, group in ipairs(groups) do
     local v = M.get_hl_attr(group, hlattr.x_fg, no_trans) --[[@as string? ]]
 
-    if v then return v end
+    if v then
+      return v
+    end
   end
 end
 
@@ -150,12 +166,16 @@ end
 function M.get_bg(groups, no_trans)
   no_trans = not not no_trans
 
-  if type(groups) ~= "table" then groups = { groups } end
+  if type(groups) ~= "table" then
+    groups = { groups }
+  end
 
   for _, group in ipairs(groups) do
     local v = M.get_hl_attr(group, hlattr.x_bg, no_trans) --[[@as string? ]]
 
-    if v then return v end
+    if v then
+      return v
+    end
   end
 end
 
@@ -165,7 +185,9 @@ end
 ---@return string?
 function M.get_style(groups, no_trans)
   no_trans = not not no_trans
-  if type(groups) ~= "table" then groups = { groups } end
+  if type(groups) ~= "table" then
+    groups = { groups }
+  end
 
   for _, group in ipairs(groups) do
     local hl = M.get_hl(group, no_trans)
@@ -174,10 +196,14 @@ function M.get_style(groups, no_trans)
       local res = {}
 
       for _, attr in ipairs(style_attrs) do
-        if hl[attr] then table.insert(res, attr) end
+        if hl[attr] then
+          table.insert(res, attr)
+        end
       end
 
-      if #res > 0 then return table.concat(res, ",") end
+      if #res > 0 then
+        return table.concat(res, ",")
+      end
     end
   end
 end
@@ -207,7 +233,9 @@ end
 ---@param groups string|string[] Syntax group name or a list of group names.
 ---@param opt hl.HiSpec
 function M.hi(groups, opt)
-  if type(groups) ~= "table" then groups = { groups } end
+  if type(groups) ~= "table" then
+    groups = { groups }
+  end
 
   for _, group in ipairs(groups) do
     local def_spec
@@ -219,7 +247,9 @@ function M.hi(groups, opt)
     end
 
     for k, v in pairs(def_spec) do
-      if v == "NONE" then def_spec[k] = nil end
+      if v == "NONE" then
+        def_spec[k] = nil
+      end
     end
 
     api.nvim_set_hl(0, group, def_spec)
@@ -239,7 +269,9 @@ function M.hi_link(from, to, opt)
     force = true,
   }) --[[@as hl.HiLinkSpec ]]
 
-  if type(from) ~= "table" then from = { from } end
+  if type(from) ~= "table" then
+    from = { from }
+  end
 
   for _, f in ipairs(from) do
     if opt.clear then
@@ -261,7 +293,9 @@ function M.hi_clear(groups)
     return
   end
 
-  if type(groups) ~= "table" then groups = { groups } end
+  if type(groups) ~= "table" then
+    groups = { groups }
+  end
 
   for _, g in ipairs(groups) do
     api.nvim_set_hl(0, g, {})
@@ -269,7 +303,9 @@ function M.hi_clear(groups)
 end
 
 function M.get_file_icon(name, ext, render_data, line_idx, offset)
-  if not config.get_config().use_icons then return "" end
+  if not config.get_config().use_icons then
+    return ""
+  end
 
   if not (web_devicons or mini_icons) then
     local ok
@@ -329,12 +365,16 @@ local git_status_hl_map = {
   ["!"] = "DiffviewStatusIgnored",
 }
 
-function M.get_git_hl(status) return git_status_hl_map[status] end
+function M.get_git_hl(status)
+  return git_status_hl_map[status]
+end
 
 ---Get the configured status icon for a git status letter.
 ---@param status string Git status letter (e.g., "M", "A", "D").
 ---@return string
-function M.get_status_icon(status) return config.get_config().status_icons[status] or status end
+function M.get_status_icon(status)
+  return config.get_config().status_icons[status] or status
+end
 
 function M.get_colors()
   return {
@@ -436,7 +476,9 @@ function M.setup()
   -- Ensure diff highlights are defined by loading the diff syntax if needed.
   -- Some colorschemes don't set diffAdded/diffRemoved/diffChanged until the
   -- diff filetype is encountered.
-  if vim.fn.hlexists("diffAdded") == 0 then vim.cmd("runtime! syntax/diff.vim") end
+  if vim.fn.hlexists("diffAdded") == 0 then
+    vim.cmd("runtime! syntax/diff.vim")
+  end
 
   for name, v in pairs(M.get_hl_groups()) do
     v = vim.tbl_extend("force", v, { default = true })

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -186,21 +186,17 @@ end
 ---Create a temporary adapter to get relevant completions
 ---@return VCSAdapter?
 function M.get_adapter()
-    local cfile = pl:vim_expand("%")
-    local top_indicators = utils.vec_join(
-      vim.bo.buftype == ""
-          and pl:absolute(cfile)
-          or nil,
-      pl:realpath(".")
-    )
+  local cfile = pl:vim_expand("%")
+  local top_indicators =
+    utils.vec_join(vim.bo.buftype == "" and pl:absolute(cfile) or nil, pl:realpath("."))
 
-    local err, adapter = vcs.get_adapter({ top_indicators = top_indicators })
+  local err, adapter = vcs.get_adapter({ top_indicators = top_indicators })
 
-    if err then
-      logger:warn("[completion] Failed to create adapter: " .. err)
-    end
+  if err then
+    logger:warn("[completion] Failed to create adapter: " .. err)
+  end
 
-    return adapter
+  return adapter
 end
 
 M.completers = {
@@ -227,13 +223,16 @@ M.completers = {
     elseif adapter then
       if not has_rev_arg and ctx.arg_lead:sub(1, 1) ~= "-" then
         utils.vec_extend(candidates, adapter.comp.open:get_all_names())
-        utils.vec_extend(candidates, adapter:rev_candidates(ctx.arg_lead, {
-          accept_range = true,
-        }))
+        utils.vec_extend(
+          candidates,
+          adapter:rev_candidates(ctx.arg_lead, {
+            accept_range = true,
+          })
+        )
       else
-        utils.vec_extend(candidates,
-          adapter.comp.open:get_completion(ctx.arg_lead)
-          or adapter.comp.open:get_all_names()
+        utils.vec_extend(
+          candidates,
+          adapter.comp.open:get_completion(ctx.arg_lead) or adapter.comp.open:get_all_names()
         )
       end
     end
@@ -250,9 +249,10 @@ M.completers = {
     local candidates = {}
 
     if adapter then
-      utils.vec_extend(candidates,
+      utils.vec_extend(
+        candidates,
         adapter.comp.file_history:get_completion(ctx.arg_lead)
-        or adapter.comp.file_history:get_all_names()
+          or adapter.comp.file_history:get_all_names()
       )
       utils.vec_extend(candidates, adapter:path_candidates(ctx.arg_lead))
     else

--- a/lua/diffview/job.lua
+++ b/lua/diffview/job.lua
@@ -74,7 +74,9 @@ Job.FAIL_COND = {
   on_empty = function(j)
     local msg = fmt("Job expected output, but returned nothing! Code: %d", j.code)
     local n = #j.stdout
-    if n == 0 or (n == 1 and j.stdout[1] == "") then return false, msg end
+    if n == 0 or (n == 1 and j.stdout[1] == "") then
+      return false, msg
+    end
     return true
   end,
 }
@@ -98,10 +100,18 @@ function Job:init(opt)
   self.log_opt = job_utils.default_log_opt(opt.log_opt, 4)
   self.check_status = job_utils.resolve_fail_cond(opt.fail_cond, Job.FAIL_COND)
 
-  if opt.on_stdout then self:on_stdout(opt.on_stdout) end
-  if opt.on_stderr then self:on_stderr(opt.on_stderr) end
-  if opt.on_exit then self:on_exit(opt.on_exit) end
-  if opt.on_retry then self:on_retry(opt.on_retry) end
+  if opt.on_stdout then
+    self:on_stdout(opt.on_stdout)
+  end
+  if opt.on_stderr then
+    self:on_stderr(opt.on_stderr)
+  end
+  if opt.on_exit then
+    self:on_exit(opt.on_exit)
+  end
+  if opt.on_retry then
+    self:on_retry(opt.on_retry)
+  end
 end
 
 ---@param ... uv_handle_t
@@ -127,7 +137,9 @@ local function process_chunks(chunks)
 
   local has_eof = data:sub(-1) == "\n"
   local ret = vim.split(data, "\r?\n")
-  if has_eof then ret[#ret] = nil end
+  if has_eof then
+    ret[#ret] = nil
+  end
 
   return ret
 end
@@ -158,7 +170,7 @@ function Job:line_reader(pipe, out, line_listeners)
 
   ---@param err? string
   ---@param data? string
-  return function (err, data)
+  return function(err, data)
     if err then
       logger:error("[Job:line_reader()] " .. err)
     end
@@ -174,7 +186,7 @@ function Job:line_reader(pipe, out, line_listeners)
         if not has_eol and i == #lines then
           line_buffer = line
         else
-          out[#out+1] = line
+          out[#out + 1] = line
 
           if line_listeners then
             for _, listener in ipairs(line_listeners) do
@@ -185,7 +197,7 @@ function Job:line_reader(pipe, out, line_listeners)
       end
     else
       if line_buffer then
-        out[#out+1] = line_buffer
+        out[#out + 1] = line_buffer
 
         if line_listeners then
           for _, listener in ipairs(line_listeners) do
@@ -220,7 +232,9 @@ end
 ---@param data string|string[]
 function Job:handle_writer(pipe, data)
   if type(data) == "string" then
-    if data:sub(-1) ~= "\n" then data = data .. "\n" end
+    if data:sub(-1) ~= "\n" then
+      data = data .. "\n"
+    end
     pipe:write(data, function(err)
       if err then
         logger:error("[Job:handle_writer()] " .. err)
@@ -228,7 +242,6 @@ function Job:handle_writer(pipe, data)
 
       try_close(pipe)
     end)
-
   else
     ---@cast data string[]
     local c = #data
@@ -292,15 +305,18 @@ Job.start = async.wrap(function(self, callback)
     cwd = self.cwd,
     env = self.env,
     hide = true,
-  },
-  function(code, signal)
+  }, function(code, signal)
     ---@cast handle -?
     handle:close()
     self.p_out:read_stop()
     self.p_err:read_stop()
 
-    if not self.code then self.code = code end
-    if not self.signal then self.signal = signal end
+    if not self.code then
+      self.code = code
+    end
+    if not self.signal then
+      self.signal = signal
+    end
 
     try_close(self.p_out, self.p_err, self.p_in)
 
@@ -419,7 +435,9 @@ end
 ---@return string? err_name
 ---@return string? err_msg
 function Job:kill(code, signal)
-  if not self.handle then return 0 end
+  if not self.handle then
+    return 0
+  end
 
   if not self.handle:is_closing() then
     self.code = code
@@ -437,7 +455,9 @@ Job.await = async.sync_wrap(function(self, callback)
   if self:is_done() then
     callback(self:is_success())
   elseif self:is_running() then
-    self:on_exit(function(_, ...) callback(...) end)
+    self:on_exit(function(_, ...)
+      callback(...)
+    end)
   else
     callback(await(self:start()))
   end
@@ -514,7 +534,9 @@ end
 ---@return string? err
 function Job:is_success()
   local ok, err = self:check_status()
-  if not ok then return false, err end
+  if not ok then
+    return false, err
+  end
   return true
 end
 

--- a/lua/diffview/lazy.lua
+++ b/lua/diffview/lazy.lua
@@ -32,16 +32,22 @@ function lazy.wrap(t, handler)
 
   return setmetatable(ret, {
     __index = function(_, key)
-      if export == nil then ret.__get() end
+      if export == nil then
+        ret.__get()
+      end
       ---@cast export table
       return export[key]
     end,
     __newindex = function(_, key, value)
-      if export == nil then ret.__get() end
+      if export == nil then
+        ret.__get()
+      end
       export[key] = value
     end,
     __call = function(_, ...)
-      if export == nil then ret.__get() end
+      if export == nil then
+        ret.__get()
+      end
       ---@cast export table
       return export(...)
     end,
@@ -100,9 +106,8 @@ end
 ---@param access_path string|string[] Either a `.` separated string of table keys, or a list.
 ---@return LazyModule
 function lazy.access(x, access_path)
-  local keys = type(access_path) == "table"
-      and access_path
-      or vim.split(access_path --[[@as string ]], ".", { plain = true })
+  local keys = type(access_path) == "table" and access_path
+    or vim.split(access_path --[[@as string ]], ".", { plain = true })
 
   local handler = function(module)
     local export = module

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -5,7 +5,8 @@ require("diffview.bootstrap")
 
 local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
 local FileDiffView = lazy.access("diffview.scene.views.diff.file_diff_view", "FileDiffView") ---@type FileDiffView|LazyModule
-local FileHistoryView = lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
+local FileHistoryView =
+  lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
 local NullAdapter = lazy.access("diffview.vcs.adapters.null", "NullAdapter") ---@type NullAdapter|LazyModule
 local StandardView = lazy.access("diffview.scene.views.standard.standard_view", "StandardView") ---@type StandardView|LazyModule
 local arg_parser = lazy.require("diffview.arg_parser") ---@module "diffview.arg_parser"
@@ -34,12 +35,14 @@ local same_rev = lazy.access(rev_lib, "same_rev") ---@type fun(a: Rev?, b: Rev?)
 ---@return DiffView?
 function M.find_existing_view(adapter, rev_arg, path_args, left, right)
   for _, view in ipairs(M.views) do
-    if DiffView.__get():ancestorof(view)
-        and view.adapter.ctx.toplevel == adapter.ctx.toplevel
-        and view.rev_arg == rev_arg
-        and vim.deep_equal(view.path_args or {}, path_args or {})
-        and same_rev(view.left, left)
-        and same_rev(view.right, right) then
+    if
+      DiffView.__get():ancestorof(view)
+      and view.adapter.ctx.toplevel == adapter.ctx.toplevel
+      and view.rev_arg == rev_arg
+      and vim.deep_equal(view.path_args or {}, path_args or {})
+      and same_rev(view.left, left)
+      and same_rev(view.right, right)
+    then
       return view
     end
   end
@@ -51,10 +54,13 @@ function M.diffview_open(args)
   local argo = arg_parser.parse(utils.flatten({ default_args, args }))
   local rev_arg = argo.args[1]
 
-  logger:info("[command call] :DiffviewOpen " .. table.concat(utils.flatten({
-    default_args,
-    args,
-  }), " "))
+  logger:info("[command call] :DiffviewOpen " .. table.concat(
+    utils.flatten({
+      default_args,
+      args,
+    }),
+    " "
+  ))
 
   local err, adapter = vcs.get_adapter({
     cmd_ctx = {
@@ -77,7 +83,8 @@ function M.diffview_open(args)
   end
 
   -- Check for existing view with matching parameters (including revisions).
-  local existing = M.find_existing_view(adapter, rev_arg, adapter.ctx.path_args, opts.left, opts.right)
+  local existing =
+    M.find_existing_view(adapter, rev_arg, adapter.ctx.path_args, opts.left, opts.right)
   if existing and existing.tabpage and api.nvim_tabpage_is_valid(existing.tabpage) then
     api.nvim_set_current_tabpage(existing.tabpage)
     logger:debug("Switched to existing DiffView")
@@ -109,10 +116,13 @@ function M.file_history(range, args)
   local default_args = config.get_config().default_args.DiffviewFileHistory
   local argo = arg_parser.parse(utils.flatten({ default_args, args }))
 
-  logger:info("[command call] :DiffviewFileHistory " .. table.concat(utils.flatten({
-    default_args,
-    args,
-  }), " "))
+  logger:info("[command call] :DiffviewFileHistory " .. table.concat(
+    utils.flatten({
+      default_args,
+      args,
+    }),
+    " "
+  ))
 
   local err, adapter = vcs.get_adapter({
     cmd_ctx = {

--- a/lua/diffview/logger.lua
+++ b/lua/diffview/logger.lua
@@ -152,7 +152,9 @@ end
 ---@param precision number
 ---@return number
 local function to_precision(num, precision)
-  if num % 1 == 0 then return num end
+  if num % 1 == 0 then
+    return num
+  end
   local pow = math.pow(10, precision)
   return math.floor(num * pow) / pow
 end
@@ -162,10 +164,7 @@ end
 function Logger.dstring(object)
   local tp = type(object)
 
-  if tp == "thread"
-    or tp == "function"
-    or tp == "userdata"
-  then
+  if tp == "thread" or tp == "function" or tp == "userdata" then
     return fmt("<%s %p>", tp, object)
   elseif tp == "number" then
     return tostring(to_precision(object, 3))
@@ -175,11 +174,15 @@ function Logger.dstring(object)
     if mt and mt.__tostring then
       return tostring(object)
     elseif utils.islist(object) then
-      if #object == 0 then return "[]" end
+      if #object == 0 then
+        return "[]"
+      end
       local s = ""
 
       for i = 1, table.maxn(object) do
-        if i > 1 then s = s .. ", " end
+        if i > 1 then
+          s = s .. ", "
+        end
         s = s .. Logger.dstring(object[i])
       end
 
@@ -274,7 +277,9 @@ Logger.queue_msg = async.void(function(self, msg)
   table.insert(self.msg_buffer, msg)
   permit:forget()
 
-  if self.batch_handle then return end
+  if self.batch_handle then
+    return
+  end
 
   self.batch_handle = loop.set_timeout(
     async.void(function()
@@ -329,22 +334,30 @@ end
 
 do
   -- Create methods
-  for level, name in ipairs(Logger.LogLevels --[[@as string[] ]]) do
+  for level, name in
+    ipairs(Logger.LogLevels --[[@as string[] ]])
+  do
     ---@param self Logger
     Logger[name] = function(self, ...)
-      if self.level < level then return end
+      if self.level < level then
+        return
+      end
       self:_log(name, false, ...)
     end
 
     ---@param self Logger
     Logger["fmt_" .. name] = function(self, formatstring, ...)
-      if self.level < level then return end
+      if self.level < level then
+        return
+      end
       self:_log(name, false, fmt(formatstring, ...))
     end
 
     ---@param self Logger
     Logger["lazy_" .. name] = function(self, func)
-      if self.level < level then return end
+      if self.level < level then
+        return
+      end
       self:_log(name, true, func)
     end
   end
@@ -366,7 +379,9 @@ end
 function Logger:log_job(job, opt)
   opt = opt or {}
 
-  if opt.silent then return end
+  if opt.silent then
+    return
+  end
   if opt.debug_level and DiffviewGlobal.debug_level < opt.debug_level then
     return
   end

--- a/lua/diffview/mock.lua
+++ b/lua/diffview/mock.lua
@@ -8,7 +8,9 @@ local mock_mt = {}
 
 local function tbl_clone(t)
   local ret = {}
-  for k, v in pairs(t) do ret[k] = v end
+  for k, v in pairs(t) do
+    ret[k] = v
+  end
   return ret
 end
 

--- a/lua/diffview/multi_job.lua
+++ b/lua/diffview/multi_job.lua
@@ -51,9 +51,7 @@ MultiJob.FAIL_COND = {
     local failed = {}
 
     for _, job in ipairs(mj.jobs) do
-      if #job.stdout == 1 and job.stdout[1] == ""
-        or #job.stdout == 0
-      then
+      if #job.stdout == 1 and job.stdout[1] == "" or #job.stdout == 0 then
         failed[#failed + 1] = job
       end
     end
@@ -77,8 +75,12 @@ function MultiJob:init(jobs, opt)
   self.log_opt = job_utils.default_log_opt(opt.log_opt, 4)
   self.check_status = job_utils.resolve_fail_cond(opt.fail_cond, MultiJob.FAIL_COND)
 
-  if opt.on_exit then self:on_exit(opt.on_exit) end
-  if opt.on_retry then self:on_retry(opt.on_retry) end
+  if opt.on_exit then
+    self:on_exit(opt.on_exit)
+  end
+  if opt.on_retry then
+    self:on_retry(opt.on_retry)
+  end
 end
 
 ---@private
@@ -116,7 +118,9 @@ MultiJob.start = async.wrap(function(self, callback)
     local ok, err
     ok, jobs, err = self:check_status()
 
-    if ok then break end
+    if ok then
+      break
+    end
     ---@cast jobs -?
 
     if i == self.retry + 1 then
@@ -164,7 +168,9 @@ MultiJob.await = async.sync_wrap(function(self, callback)
   if self:is_done() then
     callback(self:is_success())
   elseif self:is_running() then
-    self:on_exit(function(_, ...) callback(...) end)
+    self:on_exit(function(_, ...)
+      callback(...)
+    end)
   else
     callback(await(self:start()))
   end
@@ -174,7 +180,9 @@ end)
 ---@return string? err
 function MultiJob:is_success()
   local ok, _, err = self:check_status()
-  if not ok then return false, err end
+  if not ok then
+    return false, err
+  end
   return true
 end
 
@@ -230,7 +238,9 @@ function MultiJob:kill(code, signal)
   for _, job in ipairs(self.jobs) do
     if job:is_running() then
       local success = job:kill(code, signal)
-      if not success then ret = nil end
+      if not success then
+        ret = nil
+      end
     end
   end
 

--- a/lua/diffview/oop.lua
+++ b/lua/diffview/oop.lua
@@ -78,17 +78,14 @@ end
 function M.create_class(name, super_class)
   super_class = super_class or M.Object
 
-  return setmetatable(
-    {
-      __name = name,
-      super_class = super_class,
-    },
-    {
-      __index = super_class,
-      __call = new_instance,
-      __tostring = tostring,
-    }
-  )
+  return setmetatable({
+    __name = name,
+    super_class = super_class,
+  }, {
+    __index = super_class,
+    __call = new_instance,
+    __tostring = tostring,
+  })
 end
 
 local function classm_safeguard(x)
@@ -125,7 +122,9 @@ end
 ---@return boolean
 function Object:ancestorof(other)
   classm_safeguard(self)
-  if not M.is_instance(other) then return false end
+  if not M.is_instance(other) then
+    return false
+  end
 
   return other:instanceof(self)
 end
@@ -163,7 +162,9 @@ function Object:super(...)
     next_super = self.super_class
   end
 
-  if not next_super then return end
+  if not next_super then
+    return
+  end
 
   self.__init_caller = next_super
   next_super.init(self, ...)
@@ -177,7 +178,9 @@ function Object:instanceof(other)
   local cur = self.class
 
   while cur do
-    if cur == other then return true end
+    if cur == other then
+      return true
+    end
     cur = cur.super_class
   end
 
@@ -187,14 +190,18 @@ end
 ---@param x any
 ---@return boolean
 function M.is_class(x)
-  if type(x) ~= "table" then return false end
+  if type(x) ~= "table" then
+    return false
+  end
   return type(rawget(x, "__name")) == "string" and x.instanceof == Object.instanceof
 end
 
 ---@param x any
 ---@return boolean
 function M.is_instance(x)
-  if type(x) ~= "table" then return false end
+  if type(x) ~= "table" then
+    return false
+  end
   return M.is_class(x.class)
 end
 

--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -21,9 +21,13 @@ local is_windows = uv.os_uname().version:match("Windows")
 ---@return string?
 local function uv_err_code(err, err_name)
   -- When the third value looks like a bare code, prefer it.
-  if err_name and err_name:match("^[%u%d_]+$") then return err_name end
+  if err_name and err_name:match("^[%u%d_]+$") then
+    return err_name
+  end
   -- Otherwise fall back to the leading code in the second value.
-  if err then return err:match("^([%u%d_]+)") end
+  if err then
+    return err:match("^([%u%d_]+)")
+  end
   return nil
 end
 
@@ -31,7 +35,9 @@ local function handle_uv_err(x, err, err_name)
   if not x then
     -- Pick whichever value carries the full descriptive message.
     local msg = err or err_name or "unknown uv error"
-    if err_name and #err_name > #msg then msg = err_name end
+    if err_name and #err_name > #msg then
+      msg = err_name
+    end
 
     local code = uv_err_code(err, err_name)
     if code and not msg:find(code, 1, true) then
@@ -99,7 +105,9 @@ end
 ---@param path string
 function PathLib:_split_root(path)
   local root = self:root(path)
-  if not root then return "", path end
+  if not root then
+    return "", path
+  end
   return root, path:sub(#root + 1)
 end
 
@@ -161,7 +169,9 @@ function PathLib:is_abs(path)
 
   if self._is_windows then
     for _, pat in ipairs(WINDOWS_PATH_SPECIFIER) do
-      if path:match(pat) ~= nil then return true end
+      if path:match(pat) ~= nil then
+        return true
+      end
     end
 
     return false
@@ -201,7 +211,9 @@ function PathLib:is_root(path)
     if self._is_windows then
       for _, pat in ipairs(WINDOWS_PATH_SPECIFIER) do
         local prefix = path:match(pat)
-        if prefix and #path == #prefix then return true end
+        if prefix and #path == #prefix then
+          return true
+        end
       end
 
       return false
@@ -223,7 +235,9 @@ function PathLib:root(path)
     if self._is_windows then
       for _, pat in ipairs(WINDOWS_PATH_SPECIFIER) do
         local root = path:match(pat)
-        if root then return root end
+        if root then
+          return root
+        end
       end
     else
       return self.sep
@@ -378,7 +392,7 @@ function PathLib:explode(path)
   end
 
   for part in path:gmatch(string.format("([^%s]+)%s?", self.sep, self.sep)) do
-    parts[#parts+1] = part
+    parts[#parts + 1] = part
   end
 
   return parts
@@ -391,7 +405,9 @@ function PathLib:add_trailing(path)
   local root
   root, path = self:_split_root(path)
 
-  if #path == 0 then return root .. path end
+  if #path == 0 then
+    return root .. path
+  end
   if path:sub(-1) == self.sep then
     return root .. path
   end
@@ -674,7 +690,7 @@ end)
 
 function PathLib:chain(...)
   local t = {
-    __result = utils.tbl_pack(...)
+    __result = utils.tbl_pack(...),
   }
 
   return setmetatable(t, {
@@ -683,14 +699,13 @@ function PathLib:chain(...)
         return function(_)
           return utils.tbl_unpack(t.__result)
         end
-
       else
         return function(_, ...)
           t.__result = utils.tbl_pack(self[k](self, utils.tbl_unpack(t.__result), ...))
           return chain
         end
       end
-    end
+    end,
   })
 end
 

--- a/lua/diffview/perf.lua
+++ b/lua/diffview/perf.lua
@@ -72,7 +72,8 @@ function PerfTimer:__tostring()
       last = lap[2]
     end
 
-    return s .. string.format("== %s %.3f ms", utils.str_right_pad("FINAL TIME", 36), self.final_time)
+    return s
+      .. string.format("== %s %.3f ms", utils.str_right_pad("FINAL TIME", 36), self.final_time)
   end
 end
 

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -119,12 +119,16 @@ end
 
 ---@param target_layout Layout
 function FileEntry:convert_layout(target_layout)
-  if not self.revs then return end
+  if not self.revs then
+    return
+  end
 
   -- Let the old layout drop any buffer-level render state before it's
   -- replaced; the new layout reuses the same files/buffers, so leftover
   -- visuals (e.g. inline-diff extmarks) would otherwise persist.
-  if self.layout.teardown_render then self.layout:teardown_render() end
+  if self.layout.teardown_render then
+    self.layout:teardown_render()
+  end
 
   local get_data
 
@@ -219,7 +223,9 @@ function FileEntry:update_merge_context(ctx)
     )
   end
 
-  if layout.b then layout.b.file.winbar = " LOCAL (Working tree)" end
+  if layout.b then
+    layout.b.file.winbar = " LOCAL (Working tree)"
+  end
 
   if layout.c and ctx.theirs.hash then
     layout.c.file.winbar = (" THEIRS (Incoming changes) %s %s"):format(
@@ -247,7 +253,9 @@ function FileEntry.update_index_stat(adapter, stat)
   stat = stat or pl:stat(pl:join(adapter.ctx.toplevel, "index"))
 
   if stat then
-    if not fstat_cache[adapter.ctx.toplevel] then fstat_cache[adapter.ctx.toplevel] = {} end
+    if not fstat_cache[adapter.ctx.toplevel] then
+      fstat_cache[adapter.ctx.toplevel] = {}
+    end
 
     fstat_cache[adapter.ctx.toplevel].index = {
       mtime = stat.mtime.sec,

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -30,7 +30,9 @@ local function utf8_iter(s)
   local len = #s
   local pos = 1
   return function()
-    if pos > len then return nil end
+    if pos > len then
+      return nil
+    end
     local b = s:byte(pos)
     local char_len
     if b < 0x80 then
@@ -49,7 +51,9 @@ local function utf8_iter(s)
       char_len = 1
     end
     local remaining = len - pos + 1
-    if char_len > remaining then char_len = remaining end
+    if char_len > remaining then
+      char_len = remaining
+    end
     local ch = s:sub(pos, pos + char_len - 1)
     local start = pos - 1
     pos = pos + char_len
@@ -75,8 +79,12 @@ end
 ---@param ch string
 ---@return boolean
 local function is_word_char(ch)
-  if ch == "" then return false end
-  if #ch > 1 then return true end
+  if ch == "" then
+    return false
+  end
+  if #ch > 1 then
+    return true
+  end
   return is_word_byte(ch:byte(1))
 end
 
@@ -85,7 +93,9 @@ end
 -- non-word char, so the first byte determines the class.
 ---@param s string
 ---@return boolean
-local function is_word_token(s) return s ~= "" and is_word_byte(s:byte(1)) end
+local function is_word_token(s)
+  return s ~= "" and is_word_byte(s:byte(1))
+end
 
 -- Tokenize `s` for word-level intraline diffing. Each maximal run of word
 -- characters forms one token; each non-word character becomes its own
@@ -122,7 +132,9 @@ local function tokenize(s)
       byte_map[#byte_map + 1] = { byte = byte_pos, byte_len = char_len }
     end
   end
-  if word_start then byte_map[#byte_map + 1] = { byte = word_start, byte_len = word_bytes } end
+  if word_start then
+    byte_map[#byte_map + 1] = { byte = word_start, byte_len = word_bytes }
+  end
   return tokens, byte_map
 end
 
@@ -167,7 +179,9 @@ end
 ---@param b_units string[]
 ---@return integer[][]
 local function diff_units(a_units, b_units)
-  if #a_units == 0 or #b_units == 0 then return {} end
+  if #a_units == 0 or #b_units == 0 then
+    return {}
+  end
   local a = table.concat(a_units, "\n") .. "\n"
   local b = table.concat(b_units, "\n") .. "\n"
   return vim.diff(a, b, {
@@ -200,14 +214,20 @@ local INTRALINE_MAX_HUNKS = 3
 ---@param n_hunks integer
 ---@return boolean
 local function refinement_safe(old_chars, new_chars, n_hunks)
-  if n_hunks == 0 or n_hunks > INTRALINE_MAX_HUNKS then return false end
-  if n_hunks == 1 then return true end
+  if n_hunks == 0 or n_hunks > INTRALINE_MAX_HUNKS then
+    return false
+  end
+  if n_hunks == 1 then
+    return true
+  end
 
   local pre = 0
   while pre < #old_chars and pre < #new_chars and old_chars[pre + 1] == new_chars[pre + 1] do
     pre = pre + 1
   end
-  if pre >= 2 then return true end
+  if pre >= 2 then
+    return true
+  end
 
   local suf = 0
   while
@@ -314,17 +334,25 @@ end
 ---@param inline_del boolean Render deleted units as inline virt_text.
 ---@return "ok"|"noop"|"skipped" # `ok`: rendered; `noop`: identical (nothing to do); `skipped`: fragmented, caller may want to fall back.
 local function render_char_highlights(bufnr, new_row, old_line, new_line, inline_del)
-  if old_line == new_line then return "noop" end
+  if old_line == new_line then
+    return "noop"
+  end
   -- Blank-to-nonblank (or vice versa) has no meaningful char-level diff, but
   -- the lines differ: signal `skipped` so the caller's fallback path still
   -- renders a line highlight / echoes the old line in overleaf style.
-  if old_line == "" or new_line == "" then return "skipped" end
+  if old_line == "" or new_line == "" then
+    return "skipped"
+  end
 
   local old_tokens = tokenize(old_line)
   local new_tokens, new_map = tokenize(new_line)
   local hunks = diff_units(old_tokens, new_tokens)
-  if #hunks == 0 then return "noop" end
-  if #hunks > INTRALINE_MAX_HUNKS then return "skipped" end
+  if #hunks == 0 then
+    return "noop"
+  end
+  if #hunks > INTRALINE_MAX_HUNKS then
+    return "skipped"
+  end
 
   local new_line_len = #new_line
 
@@ -447,17 +475,27 @@ local function render_deleted_block(
     }
   end
 
-  if #virt_lines == 0 then return end
+  if #virt_lines == 0 then
+    return
+  end
 
   local row = anchor_row
-  if row == nil then row = new_start == 0 and 0 or new_start - 1 end
+  if row == nil then
+    row = new_start == 0 and 0 or new_start - 1
+  end
 
-  if above == nil then above = new_start == 0 end
+  if above == nil then
+    above = new_start == 0
+  end
 
   local line_count = api.nvim_buf_line_count(bufnr)
-  if line_count == 0 then return end
+  if line_count == 0 then
+    return
+  end
 
-  if row >= line_count then row = line_count - 1 end
+  if row >= line_count then
+    row = line_count - 1
+  end
 
   api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {
     virt_lines = virt_lines,
@@ -489,7 +527,9 @@ local scroll_adjuster_augroup =
 
 ---@param bufnr integer
 local function register_cache_cleanup(bufnr)
-  if cache_cleanup_registered[bufnr] or not api.nvim_buf_is_valid(bufnr) then return end
+  if cache_cleanup_registered[bufnr] or not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
 
   cache_cleanup_registered[bufnr] = true
   api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
@@ -535,15 +575,25 @@ end
 ---@param bufnr integer
 ---@param winid integer
 function M.ensure_eof_virt_lines_visible(bufnr, winid)
-  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then return end
-  if api.nvim_win_get_buf(winid) ~= bufnr then return end
+  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then
+    return
+  end
+  if api.nvim_win_get_buf(winid) ~= bufnr then
+    return
+  end
 
   local last_row = api.nvim_buf_line_count(bufnr)
-  if last_row == 0 then return end
-  if api.nvim_win_get_cursor(winid)[1] ~= last_row then return end
+  if last_row == 0 then
+    return
+  end
+  if api.nvim_win_get_cursor(winid)[1] ~= last_row then
+    return
+  end
 
   local below = count_edge_virt_lines(bufnr, last_row - 1, false)
-  if below == 0 then return end
+  if below == 0 then
+    return
+  end
 
   local height = api.nvim_win_get_height(winid)
   -- Clamp `below` so we never ask for a topline past `last_row`: we can't
@@ -578,15 +628,25 @@ end
 ---@param bufnr integer
 ---@param winid integer
 function M.ensure_bof_virt_lines_visible(bufnr, winid)
-  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then return end
-  if api.nvim_win_get_buf(winid) ~= bufnr then return end
-  if M._hunks_by_buf[bufnr] == nil then return end
+  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then
+    return
+  end
+  if api.nvim_win_get_buf(winid) ~= bufnr then
+    return
+  end
+  if M._hunks_by_buf[bufnr] == nil then
+    return
+  end
 
   api.nvim_win_call(winid, function()
     local view = vim.fn.winsaveview()
     local desired = 0
-    if view.topline == 1 then desired = count_edge_virt_lines(bufnr, 0, true) end
-    if (view.topfill or 0) == desired then return end
+    if view.topline == 1 then
+      desired = count_edge_virt_lines(bufnr, 0, true)
+    end
+    if (view.topfill or 0) == desired then
+      return
+    end
     view.topfill = desired
     vim.fn.winrestview(view)
   end)
@@ -594,7 +654,9 @@ end
 
 ---@param bufnr integer
 local function register_scroll_adjuster(bufnr)
-  if scroll_adjuster_registered[bufnr] or not api.nvim_buf_is_valid(bufnr) then return end
+  if scroll_adjuster_registered[bufnr] or not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
 
   scroll_adjuster_registered[bufnr] = true
   api.nvim_create_autocmd("CursorMoved", {
@@ -618,7 +680,9 @@ function M.clear(bufnr)
   -- autocmd installed by `register_cache_cleanup` is still pending and will
   -- reset the flag when it fires. Clearing the flag here would cause the next
   -- render pass to register a duplicate autocmd.
-  if bufnr then M._hunks_by_buf[bufnr] = nil end
+  if bufnr then
+    M._hunks_by_buf[bufnr] = nil
+  end
 end
 
 -- Fully detach the inline diff from `bufnr`: clear extmarks and cached hunks
@@ -631,14 +695,18 @@ end
 ---@param bufnr integer
 function M.detach(bufnr)
   M.clear(bufnr)
-  if not bufnr then return end
+  if not bufnr then
+    return
+  end
   if scroll_adjuster_registered[bufnr] then
     scroll_adjuster_registered[bufnr] = nil
     if api.nvim_buf_is_valid(bufnr) then
       pcall(api.nvim_clear_autocmds, { group = scroll_adjuster_augroup, buffer = bufnr })
     end
   end
-  if not api.nvim_buf_is_valid(bufnr) then return end
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
   for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
     if api.nvim_win_is_valid(winid) then
       api.nvim_win_call(winid, function()
@@ -659,7 +727,9 @@ end
 ---@return integer[]
 function M.hunk_anchor_rows(bufnr)
   local hunks = M._hunks_by_buf[bufnr]
-  if not hunks then return {} end
+  if not hunks then
+    return {}
+  end
 
   local rows = {}
   local line_count = api.nvim_buf_is_valid(bufnr) and api.nvim_buf_line_count(bufnr) or 0
@@ -674,8 +744,12 @@ function M.hunk_anchor_rows(bufnr)
       -- Pure deletion: anchor at the line that holds the virt_lines.
       row = new_start == 0 and 0 or new_start - 1
     end
-    if row < 0 then row = 0 end
-    if line_count > 0 and row >= line_count then row = line_count - 1 end
+    if row < 0 then
+      row = 0
+    end
+    if line_count > 0 and row >= line_count then
+      row = line_count - 1
+    end
 
     if not seen[row] then
       seen[row] = true
@@ -693,7 +767,9 @@ end
 ---@return integer? row
 function M.next_hunk_row(bufnr, cursor_row)
   for _, r in ipairs(M.hunk_anchor_rows(bufnr)) do
-    if r > cursor_row then return r end
+    if r > cursor_row then
+      return r
+    end
   end
 end
 
@@ -702,7 +778,9 @@ end
 -- new_count }` in 1-indexed form, as returned by `vim.diff`.
 ---@param bufnr integer
 ---@return integer[][]?
-function M.get_hunks(bufnr) return M._hunks_by_buf[bufnr] end
+function M.get_hunks(bufnr)
+  return M._hunks_by_buf[bufnr]
+end
 
 -- Find the row of the last hunk strictly before `cursor_row` (0-indexed).
 ---@param bufnr integer
@@ -769,8 +847,12 @@ function M.render(bufnr, old_lines, new_lines, opts)
   local style = STYLES[opts.style] or STYLES.unified
   M.clear(bufnr)
 
-  if not api.nvim_buf_is_valid(bufnr) then return end
-  if api.nvim_buf_line_count(bufnr) == 0 then return end
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  if api.nvim_buf_line_count(bufnr) == 0 then
+    return
+  end
 
   -- Terminate with a trailing newline so `vim.diff` treats the last line as a
   -- complete line. Without it, EOF additions/deletions get classified as
@@ -787,21 +869,33 @@ function M.render(bufnr, old_lines, new_lines, opts)
   -- explicitly set so vim.diff's own defaults apply otherwise. This mirrors
   -- how `'diffopt'` toggles flags/options by presence/absence rather than
   -- forcing fallback values here.
-  if opts.algorithm ~= nil then diff_opts.algorithm = opts.algorithm end
-  if opts.linematch ~= nil then diff_opts.linematch = opts.linematch end
-  if opts.indent_heuristic ~= nil then diff_opts.indent_heuristic = opts.indent_heuristic end
-  if opts.ignore_whitespace ~= nil then diff_opts.ignore_whitespace = opts.ignore_whitespace end
+  if opts.algorithm ~= nil then
+    diff_opts.algorithm = opts.algorithm
+  end
+  if opts.linematch ~= nil then
+    diff_opts.linematch = opts.linematch
+  end
+  if opts.indent_heuristic ~= nil then
+    diff_opts.indent_heuristic = opts.indent_heuristic
+  end
+  if opts.ignore_whitespace ~= nil then
+    diff_opts.ignore_whitespace = opts.ignore_whitespace
+  end
   if opts.ignore_whitespace_change ~= nil then
     diff_opts.ignore_whitespace_change = opts.ignore_whitespace_change
   end
   if opts.ignore_whitespace_change_at_eol ~= nil then
     diff_opts.ignore_whitespace_change_at_eol = opts.ignore_whitespace_change_at_eol
   end
-  if opts.ignore_blank_lines ~= nil then diff_opts.ignore_blank_lines = opts.ignore_blank_lines end
+  if opts.ignore_blank_lines ~= nil then
+    diff_opts.ignore_blank_lines = opts.ignore_blank_lines
+  end
 
   local hunks = vim.diff(old, new, diff_opts)
 
-  if not hunks then return end
+  if not hunks then
+    return
+  end
 
   M._hunks_by_buf[bufnr] = hunks
   register_cache_cleanup(bufnr)
@@ -875,7 +969,9 @@ function M.render(bufnr, old_lines, new_lines, opts)
         -- as a fallback when char-level rendering was skipped (fragmented
         -- pairing) so the reader still sees that the line was modified.
         local line_hl = style.change_line_hl
-        if not line_hl and char_result == "skipped" then line_hl = "DiffviewDiffChange" end
+        if not line_hl and char_result == "skipped" then
+          line_hl = "DiffviewDiffChange"
+        end
         if line_hl then
           api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {
             line_hl_group = line_hl,

--- a/lua/diffview/scene/layout.lua
+++ b/lua/diffview/scene/layout.lua
@@ -31,14 +31,18 @@ end
 ---@abstract
 ---@param self Layout
 ---@param pivot? integer The window ID of the window around which the layout will be created.
-Layout.create = async.void(function(self, pivot) oop.abstract_stub() end)
+Layout.create = async.void(function(self, pivot)
+  oop.abstract_stub()
+end)
 
 ---@abstract
 ---@param rev Rev
 ---@param status string Git status symbol.
 ---@param sym string
 ---@return boolean
-function Layout.should_null(rev, status, sym) oop.abstract_stub() end
+function Layout.should_null(rev, status, sym)
+  oop.abstract_stub()
+end
 
 ---Set a file on the window for the given symbol and tag it.
 ---@param sym string
@@ -60,12 +64,16 @@ Layout.use_entry = async.void(function(self, entry)
     self:set_file_for(sym, layout[sym].file)
   end
 
-  if self:is_valid() then await(self:open_files()) end
+  if self:is_valid() then
+    await(self:open_files())
+  end
 end)
 
 ---@abstract
 ---@return Window
-function Layout:get_main_win() oop.abstract_stub() end
+function Layout:get_main_win()
+  oop.abstract_stub()
+end
 
 ---@diagnostic enable: unused-local, missing-return
 
@@ -117,7 +125,9 @@ Layout.create_wins = async.void(function(self, pivot, win_specs, win_order)
   assert(api.nvim_win_is_valid(pivot), "Layout creation requires a valid window pivot!")
 
   for _, win in ipairs(self.windows) do
-    if win.id ~= pivot then win:close(true) end
+    if win.id ~= pivot then
+      win:close(true)
+    end
   end
 
   for _, spec in ipairs(win_specs) do
@@ -134,7 +144,9 @@ Layout.create_wins = async.void(function(self, pivot, win_specs, win_order)
   end
 
   api.nvim_win_close(pivot, true)
-  self.windows = vim.tbl_map(function(s) return self[s] end, win_order)
+  self.windows = vim.tbl_map(function(s)
+    return self[s]
+  end, win_order)
   await(self:create_post())
 end)
 
@@ -142,7 +154,9 @@ end)
 ---@return boolean
 function Layout:is_focused()
   for _, win in ipairs(self.windows) do
-    if win:is_focused() then return true end
+    if win:is_focused() then
+      return true
+    end
   end
 
   return false
@@ -156,7 +170,9 @@ function Layout:use_windows(...)
     local win = wins[i]
     win.parent = self
 
-    if utils.vec_indexof(self.windows, win) == -1 then table.insert(self.windows, win) end
+    if utils.vec_indexof(self.windows, win) == -1 then
+      table.insert(self.windows, win)
+    end
   end
 end
 
@@ -182,28 +198,36 @@ function Layout:find_pivot()
   if vim.is_callable(self.pivot_producer) then
     local ret = self.pivot_producer()
 
-    if ret then return ret end
+    if ret then
+      return ret
+    end
   end
 
   vim.cmd("1windo belowright vsp")
 
   local pivot = api.nvim_get_current_win()
 
-  if api.nvim_win_is_valid(last_win) then api.nvim_set_current_win(last_win) end
+  if api.nvim_win_is_valid(last_win) then
+    api.nvim_set_current_win(last_win)
+  end
 
   return pivot
 end
 
 ---@return vcs.File[]
 function Layout:files()
-  return utils.tbl_fmap(self.windows, function(v) return v.file end)
+  return utils.tbl_fmap(self.windows, function(v)
+    return v.file
+  end)
 end
 
 ---Return every file the layout is responsible for, including any files that
 ---aren't attached to a window (e.g. `Diff1Inline.a_file`). Used by the file
 ---entry teardown path so non-window files don't get orphaned.
 ---@return vcs.File[]
-function Layout:owned_files() return self:files() end
+function Layout:owned_files()
+  return self:files()
+end
 
 ---Look up the file the layout assigns to `sym`. Default behaviour reads
 ---`self[sym].file`; subclasses with files outside the window set can
@@ -219,7 +243,9 @@ end
 ---@return boolean
 function Layout:is_files_loaded()
   for _, f in ipairs(self:files()) do
-    if not f:is_valid() then return false end
+    if not f:is_valid() then
+      return false
+    end
   end
 
   return true
@@ -267,7 +293,9 @@ function Layout:recover(pivot)
   ---@cast pivot -?
 
   for _, win in ipairs(self.windows) do
-    if win.id ~= pivot then pcall(api.nvim_win_close, win.id, true) end
+    if win.id ~= pivot then
+      pcall(api.nvim_win_close, win.id, true)
+    end
   end
 
   self.windows = {}
@@ -279,13 +307,17 @@ end
 ---Check the validity of all composing layout windows.
 ---@return Layout.State
 function Layout:validate()
-  if not next(self.windows) then return { valid = false } end
+  if not next(self.windows) then
+    return { valid = false }
+  end
 
   local state = { valid = true }
 
   for _, win in ipairs(self.windows) do
     state[win] = win:is_valid()
-    if not state[win] then state.valid = false end
+    if not state[win] then
+      state.valid = false
+    end
   end
 
   return state
@@ -293,14 +325,20 @@ end
 
 ---Check the validity if the layout.
 ---@return boolean
-function Layout:is_valid() return self:validate().valid end
+function Layout:is_valid()
+  return self:validate().valid
+end
 
 ---@return boolean
 function Layout:is_nulled()
-  if not self:is_valid() then return false end
+  if not self:is_valid() then
+    return false
+  end
 
   for _, win in ipairs(self.windows) do
-    if not win:is_nulled() then return false end
+    if not win:is_nulled() then
+      return false
+    end
   end
 
   return true
@@ -310,7 +348,9 @@ end
 function Layout:ensure()
   local state = self:validate()
 
-  if not state.valid then self:recover() end
+  if not state.valid then
+    self:recover()
+  end
 end
 
 ---Save window local options.
@@ -356,12 +396,16 @@ function Layout:sync_scroll()
         vim.cmd("norm! " .. api.nvim_replace_termcodes("<c-e><c-y>", true, true, true))
       end
 
-      if win.id ~= curwin then api.nvim_exec_autocmds("WinLeave", { modeline = false }) end
+      if win.id ~= curwin then
+        api.nvim_exec_autocmds("WinLeave", { modeline = false })
+      end
     end)
   end
 
   -- Cursor will sometimes move +- the value of 'scrolloff'
-  if target ~= nil then api.nvim_win_set_cursor(target.id, cursor) end
+  if target ~= nil then
+    api.nvim_win_set_cursor(target.id, cursor)
+  end
 end
 
 M.Layout = Layout

--- a/lua/diffview/scene/layouts/diff_1.lua
+++ b/lua/diffview/scene/layouts/diff_1.lua
@@ -12,7 +12,6 @@ local Rev = lazy.access("diffview.vcs.rev", "Rev") ---@type Rev|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
 local Window = lazy.access("diffview.scene.window", "Window") ---@type Window|LazyModule
 
-
 local M = {}
 
 ---@class Diff1 : Layout
@@ -111,7 +110,7 @@ function Diff1:to_diff4(layout)
       get_data = main.get_data,
       rev = Rev(RevType.STAGE, 1),
       nulled = false, -- FIXME
-    })
+    }),
   })
 end
 
@@ -125,11 +124,9 @@ function Diff1.should_null(rev, status, sym)
   if rev.type == RevType.LOCAL then
     -- Deleted files have no LOCAL content.
     return status == "D"
-
   elseif rev.type == RevType.COMMIT then
     -- Deleted files have no content on the newer side.
     return status == "D"
-
   elseif rev.type == RevType.STAGE then
     -- Deleted files have no staged content.
     return status == "D"

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -88,7 +88,9 @@ end
 ---@param file vcs.File?
 function Diff1Inline:_set_a_file(file)
   self.a_file = file
-  if file then file.symbol = "a" end
+  if file then
+    file.symbol = "a"
+  end
 end
 
 ---@override
@@ -171,16 +173,24 @@ function Diff1Inline:_repaint()
   -- Batched buffer edits toggle this flag so each intermediate `TextChanged`
   -- doesn't trigger a full `vim.diff` + extmark pass; the batch owner fires
   -- a single repaint once all edits are applied.
-  if self._suppress_repaint then return end
-  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then return end
+  if self._suppress_repaint then
+    return
+  end
+  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then
+    return
+  end
   local bufnr = self.b.file.bufnr
-  if not api.nvim_buf_is_valid(bufnr) then return end
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
 
   -- The cache is populated at the end of the initial `_render_inline`. If
   -- a repaint fires before that completes (e.g. a synthetic TextChanged
   -- during buffer setup), skip rather than double-fetch from disk.
   local old_lines = self._cached_old_lines
-  if old_lines == nil then return end
+  if old_lines == nil then
+    return
+  end
 
   local new_lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
   inline_diff.render(bufnr, old_lines, new_lines, render_opts())
@@ -198,32 +208,38 @@ end
 ---@param self Diff1Inline
 ---@param bufnr integer
 local function register_repaint_autocmds(self, bufnr)
-  if self._repaint_bufnr == bufnr then return end
+  if self._repaint_bufnr == bufnr then
+    return
+  end
   -- Different buffer than last time (or first install): clear any prior
   -- registration before attaching to the new one, and close any pending
   -- debounce timer so it doesn't fire against the old buffer.
   if self._repaint_bufnr and api.nvim_buf_is_valid(self._repaint_bufnr) then
     pcall(api.nvim_clear_autocmds, { group = repaint_augroup, buffer = self._repaint_bufnr })
   end
-  if self._repaint_debounced then self._repaint_debounced:close() end
+  if self._repaint_debounced then
+    self._repaint_debounced:close()
+  end
   self._repaint_bufnr = bufnr
-  self._repaint_debounced = debounce.debounce_trailing(
-    INSERT_REPAINT_DEBOUNCE_MS,
-    false,
-    function() self:_repaint() end
-  )
+  self._repaint_debounced = debounce.debounce_trailing(INSERT_REPAINT_DEBOUNCE_MS, false, function()
+    self:_repaint()
+  end)
   api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
     group = repaint_augroup,
     buffer = bufnr,
     callback = function()
-      if self._repaint_debounced then self._repaint_debounced:cancel() end
+      if self._repaint_debounced then
+        self._repaint_debounced:cancel()
+      end
       self:_repaint()
     end,
   })
   api.nvim_create_autocmd("TextChangedI", {
     group = repaint_augroup,
     buffer = bufnr,
-    callback = function() self._repaint_debounced() end,
+    callback = function()
+      self._repaint_debounced()
+    end,
   })
 end
 
@@ -231,7 +247,9 @@ end
 ---diff as extmarks on the new-side buffer.
 ---@param self Diff1Inline
 Diff1Inline._render_inline = async.void(function(self)
-  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then return end
+  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then
+    return
+  end
 
   local bufnr = self.b.file.bufnr
   local winid = self.b.id
@@ -248,7 +266,9 @@ Diff1Inline._render_inline = async.void(function(self)
   if old_lines == nil then
     old_lines = await(self:_load_old_lines())
     await(async.scheduler())
-    if not (self.b and self.b:is_valid() and api.nvim_buf_is_valid(bufnr)) then return end
+    if not (self.b and self.b:is_valid() and api.nvim_buf_is_valid(bufnr)) then
+      return
+    end
     self._cached_old_lines = old_lines
   end
 
@@ -276,15 +296,23 @@ end)
 ---@param last integer
 ---@return integer
 function Diff1Inline:diffget(first, last)
-  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then return 0 end
+  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then
+    return 0
+  end
   local bufnr = self.b.file.bufnr
-  if not api.nvim_buf_is_valid(bufnr) then return 0 end
+  if not api.nvim_buf_is_valid(bufnr) then
+    return 0
+  end
 
   local old_lines = self._cached_old_lines
-  if old_lines == nil then return 0 end
+  if old_lines == nil then
+    return 0
+  end
 
   local hunks = inline_diff.get_hunks(bufnr)
-  if not hunks then return 0 end
+  if not hunks then
+    return 0
+  end
 
   local matches = {}
   for _, h in ipairs(hunks) do
@@ -298,10 +326,14 @@ function Diff1Inline:diffget(first, last)
       local anchor = new_start == 0 and 1 or new_start
       overlaps = first <= anchor and anchor <= last
     end
-    if overlaps then matches[#matches + 1] = h end
+    if overlaps then
+      matches[#matches + 1] = h
+    end
   end
 
-  if #matches == 0 then return 0 end
+  if #matches == 0 then
+    return 0
+  end
 
   -- Suppress the per-edit `TextChanged` repaint so a multi-hunk batch
   -- doesn't trigger N full re-diffs; a single trailing repaint below
@@ -330,7 +362,9 @@ function Diff1Inline:diffget(first, last)
     end
   end)
   self._suppress_repaint = nil
-  if not ok then error(err) end
+  if not ok then
+    error(err)
+  end
 
   self:_repaint()
 
@@ -344,7 +378,9 @@ end
 ---@return vcs.File[]
 function Diff1Inline:owned_files()
   local out = Layout.files(self)
-  if self.a_file and not vim.tbl_contains(out, self.a_file) then out[#out + 1] = self.a_file end
+  if self.a_file and not vim.tbl_contains(out, self.a_file) then
+    out[#out + 1] = self.a_file
+  end
   return out
 end
 
@@ -356,7 +392,9 @@ end
 ---@param sym string
 ---@return vcs.File?
 function Diff1Inline:get_file_for(sym)
-  if sym == "a" then return self.a_file end
+  if sym == "a" then
+    return self.a_file
+  end
   return Layout.get_file_for(self, sym)
 end
 
@@ -371,7 +409,9 @@ function Diff1Inline:teardown_render()
   end
   self._repaint_bufnr = nil
   self._cached_old_lines = nil
-  if self.b and self.b.file and self.b.file.bufnr then inline_diff.detach(self.b.file.bufnr) end
+  if self.b and self.b.file and self.b.file.bufnr then
+    inline_diff.detach(self.b.file.bufnr)
+  end
 end
 
 ---@override

--- a/lua/diffview/scene/layouts/diff_2.lua
+++ b/lua/diffview/scene/layouts/diff_2.lua
@@ -41,14 +41,12 @@ function Diff2.should_null(rev, status, sym)
 
   if rev.type == RevType.LOCAL then
     return status == "D"
-
   elseif rev.type == RevType.COMMIT then
     if sym == "a" then
       return vim.tbl_contains({ "?", "A" }, status)
     end
 
     return status == "D"
-
   elseif rev.type == RevType.STAGE then
     if sym == "a" then
       return vim.tbl_contains({ "?", "A" }, status)

--- a/lua/diffview/scene/layouts/diff_3.lua
+++ b/lua/diffview/scene/layouts/diff_3.lua
@@ -68,7 +68,7 @@ function Diff3:to_diff4(layout)
       get_data = main.get_data,
       rev = Rev(RevType.STAGE, 1),
       nulled = false, -- FIXME
-    })
+    }),
   })
 end
 
@@ -81,14 +81,12 @@ function Diff3.should_null(rev, status, sym)
 
   if rev.type == RevType.LOCAL then
     return status == "D"
-
   elseif rev.type == RevType.COMMIT then
     if sym == "a" then
       return vim.tbl_contains({ "?", "A" }, status)
     end
 
     return status == "D"
-
   elseif rev.type == RevType.STAGE then
     if rev.stage == 0 then
       if sym == "a" then

--- a/lua/diffview/scene/layouts/diff_4.lua
+++ b/lua/diffview/scene/layouts/diff_4.lua
@@ -72,14 +72,12 @@ function Diff4.should_null(rev, status, sym)
 
   if rev.type == RevType.LOCAL then
     return status == "D"
-
   elseif rev.type == RevType.COMMIT then
     if sym == "a" then
       return vim.tbl_contains({ "?", "A" }, status)
     end
 
     return status == "D"
-
   elseif rev.type == RevType.STAGE then
     if rev.stage == 0 then
       if sym == "a" then

--- a/lua/diffview/scene/view.lua
+++ b/lua/diffview/scene/view.lua
@@ -18,14 +18,21 @@ local M = {}
 
 -- Boolean diffopt flags that can be toggled.
 local diffopt_bool_flags = {
-  "indent-heuristic", "iwhite", "iwhiteall", "iwhiteeol", "iblank", "icase",
+  "indent-heuristic",
+  "iwhite",
+  "iwhiteall",
+  "iwhiteeol",
+  "iblank",
+  "icase",
 }
 
 ---Apply configured diffopt overrides, saving the original value on the view.
 ---@param view View
 local function apply_diffopt(view)
   local conf = config.get_config().diffopt
-  if not conf or vim.tbl_isempty(conf) then return end
+  if not conf or vim.tbl_isempty(conf) then
+    return
+  end
 
   if not view._saved_diffopt then
     view._saved_diffopt = vim.opt.diffopt:get()
@@ -33,23 +40,23 @@ local function apply_diffopt(view)
 
   if conf.algorithm then
     -- Remove any existing algorithm:* entry and add the new one.
-    vim.opt.diffopt:remove(
-      vim.tbl_filter(function(v) return v:match("^algorithm:") end, vim.opt.diffopt:get())
-    )
+    vim.opt.diffopt:remove(vim.tbl_filter(function(v)
+      return v:match("^algorithm:")
+    end, vim.opt.diffopt:get()))
     vim.opt.diffopt:append({ "algorithm:" .. conf.algorithm })
   end
 
   if conf.context ~= nil then
-    vim.opt.diffopt:remove(
-      vim.tbl_filter(function(v) return v:match("^context:") end, vim.opt.diffopt:get())
-    )
+    vim.opt.diffopt:remove(vim.tbl_filter(function(v)
+      return v:match("^context:")
+    end, vim.opt.diffopt:get()))
     vim.opt.diffopt:append({ "context:" .. conf.context })
   end
 
   if conf.linematch ~= nil then
-    vim.opt.diffopt:remove(
-      vim.tbl_filter(function(v) return v:match("^linematch:") end, vim.opt.diffopt:get())
-    )
+    vim.opt.diffopt:remove(vim.tbl_filter(function(v)
+      return v:match("^linematch:")
+    end, vim.opt.diffopt:get()))
     vim.opt.diffopt:append({ "linematch:" .. conf.linematch })
   end
 
@@ -94,10 +101,14 @@ local View = oop.create_class("View")
 ---@diagnostic disable unused-local
 
 ---@abstract
-function View:init_layout() oop.abstract_stub() end
+function View:init_layout()
+  oop.abstract_stub()
+end
 
 ---@abstract
-function View:post_open() oop.abstract_stub() end
+function View:post_open()
+  oop.abstract_stub()
+end
 
 ---@diagnostic enable unused-local
 

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -66,10 +66,7 @@ function DiffView:init(opt)
   self.is_loading = true
   self.options = opt.options or {}
   self.options.selected_file = self.options.selected_file
-    and pl:chain(self.options.selected_file)
-        :absolute()
-        :relative(self.adapter.ctx.toplevel)
-        :get()
+    and pl:chain(self.options.selected_file):absolute():relative(self.adapter.ctx.toplevel):get()
 
   self:super({
     panel = FilePanel(
@@ -114,9 +111,8 @@ function DiffView:post_open()
     -- to refresh the panel immediately instead of waiting for index polling.
     -- Unlike GitSignsUpdate (which fires on every buffer enter and caused
     -- spurious refreshes), GitSignsChanged only fires on actual repo changes.
-    self._gitsigns_augroup = api.nvim_create_augroup(
-      "diffview_gitsigns_" .. self.tabpage, { clear = true }
-    )
+    self._gitsigns_augroup =
+      api.nvim_create_augroup("diffview_gitsigns_" .. self.tabpage, { clear = true })
     api.nvim_create_autocmd("User", {
       group = self._gitsigns_augroup,
       pattern = "GitSignsChanged",
@@ -151,7 +147,9 @@ end
 ---@param old_entry FileEntry
 ---@diagnostic disable-next-line: unused-local
 function DiffView:file_open_post(e, new_entry, old_entry)
-  if new_entry.layout:is_nulled() then return end
+  if new_entry.layout:is_nulled() then
+    return
+  end
   if new_entry.kind == "conflicting" then
     local file = new_entry.layout:get_main_win().file
 
@@ -183,20 +181,17 @@ function DiffView:file_open_post(e, new_entry, old_entry)
         end)
       )
 
-      api.nvim_create_autocmd(
-        { "TextChanged", "TextChangedI" },
-        {
-          buffer = file.bufnr,
-          callback = function()
-            if not self.attached_bufs[file.bufnr] then
-              work:close()
-              return true
-            end
+      api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+        buffer = file.bufnr,
+        callback = function()
+          if not self.attached_bufs[file.bufnr] then
+            work:close()
+            return true
+          end
 
-            work()
-          end,
-        }
-      )
+          work()
+        end,
+      })
     end
   end
 end
@@ -208,9 +203,7 @@ function DiffView:_init_selection_events()
 
   if persist then
     local selection_store = require("diffview.selection_store")
-    self._selection_scope_key = selection_store.scope_key(
-      self.adapter.ctx.toplevel, self.rev_arg
-    )
+    self._selection_scope_key = selection_store.scope_key(self.adapter.ctx.toplevel, self.rev_arg)
 
     -- Load previously saved selections.
     local saved = selection_store.load(self._selection_scope_key)
@@ -236,7 +229,9 @@ end
 
 ---Immediately persist current selections to disk.
 function DiffView:_save_selections_now()
-  if not self._selection_scope_key then return end
+  if not self._selection_scope_key then
+    return
+  end
   local selection_store = require("diffview.selection_store")
   local keys = vim.tbl_keys(self.panel.selected_files)
   table.sort(keys)
@@ -277,9 +272,7 @@ function DiffView:set_revs(new_rev_arg, opts)
   if self._selection_scope_key then
     local selection_store = require("diffview.selection_store")
     local old_scope = self._selection_scope_key
-    self._selection_scope_key = selection_store.scope_key(
-      self.adapter.ctx.toplevel, new_rev_arg
-    )
+    self._selection_scope_key = selection_store.scope_key(self.adapter.ctx.toplevel, new_rev_arg)
 
     -- If the new scope already has saved selections, merge them with the
     -- current in-memory set so nothing is lost.
@@ -383,7 +376,9 @@ end)
 function DiffView:next_file(highlight)
   self:ensure_layout()
 
-  if self:file_safeguard() then return end
+  if self:file_safeguard() then
+    return
+  end
 
   if self.files:len() > 1 or self.nulled then
     local cur = self.panel:next_file()
@@ -406,7 +401,9 @@ end
 function DiffView:prev_file(highlight)
   self:ensure_layout()
 
-  if self:file_safeguard() then return end
+  if self:file_safeguard() then
+    return
+  end
 
   if self.files:len() > 1 or self.nulled then
     local cur = self.panel:prev_file()
@@ -432,7 +429,9 @@ DiffView.set_file = async.void(function(self, file, focus, highlight)
   ---@diagnostic disable: invisible
   self:ensure_layout()
 
-  if self:file_safeguard() or not file then return end
+  if self:file_safeguard() or not file then
+    return
+  end
 
   for _, f in self.files:iter() do
     if f == file then
@@ -471,18 +470,10 @@ end)
 ---@param self DiffView
 ---@param callback fun(err?: string[], files: FileDict)
 DiffView.get_updated_files = async.wrap(function(self, callback)
-  vcs_utils.diff_file_list(
-    self.adapter,
-    self.left,
-    self.right,
-    self.path_args,
-    self.options,
-    {
-      default_layout = DiffView.get_default_layout(),
-      merge_layout = DiffView.get_default_merge_layout(),
-    },
-    callback
-  )
+  vcs_utils.diff_file_list(self.adapter, self.left, self.right, self.path_args, self.options, {
+    default_layout = DiffView.get_default_layout(),
+    merge_layout = DiffView.get_default_merge_layout(),
+  }, callback)
 end)
 
 ---Determine whether to focus the diff window on initial open.
@@ -493,8 +484,7 @@ function DiffView:_should_focus_diff(next_file)
     return false
   end
   local conf = config.get_config()
-  local view_conf = next_file and next_file.kind == "conflicting"
-    and conf.view.merge_tool
+  local view_conf = next_file and next_file.kind == "conflicting" and conf.view.merge_tool
     or conf.view.default
   return view_conf.focus_diff
 end
@@ -612,9 +602,18 @@ DiffView.update_files = debounce.debounce_trailing(
             if not replace_noop then
               replace_noop = not (
                 same_rev(utils.tbl_access(old_file, "revs.a"), utils.tbl_access(new_file, "revs.a"))
-                and same_rev(utils.tbl_access(old_file, "revs.b"), utils.tbl_access(new_file, "revs.b"))
-                and same_rev(utils.tbl_access(old_file, "revs.c"), utils.tbl_access(new_file, "revs.c"))
-                and same_rev(utils.tbl_access(old_file, "revs.d"), utils.tbl_access(new_file, "revs.d"))
+                and same_rev(
+                  utils.tbl_access(old_file, "revs.b"),
+                  utils.tbl_access(new_file, "revs.b")
+                )
+                and same_rev(
+                  utils.tbl_access(old_file, "revs.c"),
+                  utils.tbl_access(new_file, "revs.c")
+                )
+                and same_rev(
+                  utils.tbl_access(old_file, "revs.d"),
+                  utils.tbl_access(new_file, "revs.d")
+                )
               )
             end
 
@@ -647,7 +646,6 @@ DiffView.update_files = debounce.debounce_trailing(
 
           ai = ai + 1
           bi = bi + 1
-
         elseif opr == EditToken.DELETE then
           local cur_file = v.cur_files[ai]
           if cur_file then
@@ -663,7 +661,6 @@ DiffView.update_files = debounce.debounce_trailing(
             cur_file:destroy()
             table.remove(v.cur_files, ai)
           end
-
         elseif opr == EditToken.INSERT then
           local new_file = v.new_files[bi]
           if new_file then
@@ -671,7 +668,6 @@ DiffView.update_files = debounce.debounce_trailing(
             ai = ai + 1
           end
           bi = bi + 1
-
         elseif opr == EditToken.REPLACE then
           local cur_file = v.cur_files[ai]
           local new_file = v.new_files[bi]
@@ -821,8 +817,12 @@ function DiffView:infer_cur_file(allow_dir)
   if self.panel:is_focused() then
     ---@type any
     local item = self.panel:get_item_at_cursor()
-    if not item then return end
-    if not allow_dir and type(item.collapsed) == "boolean" then return end
+    if not item then
+      return
+    end
+    if not allow_dir and type(item.collapsed) == "boolean" then
+      return
+    end
 
     return item
   else

--- a/lua/diffview/scene/views/diff/file_diff_view.lua
+++ b/lua/diffview/scene/views/diff/file_diff_view.lua
@@ -86,7 +86,9 @@ function FileDiffView:post_open()
 
     -- Open the first (only) file entry.
     local files = self.panel:ordered_file_list()
-    if files and files[1] then self:set_file(files[1], false, true) end
+    if files and files[1] then
+      self:set_file(files[1], false, true)
+    end
 
     self.ready = true
   end)

--- a/lua/diffview/scene/views/diff/file_panel.lua
+++ b/lua/diffview/scene/views/diff/file_panel.lua
@@ -84,7 +84,9 @@ end
 function FilePanel:setup_buffer()
   local conf = self:apply_keymaps("file_panel", { nowait = true })
   local help_keymap = config.find_help_keymap(conf.keymaps.file_panel)
-  if help_keymap then self.help_mapping = help_keymap[2] end
+  if help_keymap then
+    self.help_mapping = help_keymap[2]
+  end
 end
 
 ---@param files FileEntry[]
@@ -210,7 +212,9 @@ function FilePanel:prev_file()
       new_idx = (i - vim.v.count1 - 1) % #files + 1
     else
       new_idx = math.max(i - vim.v.count1, 1)
-      if new_idx == i then return end
+      if new_idx == i then
+        return
+      end
     end
     self:set_cur_file(files[new_idx])
     return self.cur_file
@@ -231,7 +235,9 @@ function FilePanel:next_file()
       new_idx = (i + vim.v.count1 - 1) % #files + 1
     else
       new_idx = math.min(i + vim.v.count1, #files)
-      if new_idx == i then return end
+      if new_idx == i then
+        return
+      end
     end
     self:set_cur_file(files[new_idx])
     return self.cur_file
@@ -253,7 +259,9 @@ end
 ---Get the file entry under the cursor.
 ---@return (FileEntry|DirData)?
 function FilePanel:get_item_at_cursor()
-  if not (self:is_open() and self:buf_loaded()) then return end
+  if not (self:is_open() and self:buf_loaded()) then
+    return
+  end
 
   local line = api.nvim_win_get_cursor(self.winid)[1]
   return self:get_item_at_line(line)
@@ -263,13 +271,19 @@ end
 ---@return DirData?
 ---@return RenderComponent?
 function FilePanel:get_dir_at_cursor()
-  if self.listing_style ~= "tree" then return end
-  if not (self:is_open() and self:buf_loaded()) then return end
+  if self.listing_style ~= "tree" then
+    return
+  end
+  if not (self:is_open() and self:buf_loaded()) then
+    return
+  end
 
   local line = api.nvim_win_get_cursor(self.winid)[1]
   local comp = self.components.comp:get_comp_on_line(line)
 
-  if not comp then return end
+  if not comp then
+    return
+  end
 
   if comp.name == "dir_name" then
     local dir_comp = comp.parent
@@ -297,7 +311,6 @@ function FilePanel:highlight_file(file)
         end
       end
     end
-
   else -- tree
     for _, comp_struct in ipairs({
       self.components.conflicting.files,
@@ -458,7 +471,6 @@ function FilePanel:_notify_selection_changed()
   end
 end
 
-
 ---Select a file entry.
 ---@param file FileEntry
 function FilePanel:select_file(file)
@@ -501,9 +513,13 @@ end
 ---@param dir_data DirData
 ---@return "all"|"some"|"none"
 function FilePanel:dir_selection_state(dir_data)
-  if not dir_data._node then return "none" end
+  if not dir_data._node then
+    return "none"
+  end
   local leaves = dir_data._node:leaves()
-  if #leaves == 0 then return "none" end
+  if #leaves == 0 then
+    return "none"
+  end
   local selected, total = 0, 0
   for _, leaf in ipairs(leaves) do
     if leaf.data then
@@ -513,8 +529,12 @@ function FilePanel:dir_selection_state(dir_data)
       end
     end
   end
-  if selected == 0 then return "none" end
-  if selected == total then return "all" end
+  if selected == 0 then
+    return "none"
+  end
+  if selected == total then
+    return "all"
+  end
   return "some"
 end
 
@@ -559,7 +579,9 @@ end
 
 ---@override
 function FilePanel:get_autosize_components()
-  if not self.components then return nil end
+  if not self.components then
+    return nil
+  end
   return {
     self.components.conflicting.comp,
     self.components.working.comp,

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -49,7 +49,9 @@ return function(view)
         end
       end
     end,
-    file_open_new = function(_, entry) actions.jump_to_first_change(view) end,
+    file_open_new = function(_, entry)
+      actions.jump_to_first_change(view)
+    end,
     ---@diagnostic disable-next-line: unused-local
     files_updated = function(_, files)
       view.initialized = true
@@ -106,7 +108,9 @@ return function(view)
       end
     end,
     toggle_select_entry = function()
-      if not view.panel:is_open() then return end
+      if not view.panel:is_open() then
+        return
+      end
 
       -- Visual-mode: toggle all files in the selected line range.
       local mode = api.nvim_get_mode().mode
@@ -135,13 +139,17 @@ return function(view)
 
       ---@type any
       local item = view.panel:get_item_at_cursor()
-      if not item then return end
+      if not item then
+        return
+      end
 
       if type(item.collapsed) == "boolean" then
         -- Directory: select all if any child is unselected, else deselect all.
         ---@cast item DirData
         local node = item._node
-        if not node then return end
+        if not node then
+          return
+        end
 
         local leaves = node:leaves()
         local all_selected = true
@@ -173,7 +181,9 @@ return function(view)
       view.panel:highlight_next_file()
     end,
     clear_select_entries = function()
-      if not view.panel:is_open() then return end
+      if not view.panel:is_open() then
+        return
+      end
       view.panel:clear_selections()
       view.panel:render()
       view.panel:redraw()
@@ -251,16 +261,18 @@ return function(view)
         end
 
         if #failed > 0 then
-          utils.err(("Failed to stage/unstage %d file(s): %s"):format(
-            #failed, table.concat(failed, ", ")
-          ))
+          utils.err(
+            ("Failed to stage/unstage %d file(s): %s"):format(#failed, table.concat(failed, ", "))
+          )
         end
 
         view.panel:clear_selections()
       else
         -- Single file operation (existing behaviour).
         local item = view:infer_cur_file(true)
-        if not item then return end
+        if not item then
+          return
+        end
 
         local success
         if item.kind == "working" or item.kind == "conflicting" then
@@ -310,18 +322,16 @@ return function(view)
         end
       end
 
-      view:update_files(
-        vim.schedule_wrap(function()
-          view.panel:highlight_cur_file()
-          -- Auto-close if all working/conflicting files have been staged.
-          if config.get_config().auto_close_on_empty then
-            if #view.files.working == 0 and #view.files.conflicting == 0 then
-              view:close()
-              lib.dispose_view(view)
-            end
+      view:update_files(vim.schedule_wrap(function()
+        view.panel:highlight_cur_file()
+        -- Auto-close if all working/conflicting files have been staged.
+        if config.get_config().auto_close_on_empty then
+          if #view.files.working == 0 and #view.files.conflicting == 0 then
+            view:close()
+            lib.dispose_view(view)
           end
-        end)
-      )
+        end
+      end))
       view.emitter:emit(EventName.FILES_STAGED, view)
     end,
     stage_all = function()
@@ -395,12 +405,16 @@ return function(view)
       else
         -- Single item restore (existing behaviour).
         local item = view:infer_cur_file(true)
-        if not item then return end
+        if not item then
+          return
+        end
 
         if type(item.collapsed) == "boolean" then
           ---@cast item DirData
           local node = item._node
-          if not node then return end
+          if not node then
+            return
+          end
 
           local leaves = node:leaves()
           local restored_count = 0
@@ -471,7 +485,9 @@ return function(view)
       view:update_files()
     end,
     open_all_folds = function()
-      if not view.panel:is_focused() or view.panel.listing_style ~= "tree" then return end
+      if not view.panel:is_focused() or view.panel.listing_style ~= "tree" then
+        return
+      end
 
       for _, file_set in ipairs({
         view.panel.components.conflicting.files,
@@ -489,7 +505,9 @@ return function(view)
       view.panel:redraw()
     end,
     close_all_folds = function()
-      if not view.panel:is_focused() or view.panel.listing_style ~= "tree" then return end
+      if not view.panel:is_focused() or view.panel.listing_style ~= "tree" then
+        return
+      end
 
       for _, file_set in ipairs({
         view.panel.components.conflicting.files,
@@ -507,12 +525,18 @@ return function(view)
       view.panel:redraw()
     end,
     open_fold = function()
-      if not view.panel:is_focused() then return end
+      if not view.panel:is_focused() then
+        return
+      end
       local dir = view.panel:get_dir_at_cursor()
-      if dir then view.panel:set_item_fold(dir, true) end
+      if dir then
+        view.panel:set_item_fold(dir, true)
+      end
     end,
     close_fold = function()
-      if not view.panel:is_focused() then return end
+      if not view.panel:is_focused() then
+        return
+      end
       local dir, comp = view.panel:get_dir_at_cursor()
       if dir and comp then
         if not dir.collapsed then
@@ -526,9 +550,13 @@ return function(view)
       end
     end,
     toggle_fold = function()
-      if not view.panel:is_focused() then return end
+      if not view.panel:is_focused() then
+        return
+      end
       local dir = view.panel:get_dir_at_cursor()
-      if dir then view.panel:toggle_item_fold(dir) end
+      if dir then
+        view.panel:toggle_item_fold(dir)
+      end
     end,
   }
 end

--- a/lua/diffview/scene/views/diff/render.lua
+++ b/lua/diffview/scene/views/diff/render.lua
@@ -15,8 +15,11 @@ local selection_signs_ns = api.nvim_create_namespace("diffview_selection_signs")
 local function has_wide_sign(conf)
   local signs = conf.signs
   for _, s in ipairs({
-    signs.selected_file, signs.unselected_file,
-    signs.selected_dir, signs.partially_selected_dir, signs.unselected_dir,
+    signs.selected_file,
+    signs.unselected_file,
+    signs.selected_dir,
+    signs.partially_selected_dir,
+    signs.unselected_dir,
   }) do
     if vim.fn.strdisplaywidth(s) >= 2 then
       return true
@@ -38,7 +41,9 @@ end
 ---@param node table  Tree node whose leaves() will be counted.
 ---@param tree_options table  Config tree_options table.
 local function render_folder_count(comp, node, tree_options)
-  if tree_options.folder_count_style == "none" then return end
+  if tree_options.folder_count_style == "none" then
+    return
+  end
 
   if tree_options.folder_count_style == "grouped" then
     local leaves = node:leaves()
@@ -79,7 +84,9 @@ local function render_file(conf, panel, comp, show_path, depth, sign_pad)
   local show_marks = conf.file_panel.mark_placement ~= "sign_column"
     and (conf.file_panel.always_show_marks or panel:has_any_selections())
 
-  if sign_pad then comp:add_text(" ") end
+  if sign_pad then
+    comp:add_text(" ")
+  end
   comp:add_text(hl.get_status_icon(file.status) .. " ", hl.get_git_hl(file.status))
 
   if show_marks then
@@ -172,7 +179,9 @@ local function render_file_tree_recurse(conf, panel, depth, comp, sign_pad)
     return
   end
 
-  if comp.name ~= "directory" then return end
+  if comp.name ~= "directory" then
+    return
+  end
 
   -- Directory component structure:
   -- {
@@ -220,7 +229,9 @@ local function render_file_tree_recurse(conf, panel, depth, comp, sign_pad)
     end
     dir:add_text(sel_mark, sel_mark_hl)
   else
-    if sign_pad then dir:add_text(" ") end
+    if sign_pad then
+      dir:add_text(" ")
+    end
     dir:add_text(
       hl.get_status_icon(get_dir_status_text(ctx, conf.file_panel.tree_options)) .. " ",
       hl.get_git_hl(ctx.status)
@@ -344,19 +355,27 @@ end
 ---component lstart/lend values are available.
 ---@param panel FilePanel
 local function place_selection_signs(panel)
-  if not panel:buf_loaded() then return end
+  if not panel:buf_loaded() then
+    return
+  end
 
   -- Always clear existing signs so that switching from sign_column to inline
   -- does not leave stale extmarks behind.
   api.nvim_buf_clear_namespace(panel.bufid, selection_signs_ns, 0, -1)
 
   local conf = config.get_config()
-  if conf.file_panel.mark_placement ~= "sign_column" then return end
-  if not panel.components then return end
+  if conf.file_panel.mark_placement ~= "sign_column" then
+    return
+  end
+  if not panel.components then
+    return
+  end
 
   local show_marks = conf.file_panel.always_show_marks or panel:has_any_selections()
 
-  if not show_marks then return end
+  if not show_marks then
+    return
+  end
 
   for _, section in ipairs({ "conflicting", "working", "staged" }) do
     local files_comp = panel.components[section].files.comp
@@ -457,12 +476,17 @@ local function render_panel(panel)
     -- Truncate the revision name from the tail so the start of the hash
     -- stays visible.
     if panel.rev_pretty_name then
-      comp:add_line(utils.str_trunc(panel.rev_pretty_name, math.max(width - 5, 1)), "DiffviewFilePanelPath")
+      comp:add_line(
+        utils.str_trunc(panel.rev_pretty_name, math.max(width - 5, 1)),
+        "DiffviewFilePanelPath"
+      )
     end
 
     for _, arg in ipairs(panel.path_args or {}) do
       local relpath = pl:relative(arg, panel.adapter.ctx.toplevel)
-      if relpath == "" then relpath = "." end
+      if relpath == "" then
+        relpath = "."
+      end
       comp:add_line(pl:truncate(relpath, width - 5), "DiffviewFilePanelPath")
     end
   end
@@ -479,5 +503,7 @@ return setmetatable({
     selection_signs_ns = selection_signs_ns,
   },
 }, {
-  __call = function(_, panel) render_panel(panel) end,
+  __call = function(_, panel)
+    render_panel(panel)
+  end,
 })

--- a/lua/diffview/scene/views/file_history/file_history_panel.lua
+++ b/lua/diffview/scene/views/file_history/file_history_panel.lua
@@ -147,9 +147,13 @@ end)
 function FileHistoryPanel:setup_buffer()
   local conf = self:apply_keymaps("file_history_panel", { nowait = true })
   local option_keymap = config.find_option_keymap(conf.keymaps.file_history_panel)
-  if option_keymap then self.option_mapping = option_keymap[2] end
+  if option_keymap then
+    self.option_mapping = option_keymap[2]
+  end
   local help_keymap = config.find_help_keymap(conf.keymaps.file_history_panel)
-  if help_keymap then self.help_mapping = help_keymap[2] end
+  if help_keymap then
+    self.help_mapping = help_keymap[2]
+  end
 end
 
 function FileHistoryPanel:update_components()
@@ -210,20 +214,19 @@ FileHistoryPanel.update_entries = async.wrap(function(self, callback)
 
   self:sync()
 
-  local render = debounce.throttle_render(
-    15,
-    function()
-      if self.shutdown:check() then return end
-      if not self:cur_file() then
-        self:update_components()
-        self.parent:next_item()
-      else
-        self:sync()
-      end
-
-      vim.cmd("redraw")
+  local render = debounce.throttle_render(15, function()
+    if self.shutdown:check() then
+      return
     end
-  )
+    if not self:cur_file() then
+      self:update_components()
+      self.parent:next_item()
+    else
+      self:sync()
+    end
+
+    vim.cmd("redraw")
+  end)
 
   local ret = {}
 
@@ -252,7 +255,7 @@ FileHistoryPanel.update_entries = async.wrap(function(self, callback)
     elseif status == JobStatus.PROGRESS then
       ---@cast entry -?
       local was_empty = #self.entries == 0
-      self.entries[#self.entries+1] = entry
+      self.entries[#self.entries + 1] = entry
 
       if was_empty then
         self.single_file = self.entries[1].single_file
@@ -318,7 +321,9 @@ end
 ---Get the log or file entry under the cursor.
 ---@return (LogEntry|FileEntry)?
 function FileHistoryPanel:get_item_at_cursor()
-  if not (self:is_open() and self:buf_loaded()) then return end
+  if not (self:is_open() and self:buf_loaded()) then
+    return
+  end
 
   local cursor = api.nvim_win_get_cursor(self.winid)
   local line = cursor[1]
@@ -339,7 +344,9 @@ end
 ---@return LogEntry?
 function FileHistoryPanel:get_log_entry_at_cursor()
   local item = self:get_item_at_cursor()
-  if not item then return end
+  if not item then
+    return
+  end
 
   if item:instanceof(LogEntry.__get()) then
     return item --[[@as LogEntry ]]
@@ -430,7 +437,9 @@ function FileHistoryPanel:_get_entry_by_file_offset(entry_idx, file_idx, offset,
 end
 
 function FileHistoryPanel:set_file_by_offset(offset)
-  if self:num_items() == 0 then return end
+  if self:num_items() == 0 then
+    return
+  end
 
   local entry, file = self.cur_item[1], self.cur_item[2]
 
@@ -445,9 +454,12 @@ function FileHistoryPanel:set_file_by_offset(offset)
 
     if entry_idx ~= -1 and file_idx ~= -1 then
       local wrap = config.get_config().wrap_entries
-      local next_entry, next_file = self:_get_entry_by_file_offset(entry_idx, file_idx, offset, wrap)
+      local next_entry, next_file =
+        self:_get_entry_by_file_offset(entry_idx, file_idx, offset, wrap)
 
-      if not next_entry then return end
+      if not next_entry then
+        return
+      end
 
       self:set_cur_item({ next_entry, next_file })
 
@@ -473,7 +485,9 @@ end
 
 ---@param item LogEntry|FileEntry
 function FileHistoryPanel:highlight_item(item)
-  if not (self:is_open() and self:buf_loaded()) then return end
+  if not (self:is_open() and self:buf_loaded()) then
+    return
+  end
 
   if item:instanceof(LogEntry.__get()) then
     ---@cast item LogEntry
@@ -508,7 +522,9 @@ function FileHistoryPanel:highlight_item(item)
 end
 
 function FileHistoryPanel:highlight_prev_item()
-  if not (self:is_open() and self:buf_loaded()) or #self.entries == 0 then return end
+  if not (self:is_open() and self:buf_loaded()) or #self.entries == 0 then
+    return
+  end
 
   pcall(api.nvim_win_set_cursor, self.winid, {
     self.constrain_cursor(self.winid, -vim.v.count1),
@@ -519,7 +535,9 @@ function FileHistoryPanel:highlight_prev_item()
 end
 
 function FileHistoryPanel:highlight_next_file()
-  if not (self:is_open() and self:buf_loaded()) or #self.entries == 0 then return end
+  if not (self:is_open() and self:buf_loaded()) or #self.entries == 0 then
+    return
+  end
 
   pcall(api.nvim_win_set_cursor, self.winid, {
     self.constrain_cursor(self.winid, vim.v.count1),
@@ -556,7 +574,9 @@ end
 
 ---@override
 function FileHistoryPanel:get_autosize_components()
-  if not self.components then return nil end
+  if not self.components then
+    return nil
+  end
   return {
     self.components.log.comp,
   }

--- a/lua/diffview/scene/views/file_history/file_history_view.lua
+++ b/lua/diffview/scene/views/file_history/file_history_view.lua
@@ -4,7 +4,8 @@ local oop = require("diffview.oop")
 
 local CommitLogPanel = lazy.access("diffview.ui.panels.commit_log_panel", "CommitLogPanel") ---@type CommitLogPanel|LazyModule
 local EventName = lazy.access("diffview.events", "EventName") ---@type EventName|LazyModule
-local FileHistoryPanel = lazy.access("diffview.scene.views.file_history.file_history_panel", "FileHistoryPanel") ---@type FileHistoryPanel|LazyModule
+local FileHistoryPanel =
+  lazy.access("diffview.scene.views.file_history.file_history_panel", "FileHistoryPanel") ---@type FileHistoryPanel|LazyModule
 local JobStatus = lazy.access("diffview.vcs.utils", "JobStatus") ---@type JobStatus|LazyModule
 local LogEntry = lazy.access("diffview.vcs.log_entry", "LogEntry") ---@type LogEntry|LazyModule
 local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
@@ -139,7 +140,9 @@ end)
 function FileHistoryView:next_item()
   self:ensure_layout()
 
-  if self:file_safeguard() then return end
+  if self:file_safeguard() then
+    return
+  end
 
   if self.panel:num_items() > 1 or self.nulled then
     local cur = self.panel:next_file()
@@ -157,7 +160,9 @@ end
 function FileHistoryView:prev_item()
   self:ensure_layout()
 
-  if self:file_safeguard() then return end
+  if self:file_safeguard() then
+    return
+  end
 
   if self.panel:num_items() > 1 or self.nulled then
     local cur = self.panel:prev_file()
@@ -179,7 +184,9 @@ FileHistoryView.set_file = async.void(function(self, file, focus)
   ---@diagnostic disable: invisible
   self:ensure_layout()
 
-  if self:file_safeguard() or not file then return end
+  if self:file_safeguard() or not file then
+    return
+  end
 
   local entry = self.panel:find_entry(file)
   local cur_entry = self.panel.cur_item[1]
@@ -200,7 +207,6 @@ FileHistoryView.set_file = async.void(function(self, file, focus)
   end
   ---@diagnostic enable: invisible
 end)
-
 
 ---Ensures there are files to load, and loads the null buffer otherwise.
 ---@return boolean

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -18,7 +18,9 @@ return function(view)
   return {
     tab_enter = function()
       local file = view.panel.cur_item[2]
-      if file then view:set_file(file) end
+      if file then
+        view:set_file(file)
+      end
 
       view:restore_panel_cursor()
     end,
@@ -26,7 +28,9 @@ return function(view)
       local file = view.panel.cur_item[2]
       view:save_panel_cursor()
 
-      if file then file.layout:detach_files() end
+      if file then
+        file.layout:detach_files()
+      end
 
       for _, entry in ipairs(view.panel.entries) do
         for _, f in ipairs(entry.files) do
@@ -34,7 +38,9 @@ return function(view)
         end
       end
     end,
-    file_open_new = function(_, entry) actions.jump_to_first_change(view) end,
+    file_open_new = function(_, entry)
+      actions.jump_to_first_change(view)
+    end,
     open_in_diffview = function()
       local file = view:infer_cur_file()
 
@@ -56,10 +62,14 @@ return function(view)
     ---Open a diffview comparing HEAD with the commit under cursor.
     diff_against_head = function()
       local item = view.panel:get_item_at_cursor()
-      if not item then return end
+      if not item then
+        return
+      end
 
       local commit = item.commit or (item.entry and item.entry.commit)
-      if not commit then return end
+      if not commit then
+        return
+      end
 
       local new_view = DiffView({
         adapter = view.adapter,
@@ -71,44 +81,64 @@ return function(view)
       lib.add_view(new_view)
       new_view:open()
     end,
-    select_next_entry = function() view:next_item() end,
-    select_prev_entry = function() view:prev_item() end,
+    select_next_entry = function()
+      view:next_item()
+    end,
+    select_prev_entry = function()
+      view:prev_item()
+    end,
     select_first_entry = function()
       local entry = view.panel.entries[1]
-      if entry and #entry.files > 0 then view:set_file(entry.files[1]) end
+      if entry and #entry.files > 0 then
+        view:set_file(entry.files[1])
+      end
     end,
     select_last_entry = function()
       local entry = view.panel.entries[#view.panel.entries]
-      if entry and #entry.files > 0 then view:set_file(entry.files[#entry.files]) end
+      if entry and #entry.files > 0 then
+        view:set_file(entry.files[#entry.files])
+      end
     end,
     select_next_commit = function()
       local cur_entry = view.panel.cur_item[1]
-      if not cur_entry then return end
+      if not cur_entry then
+        return
+      end
       local entry_idx = utils.vec_indexof(view.panel.entries, cur_entry)
-      if entry_idx == -1 then return end
+      if entry_idx == -1 then
+        return
+      end
 
       local next_idx
       if config.get_config().wrap_entries then
         next_idx = (entry_idx + vim.v.count1 - 1) % #view.panel.entries + 1
       else
         next_idx = math.min(entry_idx + vim.v.count1, #view.panel.entries)
-        if next_idx == entry_idx then return end
+        if next_idx == entry_idx then
+          return
+        end
       end
       local next_entry = view.panel.entries[next_idx]
       view:set_file(next_entry.files[1])
     end,
     select_prev_commit = function()
       local cur_entry = view.panel.cur_item[1]
-      if not cur_entry then return end
+      if not cur_entry then
+        return
+      end
       local entry_idx = utils.vec_indexof(view.panel.entries, cur_entry)
-      if entry_idx == -1 then return end
+      if entry_idx == -1 then
+        return
+      end
 
       local next_idx
       if config.get_config().wrap_entries then
         next_idx = (entry_idx - vim.v.count1 - 1) % #view.panel.entries + 1
       else
         next_idx = math.max(entry_idx - vim.v.count1, 1)
-        if next_idx == entry_idx then return end
+        if next_idx == entry_idx then
+          return
+        end
       end
       local next_entry = view.panel.entries[next_idx]
       view:set_file(next_entry.files[1])
@@ -117,17 +147,23 @@ return function(view)
     next_entry_in_commit = function()
       local cur_entry = view.panel.cur_item[1]
       local cur_file = view.panel.cur_item[2]
-      if not cur_entry or not cur_file then return end
+      if not cur_entry or not cur_file then
+        return
+      end
 
       local file_idx = utils.vec_indexof(cur_entry.files, cur_file)
-      if file_idx == -1 then return end
+      if file_idx == -1 then
+        return
+      end
 
       local next_idx
       if config.get_config().wrap_entries then
         next_idx = (file_idx % #cur_entry.files) + 1
       else
         next_idx = math.min(file_idx + 1, #cur_entry.files)
-        if next_idx == file_idx then return end
+        if next_idx == file_idx then
+          return
+        end
       end
       view:set_file(cur_entry.files[next_idx])
     end,
@@ -135,22 +171,32 @@ return function(view)
     prev_entry_in_commit = function()
       local cur_entry = view.panel.cur_item[1]
       local cur_file = view.panel.cur_item[2]
-      if not cur_entry or not cur_file then return end
+      if not cur_entry or not cur_file then
+        return
+      end
 
       local file_idx = utils.vec_indexof(cur_entry.files, cur_file)
-      if file_idx == -1 then return end
+      if file_idx == -1 then
+        return
+      end
 
       local prev_idx
       if config.get_config().wrap_entries then
         prev_idx = ((file_idx - 2) % #cur_entry.files) + 1
       else
         prev_idx = math.max(file_idx - 1, 1)
-        if prev_idx == file_idx then return end
+        if prev_idx == file_idx then
+          return
+        end
       end
       view:set_file(cur_entry.files[prev_idx])
     end,
-    next_entry = function() view.panel:highlight_next_file() end,
-    prev_entry = function() view.panel:highlight_prev_item() end,
+    next_entry = function()
+      view.panel:highlight_next_file()
+    end,
+    prev_entry = function()
+      view.panel:highlight_prev_item()
+    end,
     select_entry = function()
       if view.panel:is_focused() then
         local item = view.panel:get_item_at_cursor()
@@ -167,7 +213,9 @@ return function(view)
         end
       elseif view.panel.option_panel:is_focused() then
         local option = view.panel.option_panel:get_item_at_cursor()
-        if option then view.panel.option_panel.emitter:emit("set_option", option.key) end
+        if option then
+          view.panel.option_panel.emitter:emit("set_option", option.key)
+        end
       end
     end,
     focus_entry = function()
@@ -190,15 +238,25 @@ return function(view)
       local file = view:infer_cur_file()
       if file then
         local entry = view.panel:find_entry(file)
-        if entry then view.commit_log_panel:update(view.adapter.Rev.to_range(entry.commit.hash)) end
+        if entry then
+          view.commit_log_panel:update(view.adapter.Rev.to_range(entry.commit.hash))
+        end
       end
     end,
-    focus_files = function() view.panel:focus() end,
-    toggle_files = function() view.panel:toggle(true) end,
+    focus_files = function()
+      view.panel:focus()
+    end,
+    toggle_files = function()
+      view.panel:toggle(true)
+    end,
     refresh_files = function()
       view.panel:update_entries(function(_, status)
-        if status >= JobStatus.ERROR then return end
-        if not view:cur_file() then view:next_item() end
+        if status >= JobStatus.ERROR then
+          return
+        end
+        if not view:cur_file() then
+          view:next_item()
+        end
       end)
     end,
     open_all_folds = function()
@@ -220,19 +278,31 @@ return function(view)
       end
     end,
     open_fold = function()
-      if view.panel.single_file or not view.panel:is_focused() then return end
+      if view.panel.single_file or not view.panel:is_focused() then
+        return
+      end
       local entry = view.panel:get_log_entry_at_cursor()
-      if entry then view.panel:set_entry_fold(entry, true) end
+      if entry then
+        view.panel:set_entry_fold(entry, true)
+      end
     end,
     close_fold = function()
-      if view.panel.single_file or not view.panel:is_focused() then return end
+      if view.panel.single_file or not view.panel:is_focused() then
+        return
+      end
       local entry = view.panel:get_log_entry_at_cursor()
-      if entry then view.panel:set_entry_fold(entry, false) end
+      if entry then
+        view.panel:set_entry_fold(entry, false)
+      end
     end,
     toggle_fold = function()
-      if view.panel.single_file or not view.panel:is_focused() then return end
+      if view.panel.single_file or not view.panel:is_focused() then
+        return
+      end
       local entry = view.panel:get_log_entry_at_cursor()
-      if entry then view.panel:toggle_entry_fold(entry) end
+      if entry then
+        view.panel:toggle_entry_fold(entry)
+      end
     end,
     close = function()
       if view.panel.option_panel:is_focused() then
@@ -243,10 +313,14 @@ return function(view)
         -- Don't close the view if a floating window is focused; the float's
         -- own close listener should handle it.
         local win_conf = api.nvim_win_get_config(0)
-        if win_conf.relative == "" then view:close() end
+        if win_conf.relative == "" then
+          view:close()
+        end
       end
     end,
-    options = function() view.panel.option_panel:focus() end,
+    options = function()
+      view.panel.option_panel:focus()
+    end,
     copy_hash = function()
       if view.panel:is_focused() then
         local item = view.panel:get_item_at_cursor()
@@ -261,8 +335,12 @@ return function(view)
     end,
     open_commit_in_browser = function()
       local item = view.panel:get_item_at_cursor()
-      if not item then item = view.panel.cur_item[1] end
-      if not item or not item.commit then return end
+      if not item then
+        item = view.panel.cur_item[1]
+      end
+      if not item or not item.commit then
+        return
+      end
 
       if not view.adapter.get_commit_url then
         utils.err("Opening commits in browser is not supported for this VCS.")
@@ -286,11 +364,15 @@ return function(view)
         cmd = { "cmd", "/c", "start", "", url }
       end
 
-      if cmd then vim.fn.jobstart(cmd, { detach = true }) end
+      if cmd then
+        vim.fn.jobstart(cmd, { detach = true })
+      end
     end,
     restore_entry = async.void(function()
       local item = view:infer_cur_file()
-      if not item then return end
+      if not item then
+        return
+      end
 
       local bufid = utils.find_file_buffer(item.path)
 

--- a/lua/diffview/scene/views/file_history/option_panel.lua
+++ b/lua/diffview/scene/views/file_history/option_panel.lua
@@ -65,7 +65,6 @@ function FHOptionPanel:init(parent)
       self:_set_option(option_name, not cur_value)
       self:render()
       self:redraw()
-
     elseif self.flags.options[option_name] then
       local o = self.flags.options[option_name]
 
@@ -83,7 +82,6 @@ function FHOptionPanel:init(parent)
           self:render()
           self:redraw()
         end)
-
       else
         local completion = type(o.completion) == "function" and o.completion(self) or o.completion
 
@@ -127,7 +125,7 @@ function FHOptionPanel:init(parent)
   self:on_autocmd("WinClosed", {
     callback = function()
       if not vim.deep_equal(self.option_state, self.parent:get_log_options()) then
-        vim.schedule(function ()
+        vim.schedule(function()
           self.option_state = nil
           self.winid = nil
           self.parent:update_entries(function(_, status)
@@ -166,14 +164,9 @@ function FHOptionPanel:setup_buffer()
   for _, group in pairs(self.flags) do
     ---@cast group FlagOption[]
     for option_name, v in pairs(group) do
-      vim.keymap.set(
-        "n",
-        v.keymap,
-        function()
-          self.emitter:emit("set_option", option_name)
-        end,
-        { silent = true, buffer = self.bufid }
-      )
+      vim.keymap.set("n", v.keymap, function()
+        self.emitter:emit("set_option", option_name)
+      end, { silent = true, buffer = self.bufid })
     end
   end
 end
@@ -182,10 +175,10 @@ function FHOptionPanel:update_components()
   local switch_schema = {}
   local option_schema = {}
   for _, option in ipairs(self.flags.switches) do
-    table.insert(switch_schema, { name = "switch", context = { option = option, }, })
+    table.insert(switch_schema, { name = "switch", context = { option = option } })
   end
   for _, option in ipairs(self.flags.options) do
-    table.insert(option_schema, { name = "option", context = { option = option }, })
+    table.insert(option_schema, { name = "option", context = { option = option } })
   end
 
   ---@type CompStruct

--- a/lua/diffview/scene/views/file_history/render.lua
+++ b/lua/diffview/scene/views/file_history/render.lua
@@ -18,7 +18,9 @@ local MAX_BAR_WIDTH = 20
 ---@param deletions integer
 local function render_stat_bar(comp, additions, deletions)
   local total = additions + deletions
-  if total == 0 then return end
+  if total == 0 then
+    return
+  end
 
   local bar_width = math.min(total, MAX_BAR_WIDTH)
   local add_width = math.floor(additions / total * bar_width + 0.5)
@@ -81,7 +83,10 @@ local function render_files(comp, files)
         comp:add_text(file.parent_path .. "/", "DiffviewFilePanelPath")
       end
 
-      comp:add_text(file.basename, file.active and "DiffviewFilePanelSelected" or "DiffviewFilePanelFileName")
+      comp:add_text(
+        file.basename,
+        file.active and "DiffviewFilePanelSelected" or "DiffviewFilePanelFileName"
+      )
 
       if file.stats then
         render_file_stats(comp, file.stats, stat_style)
@@ -112,7 +117,9 @@ local formatters = {
   end,
 
   files = function(comp, entry, ctx)
-    if entry.single_file then return end
+    if entry.single_file then
+      return
+    end
     local s_num_files = tostring(ctx.max_num_files)
 
     if entry.nulled then
@@ -130,7 +137,9 @@ local formatters = {
   end,
 
   stats = function(comp, entry, ctx)
-    if ctx.max_len_stats == -1 then return end
+    if ctx.max_len_stats == -1 then
+      return
+    end
     local adds = { "-", "DiffviewNonText" }
     local dels = { "-", "DiffviewNonText" }
 
@@ -156,8 +165,13 @@ local formatters = {
   end,
 
   reflog = function(comp, entry, _ctx)
-    if (entry.commit --[[@as GitCommit ]]).reflog_selector then
-      comp:add_text((" %s"):format((entry.commit --[[@as GitCommit ]]).reflog_selector), "DiffviewReflogSelector")
+    if
+      (entry.commit --[[@as GitCommit ]]).reflog_selector
+    then
+      comp:add_text(
+        (" %s"):format((entry.commit --[[@as GitCommit ]]).reflog_selector),
+        "DiffviewReflogSelector"
+      )
     end
   end,
 
@@ -168,10 +182,8 @@ local formatters = {
   end,
 
   subject = function(comp, entry, ctx)
-    local subject = utils.str_trunc(
-      entry.commit.subject,
-      ctx.conf.file_history_panel.commit_subject_max_length
-    )
+    local subject =
+      utils.str_trunc(entry.commit.subject, ctx.conf.file_history_panel.commit_subject_max_length)
 
     if subject == "" then
       subject = "[empty message]"
@@ -180,7 +192,9 @@ local formatters = {
     local subject_hl
     if ctx.panel.cur_item[1] == entry then
       subject_hl = "DiffviewFilePanelSelected"
-    elseif ctx.conf.file_history_panel.subject_highlight == "ref_aware" and entry.has_remote_ref then
+    elseif
+      ctx.conf.file_history_panel.subject_highlight == "ref_aware" and entry.has_remote_ref
+    then
       subject_hl = "DiffviewCommitRemoteRef"
     elseif ctx.conf.file_history_panel.subject_highlight == "ref_aware" then
       subject_hl = "DiffviewCommitLocalOnly"
@@ -198,7 +212,9 @@ local formatters = {
   end,
 
   date = function(comp, entry, ctx)
-    if not entry.commit then return end
+    if not entry.commit then
+      return
+    end
     local date_format = ctx.conf.file_history_panel.date_format
     local date
     if date_format == "relative" then
@@ -210,7 +226,7 @@ local formatters = {
       date = (
         os.difftime(os.time(), entry.commit.time) > 60 * 60 * 24 * 30 * 3
           and entry.commit.iso_date
-          or entry.commit.rel_date
+        or entry.commit.rel_date
       )
     end
     comp:add_text(", " .. date, "DiffviewFilePanelPath")
@@ -261,7 +277,10 @@ local function render_entries(panel, parent, entries, updating)
     local comp = entry_struct.commit.comp
 
     if not entry.single_file then
-      comp:add_text((entry.folded and c.signs.fold_closed or c.signs.fold_open) .. " ", "DiffviewFolderSign")
+      comp:add_text(
+        (entry.folded and c.signs.fold_closed or c.signs.fold_open) .. " ",
+        "DiffviewFolderSign"
+      )
     end
 
     for _, part in ipairs(commit_format) do

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -32,12 +32,13 @@ function StandardView:init(opt)
   self.nulled = utils.sate(opt.nulled, false)
   self.panel = opt.panel or Panel()
   self.layouts = opt.layouts or {}
-  self.winopts = opt.winopts or {
-    diff1 = { a = {} },
-    diff2 = { a = {}, b = {} },
-    diff3 = { a = {}, b = {}, c = {} },
-    diff4 = { a = {}, b = {}, c = {}, d = {} },
-  }
+  self.winopts = opt.winopts
+    or {
+      diff1 = { a = {} },
+      diff2 = { a = {}, b = {} },
+      diff3 = { a = {}, b = {}, c = {} },
+      diff4 = { a = {}, b = {}, c = {}, d = {} },
+    }
 
   self.emitter:on("post_layout", utils.bind(self.post_layout, self))
 end
@@ -158,11 +159,8 @@ StandardView.use_entry = async.void(function(self, entry)
 
   for _, sym in ipairs({ "a", "b", "c", "d" }) do
     if entry.layout[sym] then
-      entry.layout[sym].file.winopts = vim.tbl_extend(
-        "force",
-        entry.layout[sym].file.winopts,
-        self.winopts[layout_key][sym] or {}
-      )
+      entry.layout[sym].file.winopts =
+        vim.tbl_extend("force", entry.layout[sym].file.winopts, self.winopts[layout_key][sym] or {})
     end
   end
 

--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -4,7 +4,8 @@ local oop = require("diffview.oop")
 
 local EventEmitter = lazy.access("diffview.events", "EventEmitter") ---@type EventEmitter|LazyModule
 local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
-local FileHistoryView = lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
+local FileHistoryView =
+  lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
 local config = lazy.require("diffview.config") ---@module "diffview.config"
 local lib = lazy.require("diffview.lib") ---@module "diffview.lib"
@@ -82,20 +83,23 @@ function Window:is_focused()
   return self:is_valid() and api.nvim_get_current_win() == self.id
 end
 
-function Window:post_open()
-end
+function Window:post_open() end
 
 ---@param self Window
 ---@param callback fun(ok: boolean)
 Window.load_file = async.wrap(function(self, callback)
   assert(self.file)
 
-  if self.file:is_valid() then return callback(true) end
+  if self.file:is_valid() then
+    return callback(true)
+  end
 
   -- Skip loading if the file has been deactivated (e.g. user navigated
   -- away). This avoids queueing unnecessary git jobs during rapid
   -- navigation.
-  if not self.file.active then return callback(false) end
+  if not self.file.active then
+    return callback(false)
+  end
 
   local ok, err = pawait(self.file.create_buffer, self.file)
 
@@ -138,14 +142,18 @@ Window.open_file = async.void(function(self)
   ---@diagnostic disable: invisible
   assert(self.file)
 
-  if not (self:is_valid() and self.file.active) then return end
+  if not (self:is_valid() and self.file.active) then
+    return
+  end
 
   if not self.file:is_valid() then
     local ok = await(self:load_file())
     await(async.scheduler())
 
     -- Ensure validity after await
-    if not (self:is_valid() and self.file.active) then return end
+    if not (self:is_valid() and self.file.active) then
+      return
+    end
 
     if not ok then
       self:open_fallback()
@@ -163,8 +171,8 @@ Window.open_file = async.void(function(self)
     self.file._orig_context_enabled = vim.b[self.file.bufnr].context_enabled
     self.file._context_state_saved = true
   end
-  vim.b[self.file.bufnr].ts_context_disable = true  -- nvim-treesitter-context
-  vim.b[self.file.bufnr].context_enabled = false    -- context.vim
+  vim.b[self.file.bufnr].ts_context_disable = true -- nvim-treesitter-context
+  vim.b[self.file.bufnr].context_enabled = false -- context.vim
 
   local conf = config.get_config()
   local set_buf_ok, set_buf_err, recovered = utils.set_win_buf(self.id, self.file.bufnr)
@@ -172,7 +180,7 @@ Window.open_file = async.void(function(self)
     Window._set_buf_warned = true
     utils.warn(
       "An external autocommand failed while opening a Diffview buffer. "
-      .. "Diffview retried without window events.",
+        .. "Diffview retried without window events.",
       true
     )
   end
@@ -301,7 +309,9 @@ local global_only_opts = {
 }
 
 function Window:_save_winopts()
-  if Window.winopt_store[self.file.bufnr] then return end
+  if Window.winopt_store[self.file.bufnr] then
+    return
+  end
 
   Window.winopt_store[self.file.bufnr] = {}
   for option, _ in pairs(self.file.winopts) do

--- a/lua/diffview/selection_store.lua
+++ b/lua/diffview/selection_store.lua
@@ -28,7 +28,9 @@ end
 ---@return table
 local function read_store(path)
   local ok, content = pcall(vim.fn.readfile, path)
-  if not ok or #content == 0 then return {} end
+  if not ok or #content == 0 then
+    return {}
+  end
   local decode_ok, data = pcall(vim.json.decode, table.concat(content, "\n"))
   if not decode_ok or type(data) ~= "table" then
     logger:warn("[SelectionStore] Corrupt store file; ignoring: " .. path)

--- a/lua/diffview/stream.lua
+++ b/lua/diffview/stream.lua
@@ -18,7 +18,7 @@ local M = {}
 local Stream = oop.create_class("Stream")
 M.Stream = Stream
 
-Stream.EOF = oop.Symbol("Stream.EOF");
+Stream.EOF = oop.Symbol("Stream.EOF")
 
 ---@alias Stream.SrcFunc fun(): (item: unknown, continue: boolean?)
 
@@ -75,7 +75,9 @@ function Stream:skip(n)
     return
   end
 
-  for _ = 1, n do self:next() end
+  for _ = 1, n do
+    self:next()
+  end
 
   return self
 end
@@ -85,7 +87,9 @@ function Stream:iter()
   return function()
     local v, i = self:next()
     ---@diagnostic disable-next-line: missing-return-value, return-type-mismatch
-    if v == Stream.EOF then return nil end
+    if v == Stream.EOF then
+      return nil
+    end
     ---@cast i -?
     return i, v
   end
@@ -94,7 +98,9 @@ end
 ---@return unknown[]
 function Stream:collect()
   local ret = {}
-  for i, v in self:iter() do ret[i] = v end
+  for i, v in self:iter() do
+    ret[i] = v
+  end
   return ret
 end
 
@@ -102,11 +108,17 @@ end
 ---@param last? integer (default: math.huge)
 ---@return Stream
 function Stream:slice(first, last)
-  if first == nil then first = 1 end
-  if last == nil then last = math.huge end
+  if first == nil then
+    first = 1
+  end
+  if last == nil then
+    last = math.huge
+  end
 
   return Stream(function()
-    if self.head > last then return nil, false end
+    if self.head > last then
+      return nil, false
+    end
     if first > self.head then
       self:skip(first - self.head)
     end
@@ -123,7 +135,9 @@ function Stream:map(f)
 
     while v ~= Stream.EOF do
       v = f(v)
-      if v ~= nil then break end
+      if v ~= nil then
+        break
+      end
       v = self:next()
     end
 
@@ -153,8 +167,12 @@ end
 ---@return T
 function Stream:reduce(f, init)
   local acc = init
-  if not acc then acc = self:next() end
-  for _, v in self:iter() do acc = f(acc, v) end
+  if not acc then
+    acc = self:next()
+  end
+  for _, v in self:iter() do
+    acc = f(acc, v)
+  end
 
   return acc
 end
@@ -242,7 +260,9 @@ end
 ---Append the given items to the end of the stream. Pushing `Stream.EOF` will
 ---close the stream.
 function AsyncListStream:push(...)
-  if self:is_closed() then return end
+  if self:is_closed() then
+    return
+  end
   local args = { ... }
   local permit = await(self.sem:acquire()) --[[@as Permit ]]
 
@@ -258,7 +278,7 @@ function AsyncListStream:push(...)
           self:invoke_listeners("on_close")
           permit = await(self.sem:acquire()) --[[@as Permit ]]
 
-          self.data[#self.data+1] = args[i]
+          self.data[#self.data + 1] = args[i]
           self.flow_state = StreamState.CLOSED
 
           self:invoke_listeners("on_post_close")
@@ -266,7 +286,7 @@ function AsyncListStream:push(...)
           break
         end
       else
-        self.data[#self.data+1] = args[i]
+        self.data[#self.data + 1] = args[i]
       end
     end
   end
@@ -282,7 +302,9 @@ end
 
 ---@param ... any Arguments to pass to the `on_close` callback.
 function AsyncListStream:close(...)
-  if self:is_closed() then return end
+  if self:is_closed() then
+    return
+  end
   self.state.on_close.args = utils.tbl_pack(...)
   self:push(Stream.EOF)
 end

--- a/lua/diffview/tests/functional/actions_features_spec.lua
+++ b/lua/diffview/tests/functional/actions_features_spec.lua
@@ -4,7 +4,8 @@ local lib = require("diffview.lib")
 local utils = require("diffview.utils")
 
 local DiffView_class = require("diffview.scene.views.diff.diff_view").DiffView
-local FileHistoryView_class = require("diffview.scene.views.file_history.file_history_view").FileHistoryView
+local FileHistoryView_class =
+  require("diffview.scene.views.file_history.file_history_view").FileHistoryView
 local Diff1 = require("diffview.scene.layouts.diff_1").Diff1
 local Diff2Hor = require("diffview.scene.layouts.diff_2_hor").Diff2Hor
 local Diff2Ver = require("diffview.scene.layouts.diff_2_ver").Diff2Ver
@@ -64,11 +65,17 @@ describe("diffview.actions.set_layout (59237ad)", function()
   local function mock_diff_view(files, cur_entry)
     return {
       class = DiffView_class,
-      instanceof = function(self, other) return self.class == other end,
+      instanceof = function(self, other)
+        return self.class == other
+      end,
       cur_entry = cur_entry,
       cur_layout = {
-        get_main_win = function() return { id = 1 } end,
-        is_focused = function() return false end,
+        get_main_win = function()
+          return { id = 1 }
+        end,
+        is_focused = function()
+          return false
+        end,
         sync_scroll = function() end,
       },
       panel = {
@@ -95,8 +102,12 @@ describe("diffview.actions.set_layout (59237ad)", function()
       local file = mock_file_entry(Diff2Hor)
       local view = mock_diff_view({ file }, file)
 
-      stub(lib, "get_current_view", function() return view end)
-      stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+      stub(lib, "get_current_view", function()
+        return view
+      end)
+      stub(vim.api, "nvim_win_get_cursor", function()
+        return { 1, 0 }
+      end)
 
       local action_fn = actions.set_layout(name)
       action_fn()
@@ -108,8 +119,12 @@ describe("diffview.actions.set_layout (59237ad)", function()
 
   it("emits an error for an invalid layout name", function()
     local err_called = false
-    stub(utils, "err", function() err_called = true end)
-    stub(lib, "get_current_view", function() return mock_diff_view({}, nil) end)
+    stub(utils, "err", function()
+      err_called = true
+    end)
+    stub(lib, "get_current_view", function()
+      return mock_diff_view({}, nil)
+    end)
 
     local action_fn = actions.set_layout("nonexistent_layout")
     action_fn()
@@ -127,8 +142,12 @@ describe("diffview.actions.set_layout (59237ad)", function()
     -- cur_entry must be one of the files for set_file to be called.
     local view = mock_diff_view(files, files[1])
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     local action_fn = actions.set_layout("diff2_vertical")
     action_fn()
@@ -140,11 +159,15 @@ describe("diffview.actions.set_layout (59237ad)", function()
   end)
 
   it("returns early without error when no view is active", function()
-    stub(lib, "get_current_view", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
 
     local action_fn = actions.set_layout("diff2_horizontal")
     -- Should not error.
-    assert.has_no.errors(function() action_fn() end)
+    assert.has_no.errors(function()
+      action_fn()
+    end)
     eq(0, #converted_layouts)
   end)
 end)
@@ -170,13 +193,19 @@ describe("copy_hash honors vim.v.register (f728b1f)", function()
     vim.fn.setreg = function(r, val)
       captured.reg, captured.val = r, val
     end
-    utils.info = function(msg) captured.msg = msg end
+    utils.info = function(msg)
+      captured.msg = msg
+    end
     vim.v = setmetatable({ register = reg }, { __index = orig_v })
 
     local mock_view = {
       panel = {
-        is_focused = function() return true end,
-        get_item_at_cursor = function() return { commit = { hash = hash } } end,
+        is_focused = function()
+          return true
+        end,
+        get_item_at_cursor = function()
+          return { commit = { hash = hash } }
+        end,
       },
     }
     local listeners = listeners_factory(mock_view)
@@ -234,7 +263,9 @@ describe("scrollbind/cursorbind cleanup (431ee89)", function()
   it("default File winopts enable scrollbind and cursorbind", function()
     local adapter = {
       ctx = { toplevel = vim.uv.cwd(), dir = vim.uv.cwd() },
-      is_binary = function() return false end,
+      is_binary = function()
+        return false
+      end,
     }
 
     local file = File({
@@ -252,7 +283,9 @@ describe("scrollbind/cursorbind cleanup (431ee89)", function()
   it("_save_winopts reads scrollbind from vim.wo, not vim.o", function()
     local adapter = {
       ctx = { toplevel = vim.uv.cwd(), dir = vim.uv.cwd() },
-      is_binary = function() return false end,
+      is_binary = function()
+        return false
+      end,
     }
 
     local file = File({
@@ -289,7 +322,9 @@ describe("scrollbind/cursorbind cleanup (431ee89)", function()
   it("_save_winopts reads cursorbind from vim.wo, not vim.o", function()
     local adapter = {
       ctx = { toplevel = vim.uv.cwd(), dir = vim.uv.cwd() },
-      is_binary = function() return false end,
+      is_binary = function()
+        return false
+      end,
     }
 
     local file = File({

--- a/lua/diffview/tests/functional/actions_spec.lua
+++ b/lua/diffview/tests/functional/actions_spec.lua
@@ -17,19 +17,27 @@ describe("diffview.actions goto_file API", function()
   -- bound inside a DiffView tabpage). Verify they consistently error
   -- rather than silently misbehaving.
   it("goto_file errors without an active view (expected guard)", function()
-    assert.has_error(function() actions.goto_file() end)
+    assert.has_error(function()
+      actions.goto_file()
+    end)
   end)
 
   it("goto_file_edit errors without an active view (expected guard)", function()
-    assert.has_error(function() actions.goto_file_edit() end)
+    assert.has_error(function()
+      actions.goto_file_edit()
+    end)
   end)
 
   it("goto_file_split errors without an active view (expected guard)", function()
-    assert.has_error(function() actions.goto_file_split() end)
+    assert.has_error(function()
+      actions.goto_file_split()
+    end)
   end)
 
   it("goto_file_tab errors without an active view (expected guard)", function()
-    assert.has_error(function() actions.goto_file_tab() end)
+    assert.has_error(function()
+      actions.goto_file_tab()
+    end)
   end)
 end)
 
@@ -52,26 +60,51 @@ describe("diffview.actions goto_file command routing", function()
 
     local mock_file = {
       absolute_path = "/tmp/test.lua",
-      layout = { restore_winopts = function() end, get_main_win = function() return { id = 1 } end },
+      layout = {
+        restore_winopts = function() end,
+        get_main_win = function()
+          return { id = 1 }
+        end,
+      },
       active = true,
     }
     local mock_view = {
       class = DiffView_class,
-      instanceof = function(self, other) return self.class == other end,
-      infer_cur_file = function() return mock_file end,
+      instanceof = function(self, other)
+        return self.class == other
+      end,
+      infer_cur_file = function()
+        return mock_file
+      end,
       cur_entry = nil,
-      cur_layout = { get_main_win = function() return { id = 1 } end },
+      cur_layout = {
+        get_main_win = function()
+          return { id = 1 }
+        end,
+      },
     }
 
-    stub(lib, "get_current_view", function() return mock_view end)
-    stub(lib, "get_prev_non_view_tabpage", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return mock_view
+    end)
+    stub(lib, "get_prev_non_view_tabpage", function()
+      return nil
+    end)
     stub(utils, "set_cursor", function() end)
-    stub(utils.path, "readable", function() return true end)
+    stub(utils.path, "readable", function()
+      return true
+    end)
     stub(vim.api, "nvim_set_current_tabpage", function() end)
-    stub(vim.api, "nvim_get_current_buf", function() return 999 end)
+    stub(vim.api, "nvim_get_current_buf", function()
+      return 999
+    end)
     stub(vim.api, "nvim_buf_delete", function() end)
-    stub(vim.fn, "fnameescape", function(p) return p end)
-    stub(vim, "cmd", function(c) cmds_issued[#cmds_issued + 1] = c end)
+    stub(vim.fn, "fnameescape", function(p)
+      return p
+    end)
+    stub(vim, "cmd", function(c)
+      cmds_issued[#cmds_issued + 1] = c
+    end)
   end)
 
   after_each(function()
@@ -95,14 +128,18 @@ describe("diffview.actions goto_file command routing", function()
   end)
 
   it("goto_file issues 'sp <file>' when a previous tab exists", function()
-    lib.get_prev_non_view_tabpage = function() return 1 end
+    lib.get_prev_non_view_tabpage = function()
+      return 1
+    end
     actions.goto_file()
     eq(1, #cmds_issued)
     assert.truthy(cmds_issued[1]:find("^sp "))
   end)
 
   it("goto_file_edit issues 'edit <file>' when a previous tab exists", function()
-    lib.get_prev_non_view_tabpage = function() return 1 end
+    lib.get_prev_non_view_tabpage = function()
+      return 1
+    end
     actions.goto_file_edit()
     eq(1, #cmds_issued)
     assert.truthy(cmds_issued[1]:find("^edit "))

--- a/lua/diffview/tests/functional/async_guards_spec.lua
+++ b/lua/diffview/tests/functional/async_guards_spec.lua
@@ -74,88 +74,112 @@ describe("diffview.async guards", function()
     -- Simulates the pattern used in DiffView:update_files where a
     -- closing signal aborts an in-flight async update.
 
-    it("aborts when closing is signalled before the update runs", test_utils.async_test(function()
-      local closing = Signal("closing")
-      local update_ran = false
+    it(
+      "aborts when closing is signalled before the update runs",
+      test_utils.async_test(function()
+        local closing = Signal("closing")
+        local update_ran = false
 
-      local update = async.void(function()
-        if closing:check() then return end
+        local update = async.void(function()
+          if closing:check() then
+            return
+          end
+          await(async.scheduler())
+          if closing:check() then
+            return
+          end
+          update_ran = true
+        end)
+
+        closing:send()
+        update()
         await(async.scheduler())
-        if closing:check() then return end
-        update_ran = true
+        assert.is_false(update_ran)
       end)
+    )
 
-      closing:send()
-      update()
-      await(async.scheduler())
-      assert.is_false(update_ran)
-    end))
+    it(
+      "aborts when closing is signalled during the update",
+      test_utils.async_test(function()
+        local closing = Signal("closing")
+        local update_reached_yield = Signal("update_reached_yield")
+        local update_completed = false
 
-    it("aborts when closing is signalled during the update", test_utils.async_test(function()
-      local closing = Signal("closing")
-      local update_reached_yield = Signal("update_reached_yield")
-      local update_completed = false
+        local update = async.void(function()
+          if closing:check() then
+            return
+          end
+          -- Notify the test that we have reached the yield point.
+          update_reached_yield:send()
+          await(async.timeout(20))
+          if closing:check() then
+            return
+          end
+          update_completed = true
+        end)
 
-      local update = async.void(function()
-        if closing:check() then return end
-        -- Notify the test that we have reached the yield point.
-        update_reached_yield:send()
-        await(async.timeout(20))
-        if closing:check() then return end
-        update_completed = true
+        update()
+        -- Wait until the update has reached its yield point.
+        await(update_reached_yield)
+
+        -- Signal closing while the update is suspended at the timeout.
+        closing:send()
+
+        -- Wait for the update's timeout to expire.
+        await(async.timeout(30))
+        await(async.scheduler())
+
+        assert.is_false(update_completed)
       end)
-
-      update()
-      -- Wait until the update has reached its yield point.
-      await(update_reached_yield)
-
-      -- Signal closing while the update is suspended at the timeout.
-      closing:send()
-
-      -- Wait for the update's timeout to expire.
-      await(async.timeout(30))
-      await(async.scheduler())
-
-      assert.is_false(update_completed)
-    end))
+    )
   end)
 
   describe("debounce_trailing", function()
-    it("collapses rapid calls into a single execution", test_utils.async_test(function()
-      local call_count = 0
-      local fn = debounce.debounce_trailing(10, false, function(callback)
-        call_count = call_count + 1
-        if callback then callback() end
+    it(
+      "collapses rapid calls into a single execution",
+      test_utils.async_test(function()
+        local call_count = 0
+        local fn = debounce.debounce_trailing(10, false, function(callback)
+          call_count = call_count + 1
+          if callback then
+            callback()
+          end
+        end)
+
+        -- Fire rapidly.
+        fn()
+        fn()
+        fn()
+
+        -- Wait for the debounce window to close.
+        await(async.timeout(50))
+        await(async.scheduler())
+
+        assert.equals(1, call_count)
       end)
+    )
 
-      -- Fire rapidly.
-      fn()
-      fn()
-      fn()
+    it(
+      "allows a second call after the debounce window",
+      test_utils.async_test(function()
+        local call_count = 0
+        local fn = debounce.debounce_trailing(10, false, function(callback)
+          call_count = call_count + 1
+          if callback then
+            callback()
+          end
+        end)
 
-      -- Wait for the debounce window to close.
-      await(async.timeout(50))
-      await(async.scheduler())
+        fn()
+        await(async.timeout(50))
+        await(async.scheduler())
 
-      assert.equals(1, call_count)
-    end))
+        fn()
+        await(async.timeout(50))
+        await(async.scheduler())
 
-    it("allows a second call after the debounce window", test_utils.async_test(function()
-      local call_count = 0
-      local fn = debounce.debounce_trailing(10, false, function(callback)
-        call_count = call_count + 1
-        if callback then callback() end
+        assert.equals(2, call_count)
       end)
-
-      fn()
-      await(async.timeout(50))
-      await(async.scheduler())
-
-      fn()
-      await(async.timeout(50))
-      await(async.scheduler())
-
-      assert.equals(2, call_count)
-    end))
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/bootstrap_spec.lua
+++ b/lua/diffview/tests/functional/bootstrap_spec.lua
@@ -23,7 +23,9 @@ describe("diffview.vcs.adapter.bootstrap_preamble", function()
   end)
 
   it("returns the err function when the executable is found", function()
-    vim.fn.executable = function() return 1 end
+    vim.fn.executable = function()
+      return 1
+    end
 
     local bs = { done = false, ok = false }
     local err = VCSAdapter.bootstrap_preamble(bs, { "git" }, "TestAdapter", "git_cmd")
@@ -34,7 +36,9 @@ describe("diffview.vcs.adapter.bootstrap_preamble", function()
   end)
 
   it("returns nil and sets bs.err when executable is not found", function()
-    vim.fn.executable = function() return 0 end
+    vim.fn.executable = function()
+      return 0
+    end
 
     local bs = { done = false, ok = false }
     local result = VCSAdapter.bootstrap_preamble(bs, { "nonexistent" }, "TestAdapter", "test_cmd")
@@ -46,7 +50,9 @@ describe("diffview.vcs.adapter.bootstrap_preamble", function()
   end)
 
   it("sets bs.done = true regardless of outcome", function()
-    vim.fn.executable = function() return 0 end
+    vim.fn.executable = function()
+      return 0
+    end
 
     local bs = { done = false, ok = false }
     VCSAdapter.bootstrap_preamble(bs, { "x" }, "Test", "test_cmd")
@@ -54,7 +60,9 @@ describe("diffview.vcs.adapter.bootstrap_preamble", function()
   end)
 
   it("err function sets bs.err and logs", function()
-    vim.fn.executable = function() return 1 end
+    vim.fn.executable = function()
+      return 1
+    end
 
     local bs = { done = false, ok = false }
     local err = VCSAdapter.bootstrap_preamble(bs, { "git" }, "TestAdapter", "git_cmd")

--- a/lua/diffview/tests/functional/browser_and_restore_spec.lua
+++ b/lua/diffview/tests/functional/browser_and_restore_spec.lua
@@ -139,20 +139,30 @@ describe("actions.open_in_new_tab (81a8d41)", function()
   end)
 
   it("returns early without error when no view is active", function()
-    stub(lib, "get_current_view", function() return nil end)
-    assert.has_no.errors(function() actions.open_in_new_tab() end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
+    assert.has_no.errors(function()
+      actions.open_in_new_tab()
+    end)
   end)
 
   it("shows info message when called from a non-DiffView", function()
     local info_called = false
-    stub(utils, "info", function() info_called = true end)
+    stub(utils, "info", function()
+      info_called = true
+    end)
 
     -- Build a mock view that is not a DiffView instance.
     local mock_view = {
       class = {},
-      instanceof = function() return false end,
+      instanceof = function()
+        return false
+      end,
     }
-    stub(lib, "get_current_view", function() return mock_view end)
+    stub(lib, "get_current_view", function()
+      return mock_view
+    end)
 
     actions.open_in_new_tab()
     assert.True(info_called)
@@ -184,7 +194,9 @@ describe("actions.open_in_new_tab (81a8d41)", function()
       options = { show_untracked = true },
     }
 
-    stub(lib, "get_current_view", function() return mock_view end)
+    stub(lib, "get_current_view", function()
+      return mock_view
+    end)
 
     -- The real DiffView.__get():ancestorof calls other:instanceof(self)
     -- which in turn calls mock_view:instanceof(DiffView_class). Stub
@@ -203,7 +215,9 @@ describe("actions.open_in_new_tab (81a8d41)", function()
     local reached_constructor = false
     local add_view_called = false
 
-    stub(lib, "add_view", function() add_view_called = true end)
+    stub(lib, "add_view", function()
+      add_view_called = true
+    end)
 
     local ok, err = pcall(actions.open_in_new_tab)
 
@@ -355,7 +369,9 @@ describe("restore_entry directory support (0fb4d16)", function()
       local modified_paths = { ["src/dirty.lua"] = true }
 
       local function find_file_buffer(path)
-        if modified_paths[path] then return 42 end
+        if modified_paths[path] then
+          return 42
+        end
         return nil
       end
 

--- a/lua/diffview/tests/functional/cdiff_view_spec.lua
+++ b/lua/diffview/tests/functional/cdiff_view_spec.lua
@@ -126,44 +126,62 @@ describe("diffview.api.CDiffView", function()
   -- -----------------------------------------------------------------------
 
   describe("construction", function()
-    it("creates a valid view with pre-populated files", test_utils.async_test(function()
-      local repo = make_repo()
-      local ok, err = pcall(function()
-        local view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files({ make_file_data("init.txt") }),
-          update_files = function() return make_files() end,
-          get_file_data = function() return {} end,
-        })
+    it(
+      "creates a valid view with pre-populated files",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local ok, err = pcall(function()
+          local view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files({ make_file_data("init.txt") }),
+            update_files = function()
+              return make_files()
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-        assert.is_true(view:is_valid())
-        eq(1, view.files:len())
+          assert.is_true(view:is_valid())
+          eq(1, view.files:len())
+        end)
+
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
+    )
 
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    it(
+      "defaults malformed revs to STAGE",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local ok, err = pcall(function()
+          local view = CDiffView({
+            git_root = repo,
+            files = make_files(),
+            update_files = function()
+              return make_files()
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-    it("defaults malformed revs to STAGE", test_utils.async_test(function()
-      local repo = make_repo()
-      local ok, err = pcall(function()
-        local view = CDiffView({
-          git_root = repo,
-          files = make_files(),
-          update_files = function() return make_files() end,
-          get_file_data = function() return {} end,
-        })
+          assert.is_true(view:is_valid())
+          eq(RevType.STAGE, view.left.type)
+          eq(RevType.STAGE, view.right.type)
+        end)
 
-        assert.is_true(view:is_valid())
-        eq(RevType.STAGE, view.left.type)
-        eq(RevType.STAGE, view.right.type)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
-
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    )
   end)
 
   -- -----------------------------------------------------------------------
@@ -171,64 +189,86 @@ describe("diffview.api.CDiffView", function()
   -- -----------------------------------------------------------------------
 
   describe("loading state", function()
-    it("clears is_loading after open when files are pre-populated", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
+    it(
+      "clears is_loading after open when files are pre-populated",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
 
-      local ok, err = pcall(function()
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files({ make_file_data("init.txt") }),
-          update_files = function() return make_files({ make_file_data("init.txt") }) end,
-          get_file_data = function() return {} end,
-        })
+        local ok, err = pcall(function()
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files({ make_file_data("init.txt") }),
+            update_files = function()
+              return make_files({ make_file_data("init.txt") })
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-        -- Before open, is_loading should be true (set in DiffView:init).
-        assert.is_true(view.is_loading)
-        assert.is_true(view.panel.is_loading)
+          -- Before open, is_loading should be true (set in DiffView:init).
+          assert.is_true(view.is_loading)
+          assert.is_true(view.panel.is_loading)
 
-        view:open()
+          view:open()
 
-        -- post_open uses vim.schedule; pump the event loop to flush it.
-        vim.wait(1000, function() return not view.is_loading end, 10)
+          -- post_open uses vim.schedule; pump the event loop to flush it.
+          vim.wait(1000, function()
+            return not view.is_loading
+          end, 10)
 
-        eq(false, view.is_loading)
-        eq(false, view.panel.is_loading)
+          eq(false, view.is_loading)
+          eq(false, view.panel.is_loading)
+        end)
+
+        close_view(view)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
+    )
 
-      close_view(view)
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    it(
+      "sets initialized to true after open with pre-populated files",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
 
-    it("sets initialized to true after open with pre-populated files", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
+        local ok, err = pcall(function()
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files({ make_file_data("init.txt") }),
+            update_files = function()
+              return make_files({ make_file_data("init.txt") })
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-      local ok, err = pcall(function()
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files({ make_file_data("init.txt") }),
-          update_files = function() return make_files({ make_file_data("init.txt") }) end,
-          get_file_data = function() return {} end,
-        })
+          view:open()
+          -- The files_updated event (which sets initialized) fires from the
+          -- vim.schedule callback in post_open.
+          vim.wait(1000, function()
+            return view.initialized
+          end, 10)
 
-        view:open()
-        -- The files_updated event (which sets initialized) fires from the
-        -- vim.schedule callback in post_open.
-        vim.wait(1000, function() return view.initialized end, 10)
+          eq(true, view.initialized)
+        end)
 
-        eq(true, view.initialized)
+        close_view(view)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
-
-      close_view(view)
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    )
   end)
 
   -- -----------------------------------------------------------------------
@@ -236,46 +276,58 @@ describe("diffview.api.CDiffView", function()
   -- -----------------------------------------------------------------------
 
   describe("panel rendering with file_panel.show = false", function()
-    it("renders file list (not loading message) when panel is toggled open", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
+    it(
+      "renders file list (not loading message) when panel is toggled open",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
 
-      local ok, err = pcall(function()
-        config.get_config().file_panel.show = false
+        local ok, err = pcall(function()
+          config.get_config().file_panel.show = false
 
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files({ make_file_data("init.txt") }),
-          update_files = function() return make_files({ make_file_data("init.txt") }) end,
-          get_file_data = function() return {} end,
-        })
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files({ make_file_data("init.txt") }),
+            update_files = function()
+              return make_files({ make_file_data("init.txt") })
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-        view:open()
-        vim.wait(1000, function() return not view.is_loading end, 10)
+          view:open()
+          vim.wait(1000, function()
+            return not view.is_loading
+          end, 10)
 
-        -- Panel should not be open yet.
-        assert.falsy(view.panel:is_open())
+          -- Panel should not be open yet.
+          assert.falsy(view.panel:is_open())
 
-        -- Toggle the panel open (simulates :DiffviewToggleFiles).
-        view.panel:toggle(true)
-        assert.is_true(view.panel:is_open())
+          -- Toggle the panel open (simulates :DiffviewToggleFiles).
+          view.panel:toggle(true)
+          assert.is_true(view.panel:is_open())
 
-        -- Read the rendered panel buffer.
-        local lines = api.nvim_buf_get_lines(view.panel.bufid, 0, -1, false)
-        local joined = table.concat(lines, "\n")
+          -- Read the rendered panel buffer.
+          local lines = api.nvim_buf_get_lines(view.panel.bufid, 0, -1, false)
+          local joined = table.concat(lines, "\n")
 
-        assert.falsy(joined:find("Fetching changes"),
-          "panel should not show loading message after open with pre-populated files")
-        assert.truthy(joined:find("Changes"),
-          "panel should show the Changes section header")
+          assert.falsy(
+            joined:find("Fetching changes"),
+            "panel should not show loading message after open with pre-populated files"
+          )
+          assert.truthy(joined:find("Changes"), "panel should show the Changes section header")
+        end)
+
+        close_view(view)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
-
-      close_view(view)
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    )
   end)
 
   -- -----------------------------------------------------------------------
@@ -283,72 +335,94 @@ describe("diffview.api.CDiffView", function()
   -- -----------------------------------------------------------------------
 
   describe("auto-registration", function()
-    it("registers view in lib.views on open", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
-      local lib = require("diffview.lib")
+    it(
+      "registers view in lib.views on open",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
+        local lib = require("diffview.lib")
 
-      local ok, err = pcall(function()
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files(),
-          update_files = function() return make_files() end,
-          get_file_data = function() return {} end,
-        })
+        local ok, err = pcall(function()
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files(),
+            update_files = function()
+              return make_files()
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-        -- Not registered before open.
-        assert.is_false(vim.tbl_contains(lib.views, view))
+          -- Not registered before open.
+          assert.is_false(vim.tbl_contains(lib.views, view))
 
-        view:open()
+          view:open()
 
-        -- Registered after open.
-        assert.is_true(vim.tbl_contains(lib.views, view))
-      end)
+          -- Registered after open.
+          assert.is_true(vim.tbl_contains(lib.views, view))
+        end)
 
-      close_view(view)
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
-
-    it("does not double-register when add_view is called before open", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
-      local lib = require("diffview.lib")
-
-      local ok, err = pcall(function()
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files(),
-          update_files = function() return make_files() end,
-          get_file_data = function() return {} end,
-        })
-
-        -- Simulate old-style manual registration before open.
-        lib.add_view(view)
-        local count_before = 0
-        for _, v in ipairs(lib.views) do
-          if v == view then count_before = count_before + 1 end
+        close_view(view)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
         end
-        eq(1, count_before)
-
-        view:open()
-
-        -- Should still only appear once.
-        local count_after = 0
-        for _, v in ipairs(lib.views) do
-          if v == view then count_after = count_after + 1 end
-        end
-        eq(1, count_after)
       end)
+    )
 
-      close_view(view)
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    it(
+      "does not double-register when add_view is called before open",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
+        local lib = require("diffview.lib")
+
+        local ok, err = pcall(function()
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files(),
+            update_files = function()
+              return make_files()
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
+
+          -- Simulate old-style manual registration before open.
+          lib.add_view(view)
+          local count_before = 0
+          for _, v in ipairs(lib.views) do
+            if v == view then
+              count_before = count_before + 1
+            end
+          end
+          eq(1, count_before)
+
+          view:open()
+
+          -- Should still only appear once.
+          local count_after = 0
+          for _, v in ipairs(lib.views) do
+            if v == view then
+              count_after = count_after + 1
+            end
+          end
+          eq(1, count_after)
+        end)
+
+        close_view(view)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
+      end)
+    )
   end)
 
   -- -----------------------------------------------------------------------
@@ -356,57 +430,73 @@ describe("diffview.api.CDiffView", function()
   -- -----------------------------------------------------------------------
 
   describe("get_updated_files", function()
-    it("calls fetch_files and returns entries", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
-      local fetch_called = false
+    it(
+      "calls fetch_files and returns entries",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
+        local fetch_called = false
 
-      local ok, err = pcall(function()
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files(),
-          update_files = function()
-            fetch_called = true
-            return make_files({ make_file_data("new.txt", "A") })
-          end,
-          get_file_data = function() return {} end,
-        })
+        local ok, err = pcall(function()
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files(),
+            update_files = function()
+              fetch_called = true
+              return make_files({ make_file_data("new.txt", "A") })
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-        local file_err, entries = async.await(view:get_updated_files())
-        assert.is_nil(file_err)
-        assert.is_true(fetch_called)
-        assert.is_table(entries)
-        assert.is_table(entries.working)
-        eq(1, #entries.working)
+          local file_err, entries = async.await(view:get_updated_files())
+          assert.is_nil(file_err)
+          assert.is_true(fetch_called)
+          assert.is_table(entries)
+          assert.is_table(entries.working)
+          eq(1, #entries.working)
+        end)
+
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
+    )
 
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    it(
+      "handles fetch_files returning malformed data",
+      test_utils.async_test(function()
+        local repo = make_repo()
+        local view
 
-    it("handles fetch_files returning malformed data", test_utils.async_test(function()
-      local repo = make_repo()
-      local view
+        local ok, err = pcall(function()
+          view = CDiffView({
+            git_root = repo,
+            left = Rev(RevType.STAGE),
+            right = Rev(RevType.LOCAL),
+            files = make_files(),
+            update_files = function()
+              return "not a table"
+            end,
+            get_file_data = function()
+              return {}
+            end,
+          })
 
-      local ok, err = pcall(function()
-        view = CDiffView({
-          git_root = repo,
-          left = Rev(RevType.STAGE),
-          right = Rev(RevType.LOCAL),
-          files = make_files(),
-          update_files = function() return "not a table" end,
-          get_file_data = function() return {} end,
-        })
+          local file_err, entries = async.await(view:get_updated_files())
+          assert.is_not_nil(file_err)
+          assert.is_nil(entries)
+        end)
 
-        local file_err, entries = async.await(view:get_updated_files())
-        assert.is_not_nil(file_err)
-        assert.is_nil(entries)
+        cleanup_repo(repo)
+        if not ok then
+          error(err)
+        end
       end)
-
-      cleanup_repo(repo)
-      if not ok then error(err) end
-    end))
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/closing_guard_spec.lua
+++ b/lua/diffview/tests/functional/closing_guard_spec.lua
@@ -74,271 +74,304 @@ end
 
 describe("closing guard in update_files (ef57357)", function()
   describe("guard 1: closing signalled before update starts", function()
-    it("returns cancellation error via callback", helpers.async_test(function()
-      local view = make_mock_view({ closing_sent = true })
+    it(
+      "returns cancellation error via callback",
+      helpers.async_test(function()
+        local view = make_mock_view({ closing_sent = true })
 
-      local err
-      local done = Signal("done")
+        local err
+        local done = Signal("done")
 
-      -- Call the guarded function directly (no debounce) so we can
-      -- inspect the callback synchronously.
-      local guarded = async.wrap(function(self, callback)
-        update_files_guards(self, callback)
+        -- Call the guarded function directly (no debounce) so we can
+        -- inspect the callback synchronously.
+        local guarded = async.wrap(function(self, callback)
+          update_files_guards(self, callback)
+        end)
+
+        async.void(function()
+          err = await(guarded(view))
+          done:send()
+        end)()
+
+        await(done)
+        assert.is_not_nil(err)
+        assert.equals("The update was cancelled.", err[1])
       end)
+    )
 
-      async.void(function()
-        err = await(guarded(view))
-        done:send()
-      end)()
+    it(
+      "does not proceed past the first guard",
+      helpers.async_test(function()
+        local view = make_mock_view({ closing_sent = true })
+        local reached_guard_2 = false
 
-      await(done)
-      assert.is_not_nil(err)
-      assert.equals("The update was cancelled.", err[1])
-    end))
+        async.void(function()
+          -- Guard 1.
+          if view.closing:check() then
+            return
+          end
+          await(async.scheduler())
+          reached_guard_2 = true
+        end)()
 
-    it("does not proceed past the first guard", helpers.async_test(function()
-      local view = make_mock_view({ closing_sent = true })
-      local reached_guard_2 = false
-
-      async.void(function()
-        -- Guard 1.
-        if view.closing:check() then return end
         await(async.scheduler())
-        reached_guard_2 = true
-      end)()
-
-      await(async.scheduler())
-      assert.is_false(reached_guard_2)
-    end))
+        assert.is_false(reached_guard_2)
+      end)
+    )
   end)
 
   describe("guard 2: closing signalled after first scheduler yield", function()
-    it("returns cancellation error when closing fires during yield", helpers.async_test(function()
-      local view = make_mock_view()
-      local update_completed = false
+    it(
+      "returns cancellation error when closing fires during yield",
+      helpers.async_test(function()
+        local view = make_mock_view()
+        local update_completed = false
 
-      -- Use the same pattern as async_guards_spec: signal closing while
-      -- the update is suspended at a timeout, then check the result.
-      local update = async.void(function()
-        -- Guard 1.
-        if view.closing:check() then return end
+        -- Use the same pattern as async_guards_spec: signal closing while
+        -- the update is suspended at a timeout, then check the result.
+        local update = async.void(function()
+          -- Guard 1.
+          if view.closing:check() then
+            return
+          end
 
-        -- Use a timeout to give the test a window to signal closing.
-        await(async.timeout(20))
+          -- Use a timeout to give the test a window to signal closing.
+          await(async.timeout(20))
 
-        -- Guard 2.
-        if view.closing:check() then return end
-        update_completed = true
+          -- Guard 2.
+          if view.closing:check() then
+            return
+          end
+          update_completed = true
+        end)
+
+        update()
+
+        -- Signal closing while the update is suspended at the timeout.
+        view.closing:send()
+
+        -- Wait for the timeout to expire and the scheduler to run.
+        await(async.timeout(30))
+        await(async.scheduler())
+
+        assert.is_false(update_completed)
       end)
+    )
 
-      update()
+    it(
+      "returns error message through callback when closing fires",
+      helpers.async_test(function()
+        local view = make_mock_view()
 
-      -- Signal closing while the update is suspended at the timeout.
-      view.closing:send()
+        -- Send closing before the scheduler yield occurs. This tests the
+        -- combined guard: closing:check() || tabpage mismatch.
+        local cb_err
+        local done = Signal("done")
 
-      -- Wait for the timeout to expire and the scheduler to run.
-      await(async.timeout(30))
-      await(async.scheduler())
+        async.void(function()
+          cb_err = await(async.wrap(function(self, callback)
+            -- Guard 1 passes.
+            if self.closing:check() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-      assert.is_false(update_completed)
-    end))
+            -- Closing fires between guard 1 and guard 2.
+            self.closing:send()
 
-    it("returns error message through callback when closing fires", helpers.async_test(function()
-      local view = make_mock_view()
+            await(async.scheduler())
 
-      -- Send closing before the scheduler yield occurs. This tests the
-      -- combined guard: closing:check() || tabpage mismatch.
-      local cb_err
-      local done = Signal("done")
+            -- Guard 2 catches it.
+            if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-      async.void(function()
-        cb_err = await(async.wrap(function(self, callback)
-          -- Guard 1 passes.
-          if self.closing:check() then
-            callback({ "The update was cancelled." })
-            return
-          end
+            callback()
+          end)(view))
+          done:send()
+        end)()
 
-          -- Closing fires between guard 1 and guard 2.
-          self.closing:send()
-
-          await(async.scheduler())
-
-          -- Guard 2 catches it.
-          if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
-            callback({ "The update was cancelled." })
-            return
-          end
-
-          callback()
-        end)(view))
-        done:send()
-      end)()
-
-      await(done)
-      assert.is_not_nil(cb_err)
-      assert.equals("The update was cancelled.", cb_err[1])
-    end))
+        await(done)
+        assert.is_not_nil(cb_err)
+        assert.equals("The update was cancelled.", cb_err[1])
+      end)
+    )
   end)
 
   describe("guard 2: wrong tabpage after first scheduler yield", function()
-    it("returns cancellation error when tabpage mismatches", helpers.async_test(function()
-      local view = make_mock_view()
-      -- Set tabpage to a value that won't match the current tabpage.
-      view.tabpage = -1
+    it(
+      "returns cancellation error when tabpage mismatches",
+      helpers.async_test(function()
+        local view = make_mock_view()
+        -- Set tabpage to a value that won't match the current tabpage.
+        view.tabpage = -1
 
-      local err
-      local done = Signal("done")
+        local err
+        local done = Signal("done")
 
-      async.void(function()
-        err = await(async.wrap(function(self, callback)
-          if self.closing:check() then
-            callback({ "The update was cancelled." })
-            return
-          end
+        async.void(function()
+          err = await(async.wrap(function(self, callback)
+            if self.closing:check() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          await(async.scheduler())
+            await(async.scheduler())
 
-          if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
-            callback({ "The update was cancelled." })
-            return
-          end
+            if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          callback()
-        end)(view))
-        done:send()
-      end)()
+            callback()
+          end)(view))
+          done:send()
+        end)()
 
-      await(done)
-      assert.is_not_nil(err)
-      assert.equals("The update was cancelled.", err[1])
-    end))
+        await(done)
+        assert.is_not_nil(err)
+        assert.equals("The update was cancelled.", err[1])
+      end)
+    )
   end)
 
   describe("guard 3: closing signalled after async work", function()
-    it("returns cancellation error when closing fires during async work", helpers.async_test(function()
-      local view = make_mock_view()
-      local work_started = Signal("work_started")
+    it(
+      "returns cancellation error when closing fires during async work",
+      helpers.async_test(function()
+        local view = make_mock_view()
+        local work_started = Signal("work_started")
 
-      local err
-      local done = Signal("done")
+        local err
+        local done = Signal("done")
 
-      async.void(function()
-        err = await(async.wrap(function(self, callback)
-          -- Guard 1.
-          if self.closing:check() then
-            callback({ "The update was cancelled." })
-            return
-          end
+        async.void(function()
+          err = await(async.wrap(function(self, callback)
+            -- Guard 1.
+            if self.closing:check() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          await(async.scheduler())
+            await(async.scheduler())
 
-          -- Guard 2.
-          if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
-            callback({ "The update was cancelled." })
-            return
-          end
+            -- Guard 2.
+            if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          -- Simulate async work.
-          work_started:send()
-          await(async.timeout(20))
-          await(async.scheduler())
+            -- Simulate async work.
+            work_started:send()
+            await(async.timeout(20))
+            await(async.scheduler())
 
-          -- Guard 3.
-          if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
-            callback({ "The update was cancelled." })
-            return
-          end
+            -- Guard 3.
+            if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          callback()
-        end)(view))
-        done:send()
-      end)()
+            callback()
+          end)(view))
+          done:send()
+        end)()
 
-      -- Wait for async work to begin, then signal closing.
-      await(work_started)
-      view.closing:send()
+        -- Wait for async work to begin, then signal closing.
+        await(work_started)
+        view.closing:send()
 
-      await(done)
-      assert.is_not_nil(err)
-      assert.equals("The update was cancelled.", err[1])
-    end))
+        await(done)
+        assert.is_not_nil(err)
+        assert.equals("The update was cancelled.", err[1])
+      end)
+    )
   end)
 
   describe("successful update (no closing, correct tabpage)", function()
-    it("returns nil error when all guards pass", helpers.async_test(function()
-      local view = make_mock_view()
+    it(
+      "returns nil error when all guards pass",
+      helpers.async_test(function()
+        local view = make_mock_view()
 
-      local err
-      local done = Signal("done")
+        local err
+        local done = Signal("done")
 
-      async.void(function()
-        err = await(async.wrap(function(self, callback)
-          update_files_guards(self, callback)
-        end)(view))
-        done:send()
-      end)()
+        async.void(function()
+          err = await(async.wrap(function(self, callback)
+            update_files_guards(self, callback)
+          end)(view))
+          done:send()
+        end)()
 
-      await(done)
-      assert.is_nil(err)
-    end))
+        await(done)
+        assert.is_nil(err)
+      end)
+    )
   end)
 
   describe("closing guard combined with tabpage check", function()
-    it("catches closing even when tabpage still matches", helpers.async_test(function()
-      -- This tests the specific fix from ef57357: closing:check() was
-      -- added to the existing tabpage guard conditions.
-      local view = make_mock_view()
+    it(
+      "catches closing even when tabpage still matches",
+      helpers.async_test(function()
+        -- This tests the specific fix from ef57357: closing:check() was
+        -- added to the existing tabpage guard conditions.
+        local view = make_mock_view()
 
-      local err
-      local done = Signal("done")
+        local err
+        local done = Signal("done")
 
-      async.void(function()
-        err = await(async.wrap(function(self, callback)
-          await(async.scheduler())
+        async.void(function()
+          err = await(async.wrap(function(self, callback)
+            await(async.scheduler())
 
-          -- Tabpage matches but closing is signalled.
-          self.closing:send()
+            -- Tabpage matches but closing is signalled.
+            self.closing:send()
 
-          if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
-            callback({ "The update was cancelled." })
-            return
-          end
+            if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          callback()
-        end)(view))
-        done:send()
-      end)()
+            callback()
+          end)(view))
+          done:send()
+        end)()
 
-      await(done)
-      assert.is_not_nil(err)
-      assert.equals("The update was cancelled.", err[1])
-    end))
+        await(done)
+        assert.is_not_nil(err)
+        assert.equals("The update was cancelled.", err[1])
+      end)
+    )
 
-    it("catches tabpage mismatch even when closing is not signalled", helpers.async_test(function()
-      local view = make_mock_view({ tabpage = -1 })
+    it(
+      "catches tabpage mismatch even when closing is not signalled",
+      helpers.async_test(function()
+        local view = make_mock_view({ tabpage = -1 })
 
-      local err
-      local done = Signal("done")
+        local err
+        local done = Signal("done")
 
-      async.void(function()
-        err = await(async.wrap(function(self, callback)
-          await(async.scheduler())
+        async.void(function()
+          err = await(async.wrap(function(self, callback)
+            await(async.scheduler())
 
-          -- Closing not signalled but tabpage does not match.
-          if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
-            callback({ "The update was cancelled." })
-            return
-          end
+            -- Closing not signalled but tabpage does not match.
+            if self.closing:check() or self.tabpage ~= vim.api.nvim_get_current_tabpage() then
+              callback({ "The update was cancelled." })
+              return
+            end
 
-          callback()
-        end)(view))
-        done:send()
-      end)()
+            callback()
+          end)(view))
+          done:send()
+        end)()
 
-      await(done)
-      assert.is_not_nil(err)
-      assert.equals("The update was cancelled.", err[1])
-    end))
+        await(done)
+        assert.is_not_nil(err)
+        assert.equals("The update was cancelled.", err[1])
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/config_features_spec.lua
+++ b/lua/diffview/tests/functional/config_features_spec.lua
@@ -230,7 +230,8 @@ describe("commit_format", function()
 
   it("has the expected default list of formatter names", function()
     local conf = setup_with({})
-    local expected = { "status", "files", "stats", "hash", "reflog", "ref", "subject", "author", "date" }
+    local expected =
+      { "status", "files", "stats", "hash", "reflog", "ref", "subject", "author", "date" }
     assert.same(expected, conf.file_history_panel.commit_format)
   end)
 

--- a/lua/diffview/tests/functional/config_options_spec.lua
+++ b/lua/diffview/tests/functional/config_options_spec.lua
@@ -162,7 +162,9 @@ describe("view.inline.style", function()
 
   it("treats omitted style (e.g. view.inline = {}) as 'use default'", function()
     local err_called = false
-    utils.err = function() err_called = true end
+    utils.err = function()
+      err_called = true
+    end
 
     local conf = setup_with({ view = { inline = {} } })
 
@@ -172,7 +174,9 @@ describe("view.inline.style", function()
 
   it("warns and falls back when view.inline is a non-table value", function()
     local warned = false
-    utils.warn = function() warned = true end
+    utils.warn = function()
+      warned = true
+    end
 
     -- A truthy non-table (e.g. user typo'd `view.inline = "overleaf"`) would
     -- crash on `view.inline.style` without the type guard.

--- a/lua/diffview/tests/functional/config_spec.lua
+++ b/lua/diffview/tests/functional/config_spec.lua
@@ -21,7 +21,9 @@ describe("diffview.config", function()
     utils.warn = old_warn
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 end)
 
@@ -29,7 +31,9 @@ describe("diffview.config default keymaps", function()
   ---Search a keymap table for an entry with the given lhs binding.
   local function find_keymap(keymaps, lhs)
     for _, km in ipairs(keymaps) do
-      if km[2] == lhs then return km end
+      if km[2] == lhs then
+        return km
+      end
     end
     return nil
   end
@@ -61,7 +65,10 @@ describe("diffview.config default keymaps", function()
     -- j, <cr>, zo are common panel keymaps.
     for _, lhs in ipairs({ "j", "<cr>", "zo", "zM" }) do
       assert.truthy(find_keymap(keymaps.file_panel, lhs), "file_panel missing " .. lhs)
-      assert.truthy(find_keymap(keymaps.file_history_panel, lhs), "file_history_panel missing " .. lhs)
+      assert.truthy(
+        find_keymap(keymaps.file_history_panel, lhs),
+        "file_history_panel missing " .. lhs
+      )
     end
   end)
 

--- a/lua/diffview/tests/functional/cycle_layouts_spec.lua
+++ b/lua/diffview/tests/functional/cycle_layouts_spec.lua
@@ -51,14 +51,18 @@ describe("diffview.config cycle_layouts defaults", function()
     utils.warn = old_warn
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 
   it("falls back to defaults when cycle_layouts is not a table", function()
     local original = vim.deepcopy(config.get_config())
     local warnings = {}
     local old_warn = utils.warn
-    utils.warn = function(msg) warnings[#warnings + 1] = msg end
+    utils.warn = function(msg)
+      warnings[#warnings + 1] = msg
+    end
 
     local ok, err = pcall(function()
       config.setup({ view = { cycle_layouts = "not a table" } })
@@ -72,7 +76,9 @@ describe("diffview.config cycle_layouts defaults", function()
     utils.warn = old_warn
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
     assert.is_true(#warnings > 0, "expected a warning about invalid cycle_layouts")
   end)
 
@@ -80,7 +86,9 @@ describe("diffview.config cycle_layouts defaults", function()
     local original = vim.deepcopy(config.get_config())
     local warnings = {}
     local old_warn = utils.warn
-    utils.warn = function(msg) warnings[#warnings + 1] = msg end
+    utils.warn = function(msg)
+      warnings[#warnings + 1] = msg
+    end
 
     local ok, err = pcall(function()
       config.setup({ view = { cycle_layouts = { default = "diff2_horizontal" } } })
@@ -92,7 +100,9 @@ describe("diffview.config cycle_layouts defaults", function()
     utils.warn = old_warn
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
     assert.is_true(#warnings > 0, "expected a warning about invalid cycle_layouts.default")
   end)
 
@@ -100,7 +110,9 @@ describe("diffview.config cycle_layouts defaults", function()
     local original = vim.deepcopy(config.get_config())
     local warnings = {}
     local old_warn = utils.warn
-    utils.warn = function(msg) warnings[#warnings + 1] = msg end
+    utils.warn = function(msg)
+      warnings[#warnings + 1] = msg
+    end
 
     local ok, err = pcall(function()
       -- A map (not a list) is rejected because `cycle_layout()` iterates
@@ -115,7 +127,9 @@ describe("diffview.config cycle_layouts defaults", function()
     utils.warn = old_warn
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
     assert.is_true(#warnings > 0, "expected a warning about invalid cycle_layouts.merge_tool")
   end)
 
@@ -142,7 +156,9 @@ describe("diffview.config cycle_layouts defaults", function()
     utils.warn = old_warn
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 end)
 
@@ -162,7 +178,9 @@ describe("diffview.actions.set_layout name resolution", function()
       err_messages[#err_messages + 1] = msg
     end)
     -- Ensure no view is active so set_layout returns early after resolving.
-    stub(lib, "get_current_view", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
   end)
 
   after_each(function()
@@ -253,11 +271,17 @@ describe("diffview.actions.cycle_layout cycling logic", function()
   local function mock_diff_view(files, cur_entry)
     return {
       class = DiffView_class,
-      instanceof = function(self, other) return self.class == other end,
+      instanceof = function(self, other)
+        return self.class == other
+      end,
       cur_entry = cur_entry,
       cur_layout = {
-        get_main_win = function() return { id = 1 } end,
-        is_focused = function() return false end,
+        get_main_win = function()
+          return { id = 1 }
+        end,
+        is_focused = function()
+          return false
+        end,
         sync_scroll = function() end,
       },
       panel = {
@@ -269,7 +293,9 @@ describe("diffview.actions.cycle_layout cycling logic", function()
   end
 
   it("returns early when no view is active", function()
-    stub(lib, "get_current_view", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
 
     -- Should not error.
     actions.cycle_layout()
@@ -279,7 +305,9 @@ describe("diffview.actions.cycle_layout cycling logic", function()
   it("returns early when cur_entry is nil (empty diff)", function()
     local view = mock_diff_view({}, nil)
 
-    stub(lib, "get_current_view", function() return view end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
 
     -- Should not error despite files being nil.
     actions.cycle_layout()
@@ -290,8 +318,12 @@ describe("diffview.actions.cycle_layout cycling logic", function()
     local file = mock_file_entry(Diff2Hor)
     local view = mock_diff_view({ file }, file)
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     actions.cycle_layout()
 
@@ -303,8 +335,12 @@ describe("diffview.actions.cycle_layout cycling logic", function()
     local file = mock_file_entry(Diff2Ver)
     local view = mock_diff_view({ file }, file)
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     actions.cycle_layout()
 
@@ -323,8 +359,12 @@ describe("diffview.actions.cycle_layout cycling logic", function()
       local view = mock_diff_view({}, file)
       view.files.conflicting = { file }
 
-      stub(lib, "get_current_view", function() return view end)
-      stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+      stub(lib, "get_current_view", function()
+        return view
+      end)
+      stub(vim.api, "nvim_win_get_cursor", function()
+        return { 1, 0 }
+      end)
 
       actions.cycle_layout()
 
@@ -348,8 +388,12 @@ describe("diffview.actions.cycle_layout cycling logic", function()
     local file3 = mock_file_entry(Diff2Hor)
     local view = mock_diff_view({ file1, file2, file3 }, file1)
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     actions.cycle_layout()
 
@@ -390,11 +434,17 @@ describe("diffview.actions.cycle_layout with custom config", function()
   local function mock_diff_view(files, cur_entry)
     return {
       class = DiffView_class,
-      instanceof = function(self, other) return self.class == other end,
+      instanceof = function(self, other)
+        return self.class == other
+      end,
       cur_entry = cur_entry,
       cur_layout = {
-        get_main_win = function() return { id = 1 } end,
-        is_focused = function() return false end,
+        get_main_win = function()
+          return { id = 1 }
+        end,
+        is_focused = function()
+          return false
+        end,
         sync_scroll = function() end,
       },
       panel = {
@@ -442,8 +492,12 @@ describe("diffview.actions.cycle_layout with custom config", function()
     local file = mock_file_entry(Diff1)
     local view = mock_diff_view({ file }, file)
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     actions.cycle_layout()
 
@@ -495,8 +549,12 @@ describe("diffview.actions.cycle_layout with custom config", function()
     local file = mock_file_entry(Diff3Hor) -- not in the default cycle
     local view = mock_diff_view({ file }, file)
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     actions.cycle_layout()
 
@@ -524,8 +582,12 @@ describe("diffview.actions.cycle_layout with custom config", function()
     local file = mock_file_entry(Diff2Hor)
     local view = mock_diff_view({ file }, file)
 
-    stub(lib, "get_current_view", function() return view end)
-    stub(vim.api, "nvim_win_get_cursor", function() return { 1, 0 } end)
+    stub(lib, "get_current_view", function()
+      return view
+    end)
+    stub(vim.api, "nvim_win_get_cursor", function()
+      return { 1, 0 }
+    end)
 
     actions.cycle_layout()
 

--- a/lua/diffview/tests/functional/debounce_spec.lua
+++ b/lua/diffview/tests/functional/debounce_spec.lua
@@ -6,166 +6,196 @@ local await = async.await
 
 describe("diffview.debounce", function()
   describe("debounce_trailing", function()
-    it("eventually fires the debounced function", test_utils.async_test(function()
-      local fired = false
-      local fn = debounce.debounce_trailing(10, false, function()
-        fired = true
+    it(
+      "eventually fires the debounced function",
+      test_utils.async_test(function()
+        local fired = false
+        local fn = debounce.debounce_trailing(10, false, function()
+          fired = true
+        end)
+
+        fn()
+
+        await(async.timeout(50))
+        await(async.scheduler())
+
+        assert.is_true(fired)
+        fn.close()
       end)
+    )
 
-      fn()
+    it(
+      "runs callback inside the main loop",
+      test_utils.async_test(function()
+        local in_fast_event = true
+        local fn = debounce.debounce_trailing(10, false, function()
+          in_fast_event = vim.in_fast_event()
+        end)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        fn()
 
-      assert.is_true(fired)
-      fn.close()
-    end))
+        await(async.timeout(50))
+        await(async.scheduler())
 
-    it("runs callback inside the main loop", test_utils.async_test(function()
-      local in_fast_event = true
-      local fn = debounce.debounce_trailing(10, false, function()
-        in_fast_event = vim.in_fast_event()
+        assert.is_false(in_fast_event)
+        fn.close()
       end)
+    )
 
-      fn()
+    it(
+      "cancel drops a pending trailing call",
+      test_utils.async_test(function()
+        local count = 0
+        local fn = debounce.debounce_trailing(10, false, function()
+          count = count + 1
+        end)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        fn()
+        fn.cancel()
 
-      assert.is_false(in_fast_event)
-      fn.close()
-    end))
+        await(async.timeout(50))
+        await(async.scheduler())
 
-    it("cancel drops a pending trailing call", test_utils.async_test(function()
-      local count = 0
-      local fn = debounce.debounce_trailing(10, false, function()
-        count = count + 1
+        assert.equals(0, count)
+        fn.close()
       end)
+    )
 
-      fn()
-      fn.cancel()
+    it(
+      "can be re-scheduled after cancel",
+      test_utils.async_test(function()
+        local count = 0
+        local fn = debounce.debounce_trailing(10, false, function()
+          count = count + 1
+        end)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        fn()
+        fn.cancel()
 
-      assert.equals(0, count)
-      fn.close()
-    end))
+        await(async.timeout(30))
+        await(async.scheduler())
+        assert.equals(0, count)
 
-    it("can be re-scheduled after cancel", test_utils.async_test(function()
-      local count = 0
-      local fn = debounce.debounce_trailing(10, false, function()
-        count = count + 1
+        fn()
+
+        await(async.timeout(50))
+        await(async.scheduler())
+        assert.equals(1, count)
+
+        fn.close()
       end)
-
-      fn()
-      fn.cancel()
-
-      await(async.timeout(30))
-      await(async.scheduler())
-      assert.equals(0, count)
-
-      fn()
-
-      await(async.timeout(50))
-      await(async.scheduler())
-      assert.equals(1, count)
-
-      fn.close()
-    end))
+    )
   end)
 
   describe("throttle_trailing", function()
-    it("fires after the throttle interval", test_utils.async_test(function()
-      local fired = false
-      local fn = debounce.throttle_trailing(10, false, function()
-        fired = true
+    it(
+      "fires after the throttle interval",
+      test_utils.async_test(function()
+        local fired = false
+        local fn = debounce.throttle_trailing(10, false, function()
+          fired = true
+        end)
+
+        fn()
+
+        await(async.timeout(50))
+        await(async.scheduler())
+
+        assert.is_true(fired)
+        fn.close()
       end)
+    )
 
-      fn()
+    it(
+      "runs callback inside the main loop",
+      test_utils.async_test(function()
+        local in_fast_event = true
+        local fn = debounce.throttle_trailing(10, false, function()
+          in_fast_event = vim.in_fast_event()
+        end)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        fn()
 
-      assert.is_true(fired)
-      fn.close()
-    end))
+        await(async.timeout(50))
+        await(async.scheduler())
 
-    it("runs callback inside the main loop", test_utils.async_test(function()
-      local in_fast_event = true
-      local fn = debounce.throttle_trailing(10, false, function()
-        in_fast_event = vim.in_fast_event()
+        assert.is_false(in_fast_event)
+        fn.close()
       end)
-
-      fn()
-
-      await(async.timeout(50))
-      await(async.scheduler())
-
-      assert.is_false(in_fast_event)
-      fn.close()
-    end))
+    )
   end)
 
   describe("set_timeout", function()
-    it("fires callback after the delay", test_utils.async_test(function()
-      local fired = false
+    it(
+      "fires callback after the delay",
+      test_utils.async_test(function()
+        local fired = false
 
-      local handle = debounce.set_timeout(function()
-        fired = true
-      end, 10)
+        local handle = debounce.set_timeout(function()
+          fired = true
+        end, 10)
 
-      assert.is_false(fired)
+        assert.is_false(fired)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        await(async.timeout(50))
+        await(async.scheduler())
 
-      assert.is_true(fired)
-      handle.close()
-    end))
+        assert.is_true(fired)
+        handle.close()
+      end)
+    )
 
-    it("runs callback inside the main loop", test_utils.async_test(function()
-      local in_fast_event = true
+    it(
+      "runs callback inside the main loop",
+      test_utils.async_test(function()
+        local in_fast_event = true
 
-      local handle = debounce.set_timeout(function()
-        in_fast_event = vim.in_fast_event()
-      end, 10)
+        local handle = debounce.set_timeout(function()
+          in_fast_event = vim.in_fast_event()
+        end, 10)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        await(async.timeout(50))
+        await(async.scheduler())
 
-      assert.is_false(in_fast_event)
-      handle.close()
-    end))
+        assert.is_false(in_fast_event)
+        handle.close()
+      end)
+    )
   end)
 
   describe("set_interval", function()
-    it("fires callback multiple times", test_utils.async_test(function()
-      local count = 0
+    it(
+      "fires callback multiple times",
+      test_utils.async_test(function()
+        local count = 0
 
-      local handle = debounce.set_interval(function()
-        count = count + 1
-      end, 10)
+        local handle = debounce.set_interval(function()
+          count = count + 1
+        end, 10)
 
-      await(async.timeout(80))
-      await(async.scheduler())
+        await(async.timeout(80))
+        await(async.scheduler())
 
-      assert.is_true(count >= 2)
-      handle.close()
-    end))
+        assert.is_true(count >= 2)
+        handle.close()
+      end)
+    )
 
-    it("runs callback inside the main loop", test_utils.async_test(function()
-      local in_fast_event = true
+    it(
+      "runs callback inside the main loop",
+      test_utils.async_test(function()
+        local in_fast_event = true
 
-      local handle = debounce.set_interval(function()
-        in_fast_event = vim.in_fast_event()
-      end, 10)
+        local handle = debounce.set_interval(function()
+          in_fast_event = vim.in_fast_event()
+        end, 10)
 
-      await(async.timeout(50))
-      await(async.scheduler())
+        await(async.timeout(50))
+        await(async.scheduler())
 
-      assert.is_false(in_fast_event)
-      handle.close()
-    end))
+        assert.is_false(in_fast_event)
+        handle.close()
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/diff_view_spec.lua
+++ b/lua/diffview/tests/functional/diff_view_spec.lua
@@ -48,7 +48,9 @@ local function cleanup_repo(repo)
 end
 
 local function close_view(view)
-  if not view then return end
+  if not view then
+    return
+  end
   if view.tabpage and api.nvim_tabpage_is_valid(view.tabpage) then
     view:close()
   end
@@ -84,7 +86,8 @@ describe("diffview.scene.views.diff.DiffView", function()
     -- HEAD-tracking refresh, so committing while such a view stayed open
     -- left `self.left` pinned to the stale HEAD and the file diff was
     -- computed against the wrong base.
-    it("refreshes left when track_head is set and HEAD moves, even when right is STAGE",
+    it(
+      "refreshes left when track_head is set and HEAD moves, even when right is STAGE",
       test_utils.async_test(function()
         local repo = make_repo()
         local view
@@ -99,12 +102,18 @@ describe("diffview.scene.views.diff.DiffView", function()
             left = Rev(RevType.COMMIT, initial_head, true),
             right = Rev(RevType.STAGE, 0),
             files = make_files(),
-            update_files = function() return make_files() end,
-            get_file_data = function() return {} end,
+            update_files = function()
+              return make_files()
+            end,
+            get_file_data = function()
+              return {}
+            end,
           })
 
           view:open()
-          vim.wait(2000, function() return view.initialized end, 10)
+          vim.wait(2000, function()
+            return view.initialized
+          end, 10)
           eq(initial_head, view.left.commit)
 
           -- Advance HEAD by committing a new file outside the view.
@@ -119,14 +128,19 @@ describe("diffview.scene.views.diff.DiffView", function()
           -- Trigger a refresh; the track_head block in update_files must
           -- pick up the new HEAD.
           view:update_files()
-          vim.wait(2000, function() return view.left.commit == new_head end, 10)
+          vim.wait(2000, function()
+            return view.left.commit == new_head
+          end, 10)
 
           eq(new_head, view.left.commit)
         end)
 
         close_view(view)
         cleanup_repo(repo)
-        if not ok then error(err) end
-      end))
+        if not ok then
+          error(err)
+        end
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/event_emitter_spec.lua
+++ b/lua/diffview/tests/functional/event_emitter_spec.lua
@@ -160,8 +160,10 @@ describe("diffview.events", function()
       view:close()
 
       -- The on_any listener should have seen "view_closed".
-      assert(vim.tbl_contains(any_events, "view_closed"),
-        "on_any listener should see view_closed event")
+      assert(
+        vim.tbl_contains(any_events, "view_closed"),
+        "on_any listener should see view_closed event"
+      )
 
       -- No listeners should remain on the global emitter.
       eq(0, #(DiffviewGlobal.emitter:get("view_closed") or {}))
@@ -246,25 +248,28 @@ describe("diffview.events", function()
       eq(false, view_closed)
     end)
 
-    it("sub-panel listener registered BEFORE view listener does NOT stop propagation in time", function()
-      local emitter = EventEmitter()
-      local view_closed = false
+    it(
+      "sub-panel listener registered BEFORE view listener does NOT stop propagation in time",
+      function()
+        local emitter = EventEmitter()
+        local view_closed = false
 
-      -- Simulate the buggy ordering: sub-panel registered first (pushed to
-      -- position 2), view listener registered second (inserted at position 1).
-      emitter:on("close", function(e)
-        e:stop_propagation()
-      end)
+        -- Simulate the buggy ordering: sub-panel registered first (pushed to
+        -- position 2), view listener registered second (inserted at position 1).
+        emitter:on("close", function(e)
+          e:stop_propagation()
+        end)
 
-      emitter:on("close", function()
-        view_closed = true
-      end)
+        emitter:on("close", function()
+          view_closed = true
+        end)
 
-      emitter:emit("close")
+        emitter:emit("close")
 
-      -- The view listener ran first because it was at position 1; stop_propagation
-      -- came too late. This is the original bug.
-      eq(true, view_closed)
-    end)
+        -- The view listener ran first because it was at position 1; stop_propagation
+        -- came too late. This is the original bug.
+        eq(true, view_closed)
+      end
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/file_diff_view_spec.lua
+++ b/lua/diffview/tests/functional/file_diff_view_spec.lua
@@ -161,7 +161,9 @@ describe("diffview.scene.views.diff.file_diff_view", function()
       })
 
       -- Calling update_files should not error and should not change the file list.
-      assert.has_no.errors(function() view:update_files() end)
+      assert.has_no.errors(function()
+        view:update_files()
+      end)
       eq(1, view.files:len())
 
       os.remove(left)

--- a/lua/diffview/tests/functional/file_entry_spec.lua
+++ b/lua/diffview/tests/functional/file_entry_spec.lua
@@ -13,7 +13,9 @@ describe("diffview.scene.file_entry", function()
     local original_layout = entry.layout
 
     -- Must not error; null entries have no revs.
-    assert.has_no.errors(function() entry:convert_layout(Diff2Hor) end)
+    assert.has_no.errors(function()
+      entry:convert_layout(Diff2Hor)
+    end)
 
     assert.are.equal(original_layout, entry.layout)
   end)
@@ -23,10 +25,18 @@ describe("diffview.scene.file_entry", function()
     local rev = GitRev(RevType.STAGE, 0)
     local file_b = { bufnr = -1 }
     local old_layout = {
-      files = function() return { file_b } end,
-      owned_files = function() return { file_b } end,
-      get_file_for = function(_, sym) return sym == "b" and file_b or nil end,
-      teardown_render = function() teardown_calls = teardown_calls + 1 end,
+      files = function()
+        return { file_b }
+      end,
+      owned_files = function()
+        return { file_b }
+      end,
+      get_file_for = function(_, sym)
+        return sym == "b" and file_b or nil
+      end,
+      teardown_render = function()
+        teardown_calls = teardown_calls + 1
+      end,
     }
 
     local entry = FileEntry({
@@ -42,7 +52,13 @@ describe("diffview.scene.file_entry", function()
 
     local new_layout = {}
     setmetatable(new_layout, {
-      __call = function() return { files = function() return {} end } end,
+      __call = function()
+        return {
+          files = function()
+            return {}
+          end,
+        }
+      end,
     })
 
     entry:convert_layout(new_layout)
@@ -52,12 +68,16 @@ describe("diffview.scene.file_entry", function()
   it("does not treat should_null errors as truthy null markers", function()
     local captured
     local layout_class = setmetatable({
-      should_null = function() error("boom") end,
+      should_null = function()
+        error("boom")
+      end,
     }, {
       __call = function(_, opt)
         captured = opt
         return {
-          files = function() return { opt.b } end,
+          files = function()
+            return { opt.b }
+          end,
         }
       end,
     })
@@ -103,15 +123,13 @@ describe("diffview.scene.file_entry", function()
     it("does not error when merge context entries have nil hashes", function()
       local entry, _, file_stubs = make_entry_with_layout()
 
-      assert.has_no.errors(
-        function()
-          entry:update_merge_context({
-            ours = {},
-            theirs = {},
-            base = {},
-          })
-        end
-      )
+      assert.has_no.errors(function()
+        entry:update_merge_context({
+          ours = {},
+          theirs = {},
+          base = {},
+        })
+      end)
 
       -- Winbars for ours/theirs/base should remain unset.
       assert.is_nil(file_stubs.a.winbar)
@@ -144,15 +162,13 @@ describe("diffview.scene.file_entry", function()
     it("handles a mix of present and missing hashes", function()
       local entry, _, file_stubs = make_entry_with_layout()
 
-      assert.has_no.errors(
-        function()
-          entry:update_merge_context({
-            ours = { hash = "abc123def456" },
-            theirs = {},
-            base = { hash = "def789abc012" },
-          })
-        end
-      )
+      assert.has_no.errors(function()
+        entry:update_merge_context({
+          ours = { hash = "abc123def456" },
+          theirs = {},
+          base = { hash = "def789abc012" },
+        })
+      end)
 
       assert.truthy(file_stubs.a.winbar:find("OURS"))
       assert.is_nil(file_stubs.c.winbar)
@@ -166,16 +182,26 @@ describe("diffview.scene.file_entry", function()
 
     local files_list = {
       {
-        destroy = function(_, force) seen[#seen + 1] = force end,
+        destroy = function(_, force)
+          seen[#seen + 1] = force
+        end,
       },
       {
-        destroy = function(_, force) seen[#seen + 1] = force end,
+        destroy = function(_, force)
+          seen[#seen + 1] = force
+        end,
       },
     }
     local layout = {
-      files = function() return files_list end,
-      owned_files = function() return files_list end,
-      destroy = function() layout_destroyed = true end,
+      files = function()
+        return files_list
+      end,
+      owned_files = function()
+        return files_list
+      end,
+      destroy = function()
+        layout_destroyed = true
+      end,
     }
 
     local entry = FileEntry({

--- a/lua/diffview/tests/functional/file_history_render_spec.lua
+++ b/lua/diffview/tests/functional/file_history_render_spec.lua
@@ -8,7 +8,6 @@ local render_stat_bar = render._test.render_stat_bar
 local render_file_stats = render._test.render_file_stats
 local formatters = render._test.formatters
 
-
 -- ---------------------------------------------------------------------------
 -- Mock RenderComponent
 -- ---------------------------------------------------------------------------
@@ -69,7 +68,9 @@ local function make_file(name)
   return {
     name = name,
     active = false,
-    set_active = function(self, v) self.active = v end,
+    set_active = function(self, v)
+      self.active = v
+    end,
   }
 end
 
@@ -90,9 +91,8 @@ end
 ---@param file_idx integer
 ---@return table
 local function make_panel(entries, entry_idx, file_idx)
-  local FileHistoryPanel = require(
-    "diffview.scene.views.file_history.file_history_panel"
-  ).FileHistoryPanel
+  local FileHistoryPanel =
+    require("diffview.scene.views.file_history.file_history_panel").FileHistoryPanel
 
   local panel = {
     entries = entries,

--- a/lua/diffview/tests/functional/file_spec.lua
+++ b/lua/diffview/tests/functional/file_spec.lua
@@ -43,102 +43,108 @@ describe("diffview.vcs.file", function()
     assert.False(show_called)
   end)
 
-  it("bails out of create_buffer if deactivated before produce_data", helpers.async_test(function()
-    local show_called = false
+  it(
+    "bails out of create_buffer if deactivated before produce_data",
+    helpers.async_test(function()
+      local show_called = false
 
-    local adapter = {
-      ctx = {
-        toplevel = vim.uv.cwd(),
-        dir = vim.uv.cwd(),
-      },
-      is_binary = function()
-        return false
-      end,
-      show = async.wrap(function(_, _, _, callback)
-        show_called = true
-        callback(nil, { "some data" })
-      end),
-    }
+      local adapter = {
+        ctx = {
+          toplevel = vim.uv.cwd(),
+          dir = vim.uv.cwd(),
+        },
+        is_binary = function()
+          return false
+        end,
+        show = async.wrap(function(_, _, _, callback)
+          show_called = true
+          callback(nil, { "some data" })
+        end),
+      }
 
-    local file = File({
-      adapter = adapter,
-      path = "README.md",
-      kind = "working",
-      rev = GitRev(RevType.COMMIT, "abc1234"),
-    })
+      local file = File({
+        adapter = adapter,
+        path = "README.md",
+        kind = "working",
+        rev = GitRev(RevType.COMMIT, "abc1234"),
+      })
 
-    -- Deactivate the file before create_buffer runs.
-    file.active = false
+      -- Deactivate the file before create_buffer runs.
+      file.active = false
 
-    local ok, err = async.pawait(file.create_buffer, file)
+      local ok, err = async.pawait(file.create_buffer, file)
 
-    assert.False(ok)
-    assert.is_string(err)
-    assert.is_not_nil(err:find(File.CANCELLED, 1, true))
-    -- produce_data (and thus show) should never have been called.
-    assert.False(show_called)
-    assert.is_nil(file.bufnr)
-  end))
-
-  it("bails out of create_buffer if deactivated during produce_data", helpers.async_test(function()
-    local yield_signal = Signal("yield")
-    local produce_data_started = Signal("produce_data_started")
-    local show_called = false
-
-    local adapter = {
-      ctx = {
-        toplevel = vim.uv.cwd(),
-        dir = vim.uv.cwd(),
-      },
-      is_binary = function()
-        return false
-      end,
-      show = async.wrap(function(_, _, _, callback)
-        show_called = true
-        produce_data_started:send()
-        async.await(yield_signal)
-        callback(nil, { "some data" })
-      end),
-    }
-
-    local file = File({
-      adapter = adapter,
-      path = "README.md",
-      kind = "working",
-      rev = GitRev(RevType.COMMIT, "abc1234"),
-    })
-
-    -- Capture results from the thread so we can assert outside it.
-    -- Assertions inside async.void coroutines fail silently.
-    local thread_ok, thread_err
-
-    local create_buffer_thread = async.void(function()
-      thread_ok, thread_err = async.pawait(file.create_buffer, file)
+      assert.False(ok)
+      assert.is_string(err)
+      assert.is_not_nil(err:find(File.CANCELLED, 1, true))
+      -- produce_data (and thus show) should never have been called.
+      assert.False(show_called)
+      assert.is_nil(file.bufnr)
     end)
+  )
 
-    create_buffer_thread()
+  it(
+    "bails out of create_buffer if deactivated during produce_data",
+    helpers.async_test(function()
+      local yield_signal = Signal("yield")
+      local produce_data_started = Signal("produce_data_started")
+      local show_called = false
 
-    -- Wait for produce_data to start, confirming the show job was invoked.
-    async.await(produce_data_started)
-    assert.is_not_nil(file.bufnr)
-    assert.is_true(vim.api.nvim_buf_is_valid(file.bufnr))
-    local pre_cancel_bufnr = file.bufnr
+      local adapter = {
+        ctx = {
+          toplevel = vim.uv.cwd(),
+          dir = vim.uv.cwd(),
+        },
+        is_binary = function()
+          return false
+        end,
+        show = async.wrap(function(_, _, _, callback)
+          show_called = true
+          produce_data_started:send()
+          async.await(yield_signal)
+          callback(nil, { "some data" })
+        end),
+      }
 
-    -- Deactivate the file while produce_data is yielded, then resume it.
-    file.active = false
-    yield_signal:send()
+      local file = File({
+        adapter = adapter,
+        path = "README.md",
+        kind = "working",
+        rev = GitRev(RevType.COMMIT, "abc1234"),
+      })
 
-    -- Let the thread finish.
-    async.await(async.scheduler())
+      -- Capture results from the thread so we can assert outside it.
+      -- Assertions inside async.void coroutines fail silently.
+      local thread_ok, thread_err
 
-    -- The pre-allocated buffer should have been cleaned up.
-    assert.is_true(show_called)
-    assert.False(thread_ok)
-    assert.is_string(thread_err)
-    assert.is_not_nil(thread_err:find(File.CANCELLED, 1, true))
-    assert.is_nil(file.bufnr)
-    assert.is_false(vim.api.nvim_buf_is_valid(pre_cancel_bufnr))
-  end))
+      local create_buffer_thread = async.void(function()
+        thread_ok, thread_err = async.pawait(file.create_buffer, file)
+      end)
+
+      create_buffer_thread()
+
+      -- Wait for produce_data to start, confirming the show job was invoked.
+      async.await(produce_data_started)
+      assert.is_not_nil(file.bufnr)
+      assert.is_true(vim.api.nvim_buf_is_valid(file.bufnr))
+      local pre_cancel_bufnr = file.bufnr
+
+      -- Deactivate the file while produce_data is yielded, then resume it.
+      file.active = false
+      yield_signal:send()
+
+      -- Let the thread finish.
+      async.await(async.scheduler())
+
+      -- The pre-allocated buffer should have been cleaned up.
+      assert.is_true(show_called)
+      assert.False(thread_ok)
+      assert.is_string(thread_err)
+      assert.is_not_nil(thread_err:find(File.CANCELLED, 1, true))
+      assert.is_nil(file.bufnr)
+      assert.is_false(vim.api.nvim_buf_is_valid(pre_cancel_bufnr))
+    end)
+  )
 
   describe("diffview:// buffer guards", function()
     local file_counter = 0
@@ -180,59 +186,68 @@ describe("diffview.vcs.file", function()
       created_files = {}
     end)
 
-    it("sets autoformat=false on diffview:// buffers", helpers.async_test(function()
-      local file = make_commit_file()
-      async.await(file:create_buffer())
+    it(
+      "sets autoformat=false on diffview:// buffers",
+      helpers.async_test(function()
+        local file = make_commit_file()
+        async.await(file:create_buffer())
 
-      assert.is_not_nil(file.bufnr)
-      assert.is_false(vim.b[file.bufnr].autoformat)
-    end))
+        assert.is_not_nil(file.bufnr)
+        assert.is_false(vim.b[file.bufnr].autoformat)
+      end)
+    )
 
-    it("registers an LspAttach autocmd on diffview:// buffers", helpers.async_test(function()
-      local file = make_commit_file()
-      async.await(file:create_buffer())
+    it(
+      "registers an LspAttach autocmd on diffview:// buffers",
+      helpers.async_test(function()
+        local file = make_commit_file()
+        async.await(file:create_buffer())
 
-      assert.is_not_nil(file.bufnr)
-      local aus = vim.api.nvim_get_autocmds({ event = "LspAttach", buffer = file.bufnr })
-      assert.is_true(#aus > 0)
-    end))
+        assert.is_not_nil(file.bufnr)
+        local aus = vim.api.nvim_get_autocmds({ event = "LspAttach", buffer = file.bufnr })
+        assert.is_true(#aus > 0)
+      end)
+    )
 
-    it("sets buftype=acwrite on stage-0 diffview:// buffers", helpers.async_test(function()
-      file_counter = file_counter + 1
+    it(
+      "sets buftype=acwrite on stage-0 diffview:// buffers",
+      helpers.async_test(function()
+        file_counter = file_counter + 1
 
-      local adapter = {
-        ctx = {
-          toplevel = vim.uv.cwd(),
-          dir = vim.uv.cwd(),
-        },
-        is_binary = function()
-          return false
-        end,
-        show = async.wrap(function(_, _, _, callback)
-          callback(nil, { "line1", "line2" })
-        end),
-        file_blob_hash = function()
-          return "abcdef1234"
-        end,
-      }
+        local adapter = {
+          ctx = {
+            toplevel = vim.uv.cwd(),
+            dir = vim.uv.cwd(),
+          },
+          is_binary = function()
+            return false
+          end,
+          show = async.wrap(function(_, _, _, callback)
+            callback(nil, { "line1", "line2" })
+          end),
+          file_blob_hash = function()
+            return "abcdef1234"
+          end,
+        }
 
-      local file = File({
-        adapter = adapter,
-        path = "test_guard_" .. file_counter .. ".c",
-        kind = "working",
-        rev = GitRev(RevType.STAGE, 0),
-      })
-      table.insert(created_files, file)
+        local file = File({
+          adapter = adapter,
+          path = "test_guard_" .. file_counter .. ".c",
+          kind = "working",
+          rev = GitRev(RevType.STAGE, 0),
+        })
+        table.insert(created_files, file)
 
-      async.await(file:create_buffer())
+        async.await(file:create_buffer())
 
-      assert.is_not_nil(file.bufnr)
-      -- Stage-0 buffers write via BufWriteCmd, so buftype must be "acwrite"
-      -- rather than "" to prevent LSP clients and plugins (e.g. LazyVim)
-      -- from treating them as normal files.
-      assert.equals("acwrite", vim.bo[file.bufnr].buftype)
-      assert.is_true(vim.bo[file.bufnr].modifiable)
-    end))
+        assert.is_not_nil(file.bufnr)
+        -- Stage-0 buffers write via BufWriteCmd, so buftype must be "acwrite"
+        -- rather than "" to prevent LSP clients and plugins (e.g. LazyVim)
+        -- from treating them as normal files.
+        assert.equals("acwrite", vim.bo[file.bufnr].buftype)
+        assert.is_true(vim.bo[file.bufnr].modifiable)
+      end)
+    )
 
     describe("large_file_threshold", function()
       local original_config
@@ -248,66 +263,76 @@ describe("diffview.vcs.file", function()
         end
       end)
 
-      it("sets diffview_disable_ts flag when buffer exceeds threshold", helpers.async_test(function()
-        config.setup({ large_file_threshold = 5 })
+      it(
+        "sets diffview_disable_ts flag when buffer exceeds threshold",
+        helpers.async_test(function()
+          config.setup({ large_file_threshold = 5 })
 
-        local lines = {}
-        for i = 1, 10 do
-          lines[i] = "line " .. i
-        end
+          local lines = {}
+          for i = 1, 10 do
+            lines[i] = "line " .. i
+          end
 
-        file_counter = file_counter + 1
-        local adapter = {
-          ctx = {
-            toplevel = vim.uv.cwd(),
-            dir = vim.uv.cwd(),
-          },
-          is_binary = function() return false end,
-          show = async.wrap(function(_, _, _, callback)
-            callback(nil, lines)
-          end),
-        }
+          file_counter = file_counter + 1
+          local adapter = {
+            ctx = {
+              toplevel = vim.uv.cwd(),
+              dir = vim.uv.cwd(),
+            },
+            is_binary = function()
+              return false
+            end,
+            show = async.wrap(function(_, _, _, callback)
+              callback(nil, lines)
+            end),
+          }
 
-        local file = File({
-          adapter = adapter,
-          path = "test_large_" .. file_counter .. ".txt",
-          kind = "working",
-          rev = GitRev(RevType.COMMIT, "abc1234"),
-        })
-        table.insert(created_files, file)
-        async.await(file:create_buffer())
+          local file = File({
+            adapter = adapter,
+            path = "test_large_" .. file_counter .. ".txt",
+            kind = "working",
+            rev = GitRev(RevType.COMMIT, "abc1234"),
+          })
+          table.insert(created_files, file)
+          async.await(file:create_buffer())
 
-        assert.is_not_nil(file.bufnr)
-        assert.is_true(vim.b[file.bufnr].diffview_disable_ts)
-      end))
+          assert.is_not_nil(file.bufnr)
+          assert.is_true(vim.b[file.bufnr].diffview_disable_ts)
+        end)
+      )
 
-      it("does not set diffview_disable_ts flag when buffer is under threshold", helpers.async_test(function()
-        config.setup({ large_file_threshold = 100 })
+      it(
+        "does not set diffview_disable_ts flag when buffer is under threshold",
+        helpers.async_test(function()
+          config.setup({ large_file_threshold = 100 })
 
-        file_counter = file_counter + 1
-        local adapter = {
-          ctx = {
-            toplevel = vim.uv.cwd(),
-            dir = vim.uv.cwd(),
-          },
-          is_binary = function() return false end,
-          show = async.wrap(function(_, _, _, callback)
-            callback(nil, { "line1", "line2" })
-          end),
-        }
+          file_counter = file_counter + 1
+          local adapter = {
+            ctx = {
+              toplevel = vim.uv.cwd(),
+              dir = vim.uv.cwd(),
+            },
+            is_binary = function()
+              return false
+            end,
+            show = async.wrap(function(_, _, _, callback)
+              callback(nil, { "line1", "line2" })
+            end),
+          }
 
-        local file = File({
-          adapter = adapter,
-          path = "test_small_" .. file_counter .. ".txt",
-          kind = "working",
-          rev = GitRev(RevType.COMMIT, "abc1234"),
-        })
-        table.insert(created_files, file)
-        async.await(file:create_buffer())
+          local file = File({
+            adapter = adapter,
+            path = "test_small_" .. file_counter .. ".txt",
+            kind = "working",
+            rev = GitRev(RevType.COMMIT, "abc1234"),
+          })
+          table.insert(created_files, file)
+          async.await(file:create_buffer())
 
-        assert.is_not_nil(file.bufnr)
-        assert.is_nil(vim.b[file.bufnr].diffview_disable_ts)
-      end))
+          assert.is_not_nil(file.bufnr)
+          assert.is_nil(vim.b[file.bufnr].diffview_disable_ts)
+        end)
+      )
     end)
   end)
 end)

--- a/lua/diffview/tests/functional/focus_diff_spec.lua
+++ b/lua/diffview/tests/functional/focus_diff_spec.lua
@@ -104,7 +104,6 @@ describe("DiffView._should_focus_diff", function()
     local view = { initialized = true }
     assert.is_false(DiffView._should_focus_diff(view, { kind = "working" }))
   end)
-
 end)
 
 describe("DiffView selected_row focuses main window", function()
@@ -132,11 +131,21 @@ describe("DiffView selected_row focuses main window", function()
     local cursor_set = nil
     local main_win_id = 77
 
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.api.nvim_set_current_win = function(id) focused_win = id end
-    vim.api.nvim_win_get_buf = function() return 1 end
-    vim.api.nvim_buf_line_count = function() return 100 end
-    vim.api.nvim_win_set_cursor = function(id, pos) cursor_set = { id = id, pos = pos } end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.api.nvim_set_current_win = function(id)
+      focused_win = id
+    end
+    vim.api.nvim_win_get_buf = function()
+      return 1
+    end
+    vim.api.nvim_buf_line_count = function()
+      return 100
+    end
+    vim.api.nvim_win_set_cursor = function(id, pos)
+      cursor_set = { id = id, pos = pos }
+    end
 
     -- Simulate the selected_row block from update_files.
     local initialized = false
@@ -166,16 +175,26 @@ describe("DiffView selected_row focuses main window", function()
   it("clamps row to buffer line count", function()
     local cursor_set = nil
 
-    vim.api.nvim_win_is_valid = function() return true end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
     vim.api.nvim_set_current_win = function() end
-    vim.api.nvim_win_get_buf = function() return 1 end
-    vim.api.nvim_buf_line_count = function() return 10 end
-    vim.api.nvim_win_set_cursor = function(id, pos) cursor_set = { id = id, pos = pos } end
+    vim.api.nvim_win_get_buf = function()
+      return 1
+    end
+    vim.api.nvim_buf_line_count = function()
+      return 10
+    end
+    vim.api.nvim_win_set_cursor = function(id, pos)
+      cursor_set = { id = id, pos = pos }
+    end
 
     local initialized = false
     local selected_row = 999
     local cur_layout = {
-      get_main_win = function() return { id = 1 } end,
+      get_main_win = function()
+        return { id = 1 }
+      end,
     }
 
     if not initialized and selected_row then

--- a/lua/diffview/tests/functional/fold_limit_spec.lua
+++ b/lua/diffview/tests/functional/fold_limit_spec.lua
@@ -40,7 +40,9 @@ describe("fold limit removal (a67a808, fc62484)", function()
 
     local adapter = {
       ctx = { toplevel = vim.uv.cwd(), dir = vim.uv.cwd() },
-      is_binary = function() return false end,
+      is_binary = function()
+        return false
+      end,
     }
 
     local file = File({

--- a/lua/diffview/tests/functional/git_adapter_spec.lua
+++ b/lua/diffview/tests/functional/git_adapter_spec.lua
@@ -42,213 +42,179 @@ end
 
 describe("diffview.vcs.adapters.git", function()
   describe("get_show_args", function()
-    it("includes --no-show-signature", test_utils.async_test(function()
-      local repo, adapter = make_repo_and_adapter()
+    it(
+      "includes --no-show-signature",
+      test_utils.async_test(function()
+        local repo, adapter = make_repo_and_adapter()
 
-      local ok, err = pcall(function()
-        local head = run({ "git", "rev-parse", "HEAD" }, repo)
-        local rev = GitRev(RevType.COMMIT, head)
-        local args = adapter:get_show_args("init.txt", rev)
+        local ok, err = pcall(function()
+          local head = run({ "git", "rev-parse", "HEAD" }, repo)
+          local rev = GitRev(RevType.COMMIT, head)
+          local args = adapter:get_show_args("init.txt", rev)
 
-        local found = false
-        for _, arg in ipairs(args) do
-          if arg == "--no-show-signature" then
-            found = true
-            break
+          local found = false
+          for _, arg in ipairs(args) do
+            if arg == "--no-show-signature" then
+              found = true
+              break
+            end
           end
+
+          assert.True(found, "get_show_args must include --no-show-signature")
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
         end
-
-        assert.True(found, "get_show_args must include --no-show-signature")
       end)
+    )
 
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
+    it(
+      "includes --no-show-signature when rev is nil",
+      test_utils.async_test(function()
+        local repo, adapter = make_repo_and_adapter()
 
-      if not ok then error(err) end
-    end))
+        local ok, err = pcall(function()
+          local args = adapter:get_show_args("init.txt", nil)
 
-    it("includes --no-show-signature when rev is nil", test_utils.async_test(function()
-      local repo, adapter = make_repo_and_adapter()
-
-      local ok, err = pcall(function()
-        local args = adapter:get_show_args("init.txt", nil)
-
-        local found = false
-        for _, arg in ipairs(args) do
-          if arg == "--no-show-signature" then
-            found = true
-            break
+          local found = false
+          for _, arg in ipairs(args) do
+            if arg == "--no-show-signature" then
+              found = true
+              break
+            end
           end
+
+          assert.True(found, "get_show_args must include --no-show-signature even with nil rev")
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
         end
-
-        assert.True(found, "get_show_args must include --no-show-signature even with nil rev")
       end)
-
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
+    )
   end)
 
   describe("get_log_args", function()
-    it("includes --no-show-signature", test_utils.async_test(function()
-      local repo, adapter = make_repo_and_adapter()
+    it(
+      "includes --no-show-signature",
+      test_utils.async_test(function()
+        local repo, adapter = make_repo_and_adapter()
 
-      local ok, err = pcall(function()
-        local args = adapter:get_log_args({})
+        local ok, err = pcall(function()
+          local args = adapter:get_log_args({})
 
-        local found = false
-        for _, arg in ipairs(args) do
-          if arg == "--no-show-signature" then
-            found = true
-            break
+          local found = false
+          for _, arg in ipairs(args) do
+            if arg == "--no-show-signature" then
+              found = true
+              break
+            end
           end
+
+          assert.True(found, "get_log_args must include --no-show-signature")
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
         end
-
-        assert.True(found, "get_log_args must include --no-show-signature")
       end)
-
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
+    )
   end)
 
   describe("show_untracked", function()
-    it("returns true when left is STAGE and right is LOCAL", test_utils.async_test(function()
-      local repo, adapter = make_repo_and_adapter()
+    it(
+      "returns true when left is STAGE and right is LOCAL",
+      test_utils.async_test(function()
+        local repo, adapter = make_repo_and_adapter()
 
-      local ok, err = pcall(function()
-        local left = GitRev(RevType.STAGE, 0)
-        local right = GitRev(RevType.LOCAL)
-        local result = adapter:show_untracked({ revs = { left = left, right = right } })
-        assert.is_true(result)
+        local ok, err = pcall(function()
+          local left = GitRev(RevType.STAGE, 0)
+          local right = GitRev(RevType.LOCAL)
+          local result = adapter:show_untracked({ revs = { left = left, right = right } })
+          assert.is_true(result)
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
+        end
       end)
+    )
 
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
+    it(
+      "returns false when left is COMMIT and right is LOCAL",
+      test_utils.async_test(function()
+        local repo, adapter = make_repo_and_adapter()
+
+        local ok, err = pcall(function()
+          local head = run({ "git", "rev-parse", "HEAD" }, repo)
+          local left = GitRev(RevType.COMMIT, head)
+          local right = GitRev(RevType.LOCAL)
+          local result = adapter:show_untracked({ revs = { left = left, right = right } })
+          assert.is_false(result)
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
+        end
       end)
-      async.await(async.scheduler())
+    )
 
-      if not ok then error(err) end
-    end))
+    it(
+      "returns false when user config show_untracked is false (STAGE vs LOCAL)",
+      test_utils.async_test(function()
+        local repo, adapter = make_repo_and_adapter()
 
-    it("returns false when left is COMMIT and right is LOCAL", test_utils.async_test(function()
-      local repo, adapter = make_repo_and_adapter()
+        local ok, err = pcall(function()
+          local left = GitRev(RevType.STAGE, 0)
+          local right = GitRev(RevType.LOCAL)
+          local result = adapter:show_untracked({
+            revs = { left = left, right = right },
+            dv_opt = { show_untracked = false },
+          })
+          assert.is_false(result)
+        end)
 
-      local ok, err = pcall(function()
-        local head = run({ "git", "rev-parse", "HEAD" }, repo)
-        local left = GitRev(RevType.COMMIT, head)
-        local right = GitRev(RevType.LOCAL)
-        local result = adapter:show_untracked({ revs = { left = left, right = right } })
-        assert.is_false(result)
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
+        end
       end)
-
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
-
-    it("returns false when user config show_untracked is false (STAGE vs LOCAL)", test_utils.async_test(function()
-      local repo, adapter = make_repo_and_adapter()
-
-      local ok, err = pcall(function()
-        local left = GitRev(RevType.STAGE, 0)
-        local right = GitRev(RevType.LOCAL)
-        local result = adapter:show_untracked({
-          revs = { left = left, right = right },
-          dv_opt = { show_untracked = false },
-        })
-        assert.is_false(result)
-      end)
-
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
+    )
   end)
 
-  it("handles LOCAL..COMMIT binary stats without crashing", test_utils.async_test(function()
-    local repo = vim.fn.tempname()
-    assert.equals(1, vim.fn.mkdir(repo, "p"))
-
-    local ok, err = pcall(function()
-      run({ "git", "init", "-q" }, repo)
-      run({ "git", "config", "user.name", "Diffview Test" }, repo)
-      run({ "git", "config", "user.email", "diffview@test.local" }, repo)
-
-      local path = repo .. "/bin.dat"
-      local f = assert(io.open(path, "wb"))
-      f:write(string.char(0, 1, 2, 3))
-      f:close()
-
-      run({ "git", "add", "bin.dat" }, repo)
-      run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "init" }, repo)
-
-      f = assert(io.open(path, "wb"))
-      f:write(string.char(0, 1, 9, 3))
-      f:close()
-
-      local adapter = GitAdapter({
-        toplevel = repo,
-        cpath = repo,
-        path_args = {},
-      })
-
-      local head = run({ "git", "rev-parse", "HEAD" }, repo)
-      local left = GitRev(RevType.LOCAL)
-      local right = GitRev(RevType.COMMIT, head)
-      local args = adapter:rev_to_args(left, right)
-
-      local tracked_err, files = async.await(adapter:tracked_files(
-        left,
-        right,
-        args,
-        "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
-
-      assert.is_nil(tracked_err)
-      assert.is_true(#files > 0)
-
-      local found = false
-      for _, file in ipairs(files) do
-        if file.path == "bin.dat" then
-          found = true
-          assert.is_nil(file.stats)
-        end
-      end
-
-      assert.True(found)
-    end)
-
-    vim.schedule(function()
-      pcall(vim.fn.delete, repo, "rf")
-    end)
-    async.await(async.scheduler())
-
-    if not ok then error(err) end
-  end))
-
-  describe("merge-base failure during rebase --root", function()
-    it("falls back to NULL_TREE_SHA when merge-base fails", test_utils.async_test(function()
-      -- Simulate an initial-commit rebase scenario where merge-base has no
-      -- common ancestor.  We create two independent repos and graft an orphan
-      -- branch so that "git merge-base" exits non-zero.
+  it(
+    "handles LOCAL..COMMIT binary stats without crashing",
+    test_utils.async_test(function()
       local repo = vim.fn.tempname()
       assert.equals(1, vim.fn.mkdir(repo, "p"))
 
@@ -257,45 +223,51 @@ describe("diffview.vcs.adapters.git", function()
         run({ "git", "config", "user.name", "Diffview Test" }, repo)
         run({ "git", "config", "user.email", "diffview@test.local" }, repo)
 
-        -- Create a commit on the default branch.
-        local path = repo .. "/a.txt"
-        local f = assert(io.open(path, "w"))
-        f:write("a\n")
+        local path = repo .. "/bin.dat"
+        local f = assert(io.open(path, "wb"))
+        f:write(string.char(0, 1, 2, 3))
         f:close()
-        run({ "git", "add", "a.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "first" }, repo)
-        local main_sha = run({ "git", "rev-parse", "HEAD" }, repo)
 
-        -- Create an orphan branch with an unrelated history.  Remove tracked
-        -- files so the index is clean for the orphan commit.
-        run({ "git", "checkout", "--orphan", "orphan" }, repo)
-        run({ "git", "rm", "-rf", "." }, repo)
-        local p2 = repo .. "/b.txt"
-        f = assert(io.open(p2, "w"))
-        f:write("b\n")
+        run({ "git", "add", "bin.dat" }, repo)
+        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "init" }, repo)
+
+        f = assert(io.open(path, "wb"))
+        f:write(string.char(0, 1, 9, 3))
         f:close()
-        run({ "git", "add", "b.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "orphan" }, repo)
-        local orphan_sha = run({ "git", "rev-parse", "HEAD" }, repo)
 
-        -- Confirm that merge-base between the two disjoint roots fails.
-        local mb_result = vim.system(
-          { "git", "merge-base", main_sha, orphan_sha },
-          { cwd = repo, text = true }
-        ):wait()
-        assert.is_not.equal(0, mb_result.code, "merge-base should fail for disjoint histories")
+        local adapter = GitAdapter({
+          toplevel = repo,
+          cpath = repo,
+          path_args = {},
+        })
 
-        -- Verify that NULL_TREE_SHA is the expected fallback constant.
-        assert.equals(
-          "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
-          GitRev.NULL_TREE_SHA,
-          "NULL_TREE_SHA must be the canonical git empty tree"
+        local head = run({ "git", "rev-parse", "HEAD" }, repo)
+        local left = GitRev(RevType.LOCAL)
+        local right = GitRev(RevType.COMMIT, head)
+        local args = adapter:rev_to_args(left, right)
+
+        local tracked_err, files = async.await(
+          adapter:tracked_files(
+            left,
+            right,
+            args,
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
         )
 
-        -- Verify that a null-tree rev can be constructed from the constant.
-        local null_rev = GitRev.new_null_tree()
-        assert.equals(RevType.COMMIT, null_rev.type)
-        assert.equals(GitRev.NULL_TREE_SHA, null_rev:object_name())
+        assert.is_nil(tracked_err)
+        assert.is_true(#files > 0)
+
+        local found = false
+        for _, file in ipairs(files) do
+          if file.path == "bin.dat" then
+            found = true
+            assert.is_nil(file.stats)
+          end
+        end
+
+        assert.True(found)
       end)
 
       vim.schedule(function()
@@ -303,128 +275,207 @@ describe("diffview.vcs.adapters.git", function()
       end)
       async.await(async.scheduler())
 
-      if not ok then error(err) end
-    end))
+      if not ok then
+        error(err)
+      end
+    end)
+  )
+
+  describe("merge-base failure during rebase --root", function()
+    it(
+      "falls back to NULL_TREE_SHA when merge-base fails",
+      test_utils.async_test(function()
+        -- Simulate an initial-commit rebase scenario where merge-base has no
+        -- common ancestor.  We create two independent repos and graft an orphan
+        -- branch so that "git merge-base" exits non-zero.
+        local repo = vim.fn.tempname()
+        assert.equals(1, vim.fn.mkdir(repo, "p"))
+
+        local ok, err = pcall(function()
+          run({ "git", "init", "-q" }, repo)
+          run({ "git", "config", "user.name", "Diffview Test" }, repo)
+          run({ "git", "config", "user.email", "diffview@test.local" }, repo)
+
+          -- Create a commit on the default branch.
+          local path = repo .. "/a.txt"
+          local f = assert(io.open(path, "w"))
+          f:write("a\n")
+          f:close()
+          run({ "git", "add", "a.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "first" }, repo)
+          local main_sha = run({ "git", "rev-parse", "HEAD" }, repo)
+
+          -- Create an orphan branch with an unrelated history.  Remove tracked
+          -- files so the index is clean for the orphan commit.
+          run({ "git", "checkout", "--orphan", "orphan" }, repo)
+          run({ "git", "rm", "-rf", "." }, repo)
+          local p2 = repo .. "/b.txt"
+          f = assert(io.open(p2, "w"))
+          f:write("b\n")
+          f:close()
+          run({ "git", "add", "b.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "orphan" }, repo)
+          local orphan_sha = run({ "git", "rev-parse", "HEAD" }, repo)
+
+          -- Confirm that merge-base between the two disjoint roots fails.
+          local mb_result = vim
+            .system({ "git", "merge-base", main_sha, orphan_sha }, { cwd = repo, text = true })
+            :wait()
+          assert.is_not.equal(0, mb_result.code, "merge-base should fail for disjoint histories")
+
+          -- Verify that NULL_TREE_SHA is the expected fallback constant.
+          assert.equals(
+            "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+            GitRev.NULL_TREE_SHA,
+            "NULL_TREE_SHA must be the canonical git empty tree"
+          )
+
+          -- Verify that a null-tree rev can be constructed from the constant.
+          local null_rev = GitRev.new_null_tree()
+          assert.equals(RevType.COMMIT, null_rev.type)
+          assert.equals(GitRev.NULL_TREE_SHA, null_rev:object_name())
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
+        end
+      end)
+    )
   end)
 
   describe("--merge-base option in parse_revs", function()
-    it("uses merge-base when the flag is set", test_utils.async_test(function()
-      local repo = vim.fn.tempname()
-      assert.equals(1, vim.fn.mkdir(repo, "p"))
+    it(
+      "uses merge-base when the flag is set",
+      test_utils.async_test(function()
+        local repo = vim.fn.tempname()
+        assert.equals(1, vim.fn.mkdir(repo, "p"))
 
-      local ok, err = pcall(function()
-        run({ "git", "init", "-q" }, repo)
-        run({ "git", "config", "user.name", "Diffview Test" }, repo)
-        run({ "git", "config", "user.email", "diffview@test.local" }, repo)
+        local ok, err = pcall(function()
+          run({ "git", "init", "-q" }, repo)
+          run({ "git", "config", "user.name", "Diffview Test" }, repo)
+          run({ "git", "config", "user.email", "diffview@test.local" }, repo)
 
-        -- Create two commits on the default branch.
-        local path = repo .. "/a.txt"
-        local f = assert(io.open(path, "w"))
-        f:write("a\n")
-        f:close()
-        run({ "git", "add", "a.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "base" }, repo)
-        local base_sha = run({ "git", "rev-parse", "HEAD" }, repo)
+          -- Create two commits on the default branch.
+          local path = repo .. "/a.txt"
+          local f = assert(io.open(path, "w"))
+          f:write("a\n")
+          f:close()
+          run({ "git", "add", "a.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "base" }, repo)
+          local base_sha = run({ "git", "rev-parse", "HEAD" }, repo)
 
-        -- Create a feature branch diverging from base.
-        run({ "git", "checkout", "-b", "feature" }, repo)
-        f = assert(io.open(path, "w"))
-        f:write("a-feature\n")
-        f:close()
-        run({ "git", "add", "a.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "feature" }, repo)
-        local feature_sha = run({ "git", "rev-parse", "HEAD" }, repo)
+          -- Create a feature branch diverging from base.
+          run({ "git", "checkout", "-b", "feature" }, repo)
+          f = assert(io.open(path, "w"))
+          f:write("a-feature\n")
+          f:close()
+          run({ "git", "add", "a.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "feature" }, repo)
+          local feature_sha = run({ "git", "rev-parse", "HEAD" }, repo)
 
-        -- Advance the default branch so HEAD diverges from the feature branch.
-        run({ "git", "checkout", "-" }, repo)
-        f = assert(io.open(path, "w"))
-        f:write("a-main\n")
-        f:close()
-        run({ "git", "add", "a.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "main-advance" }, repo)
+          -- Advance the default branch so HEAD diverges from the feature branch.
+          run({ "git", "checkout", "-" }, repo)
+          f = assert(io.open(path, "w"))
+          f:write("a-main\n")
+          f:close()
+          run({ "git", "add", "a.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "main-advance" }, repo)
 
-        local adapter = GitAdapter({
-          toplevel = repo,
-          cpath = repo,
-          path_args = {},
-        })
+          local adapter = GitAdapter({
+            toplevel = repo,
+            cpath = repo,
+            path_args = {},
+          })
 
-        -- Without merge_base, parse_revs should use the ref directly.
-        local left_plain, right_plain = adapter:parse_revs(feature_sha, {})
-        assert.is_not_nil(left_plain)
-        assert.equals(feature_sha, left_plain:object_name())
-        assert.equals(RevType.LOCAL, right_plain.type)
+          -- Without merge_base, parse_revs should use the ref directly.
+          local left_plain, right_plain = adapter:parse_revs(feature_sha, {})
+          assert.is_not_nil(left_plain)
+          assert.equals(feature_sha, left_plain:object_name())
+          assert.equals(RevType.LOCAL, right_plain.type)
 
-        -- With merge_base, parse_revs should resolve to the merge-base of HEAD
-        -- and the given ref, which is base_sha.
-        local left_mb, right_mb = adapter:parse_revs(feature_sha, { merge_base = true })
-        assert.is_not_nil(left_mb)
-        assert.equals(base_sha, left_mb:object_name())
-        assert.equals(RevType.LOCAL, right_mb.type)
+          -- With merge_base, parse_revs should resolve to the merge-base of HEAD
+          -- and the given ref, which is base_sha.
+          local left_mb, right_mb = adapter:parse_revs(feature_sha, { merge_base = true })
+          assert.is_not_nil(left_mb)
+          assert.equals(base_sha, left_mb:object_name())
+          assert.equals(RevType.LOCAL, right_mb.type)
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
+        end
       end)
+    )
 
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
+    it(
+      "falls back to the ref when merge-base fails",
+      test_utils.async_test(function()
+        local repo = vim.fn.tempname()
+        assert.equals(1, vim.fn.mkdir(repo, "p"))
+
+        local ok, err = pcall(function()
+          run({ "git", "init", "-q" }, repo)
+          run({ "git", "config", "user.name", "Diffview Test" }, repo)
+          run({ "git", "config", "user.email", "diffview@test.local" }, repo)
+
+          -- Create a commit on the default branch and record its name.
+          local default_branch = run({ "git", "branch", "--show-current" }, repo)
+          local path = repo .. "/a.txt"
+          local f = assert(io.open(path, "w"))
+          f:write("a\n")
+          f:close()
+          run({ "git", "add", "a.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "first" }, repo)
+
+          -- Create an orphan branch with disjoint history.  Remove tracked files
+          -- so the index is clean for the orphan commit.
+          run({ "git", "checkout", "--orphan", "orphan" }, repo)
+          run({ "git", "rm", "-rf", "." }, repo)
+          local p2 = repo .. "/b.txt"
+          f = assert(io.open(p2, "w"))
+          f:write("b\n")
+          f:close()
+          run({ "git", "add", "b.txt" }, repo)
+          run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "orphan" }, repo)
+          local orphan_sha = run({ "git", "rev-parse", "HEAD" }, repo)
+
+          -- Switch back to the default branch.
+          run({ "git", "checkout", default_branch }, repo)
+
+          local adapter = GitAdapter({
+            toplevel = repo,
+            cpath = repo,
+            path_args = {},
+          })
+
+          -- With merge_base=true but disjoint histories, parse_revs should fall
+          -- back to using the ref itself.
+          local left, right = adapter:parse_revs(orphan_sha, { merge_base = true })
+          assert.is_not_nil(left)
+          assert.equals(orphan_sha, left:object_name())
+          assert.equals(RevType.LOCAL, right.type)
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
+        end
       end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
-
-    it("falls back to the ref when merge-base fails", test_utils.async_test(function()
-      local repo = vim.fn.tempname()
-      assert.equals(1, vim.fn.mkdir(repo, "p"))
-
-      local ok, err = pcall(function()
-        run({ "git", "init", "-q" }, repo)
-        run({ "git", "config", "user.name", "Diffview Test" }, repo)
-        run({ "git", "config", "user.email", "diffview@test.local" }, repo)
-
-        -- Create a commit on the default branch and record its name.
-        local default_branch = run({ "git", "branch", "--show-current" }, repo)
-        local path = repo .. "/a.txt"
-        local f = assert(io.open(path, "w"))
-        f:write("a\n")
-        f:close()
-        run({ "git", "add", "a.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "first" }, repo)
-
-        -- Create an orphan branch with disjoint history.  Remove tracked files
-        -- so the index is clean for the orphan commit.
-        run({ "git", "checkout", "--orphan", "orphan" }, repo)
-        run({ "git", "rm", "-rf", "." }, repo)
-        local p2 = repo .. "/b.txt"
-        f = assert(io.open(p2, "w"))
-        f:write("b\n")
-        f:close()
-        run({ "git", "add", "b.txt" }, repo)
-        run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "orphan" }, repo)
-        local orphan_sha = run({ "git", "rev-parse", "HEAD" }, repo)
-
-        -- Switch back to the default branch.
-        run({ "git", "checkout", default_branch }, repo)
-
-        local adapter = GitAdapter({
-          toplevel = repo,
-          cpath = repo,
-          path_args = {},
-        })
-
-        -- With merge_base=true but disjoint histories, parse_revs should fall
-        -- back to using the ref itself.
-        local left, right = adapter:parse_revs(orphan_sha, { merge_base = true })
-        assert.is_not_nil(left)
-        assert.equals(orphan_sha, left:object_name())
-        assert.equals(RevType.LOCAL, right.type)
-      end)
-
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
+    )
   end)
 
   describe("GIT_OPTIONAL_LOCKS in job environment", function()
@@ -473,8 +524,12 @@ describe("diffview.vcs.adapters.git", function()
       local found_locks = false
       local found_custom = false
       for _, entry in ipairs(job.env) do
-        if entry == "GIT_OPTIONAL_LOCKS=0" then found_locks = true end
-        if entry == "MY_VAR=hello" then found_custom = true end
+        if entry == "GIT_OPTIONAL_LOCKS=0" then
+          found_locks = true
+        end
+        if entry == "MY_VAR=hello" then
+          found_custom = true
+        end
       end
 
       assert.True(found_locks, "GIT_OPTIONAL_LOCKS=0 must be present")

--- a/lua/diffview/tests/functional/git_merge_matrix_spec.lua
+++ b/lua/diffview/tests/functional/git_merge_matrix_spec.lua
@@ -50,7 +50,6 @@ local function setup_repo(case_name)
     assert.is_true(merge.code ~= 0)
 
     return repo, "conflict.txt"
-
   elseif case_name == "modify_delete" then
     local path = repo .. "/delete_conflict.txt"
     local f = assert(io.open(path, "w"))
@@ -82,56 +81,63 @@ end
 
 describe("diffview.vcs.adapters.git merge conflict matrix", function()
   for _, case_name in ipairs({ "modify_modify", "modify_delete" }) do
-    it("opens conflict stages safely for " .. case_name, test_utils.async_test(function()
-      local repo, conflict_path = setup_repo(case_name)
+    it(
+      "opens conflict stages safely for " .. case_name,
+      test_utils.async_test(function()
+        local repo, conflict_path = setup_repo(case_name)
 
-      local ok, err = pcall(function()
-        local adapter = GitAdapter({
-          toplevel = repo,
-          cpath = repo,
-          path_args = {},
-        })
+        local ok, err = pcall(function()
+          local adapter = GitAdapter({
+            toplevel = repo,
+            cpath = repo,
+            path_args = {},
+          })
 
-        local left = GitRev(RevType.STAGE, 0)
-        local right = GitRev(RevType.LOCAL)
-        local args = adapter:rev_to_args(left, right)
+          local left = GitRev(RevType.STAGE, 0)
+          local right = GitRev(RevType.LOCAL)
+          local args = adapter:rev_to_args(left, right)
 
-        local tracked_err, _, conflicts = async.await(adapter:tracked_files(
-          left,
-          right,
-          args,
-          "working",
-          { default_layout = Diff2, merge_layout = Diff4 }
-        ))
+          local tracked_err, _, conflicts = async.await(
+            adapter:tracked_files(
+              left,
+              right,
+              args,
+              "working",
+              { default_layout = Diff2, merge_layout = Diff4 }
+            )
+          )
 
-        assert.is_nil(tracked_err)
-        assert.is_true(#conflicts > 0)
+          assert.is_nil(tracked_err)
+          assert.is_true(#conflicts > 0)
 
-        local target
-        for _, entry in ipairs(conflicts) do
-          if entry.path == conflict_path then
-            target = entry
-            break
+          local target
+          for _, entry in ipairs(conflicts) do
+            if entry.path == conflict_path then
+              target = entry
+              break
+            end
           end
-        end
 
-        assert.is_not_nil(target)
+          assert.is_not_nil(target)
 
-        -- Ensure all merge panes can be materialized without crashing,
-        -- including missing stages for modify/delete style conflicts.
-        for _, sym in ipairs({ "a", "b", "c", "d" }) do
-          local file = target.layout[sym].file
-          local bufnr = async.await(file:create_buffer())
-          assert.is_true(type(bufnr) == "number")
+          -- Ensure all merge panes can be materialized without crashing,
+          -- including missing stages for modify/delete style conflicts.
+          for _, sym in ipairs({ "a", "b", "c", "d" }) do
+            local file = target.layout[sym].file
+            local bufnr = async.await(file:create_buffer())
+            assert.is_true(type(bufnr) == "number")
+          end
+        end)
+
+        vim.schedule(function()
+          pcall(vim.fn.delete, repo, "rf")
+        end)
+        async.await(async.scheduler())
+
+        if not ok then
+          error(err)
         end
       end)
-
-      vim.schedule(function()
-        pcall(vim.fn.delete, repo, "rf")
-      end)
-      async.await(async.scheduler())
-
-      if not ok then error(err) end
-    end))
+    )
   end
 end)

--- a/lua/diffview/tests/functional/git_parser_spec.lua
+++ b/lua/diffview/tests/functional/git_parser_spec.lua
@@ -75,14 +75,14 @@ describe("diffview.vcs.adapters.git.parser", function()
 
     local function make_stat_data(overrides)
       local defaults = {
-        "abc123 def456",            -- [1] right_hash left_hash
-        "Test Author",              -- [2] author
-        "1700000000",               -- [3] epoch
-        "2023-11-14 12:00 +0100",   -- [4] date with offset
-        "2 days ago",               -- [5] relative date
-        "::HEAD -> main",           -- [6] ref names
-        "::",                       -- [7] reflog selector
-        "::Fix a bug",              -- [8] subject
+        "abc123 def456", -- [1] right_hash left_hash
+        "Test Author", -- [2] author
+        "1700000000", -- [3] epoch
+        "2023-11-14 12:00 +0100", -- [4] date with offset
+        "2 days ago", -- [5] relative date
+        "::HEAD -> main", -- [6] ref names
+        "::", -- [7] reflog selector
+        "::Fix a bug", -- [8] subject
       }
 
       if overrides then

--- a/lua/diffview/tests/functional/gitsigns_autocmd_spec.lua
+++ b/lua/diffview/tests/functional/gitsigns_autocmd_spec.lua
@@ -20,7 +20,9 @@ local function make_mock_view(opts)
     closing = closing,
     tabpage = opts.tabpage or api.nvim_get_current_tabpage(),
     update_files_called = false,
-    update_files = function(self) self.update_files_called = true end,
+    update_files = function(self)
+      self.update_files_called = true
+    end,
   }
 end
 
@@ -29,9 +31,8 @@ end
 ---@param view table  Mock view from make_mock_view.
 ---@return integer augroup_id
 local function register_autocmd(view)
-  local augroup = api.nvim_create_augroup(
-    "diffview_gitsigns_test_" .. view.tabpage, { clear = true }
-  )
+  local augroup =
+    api.nvim_create_augroup("diffview_gitsigns_test_" .. view.tabpage, { clear = true })
   api.nvim_create_autocmd("User", {
     group = augroup,
     pattern = "GitSignsChanged",

--- a/lua/diffview/tests/functional/hg_adapter_spec.lua
+++ b/lua/diffview/tests/functional/hg_adapter_spec.lua
@@ -106,96 +106,126 @@ describe("diffview.vcs.adapters.hg", function()
     end)
 
     after_each(function()
-      if repo then repo.cleanup() end
+      if repo then
+        repo.cleanup()
+      end
     end)
 
-    it("lists modified, added, and removed files", helpers.async_test(function()
-      if not hg_available() then pending("hg not installed") return end
+    it(
+      "lists modified, added, and removed files",
+      helpers.async_test(function()
+        if not hg_available() then
+          pending("hg not installed")
+          return
+        end
 
-      -- Initial commit.
-      repo.write("src/main.lua", 'print("v1")\n')
-      repo.write("src/utils.lua", "local M = {}\nreturn M\n")
-      repo.hg({ "add", "src/main.lua", "src/utils.lua" })
-      repo.hg({ "commit", "-m", "initial", "-u", "test <test@test.com>" })
+        -- Initial commit.
+        repo.write("src/main.lua", 'print("v1")\n')
+        repo.write("src/utils.lua", "local M = {}\nreturn M\n")
+        repo.hg({ "add", "src/main.lua", "src/utils.lua" })
+        repo.hg({ "commit", "-m", "initial", "-u", "test <test@test.com>" })
 
-      -- Working copy changes: modify, remove, add.
-      repo.write("src/main.lua", 'print("v2")\n')
-      repo.hg({ "remove", "src/utils.lua" })
-      repo.write("src/new.lua", "new\n")
-      repo.hg({ "add", "src/new.lua" })
+        -- Working copy changes: modify, remove, add.
+        repo.write("src/main.lua", 'print("v2")\n')
+        repo.hg({ "remove", "src/utils.lua" })
+        repo.write("src/new.lua", "new\n")
+        repo.hg({ "add", "src/new.lua" })
 
-      local adapter = repo.adapter()
-      local HgRev = adapter.Rev
-      local left = HgRev(RevType.COMMIT, "tip")
-      local right = HgRev(RevType.LOCAL)
+        local adapter = repo.adapter()
+        local HgRev = adapter.Rev
+        local left = HgRev(RevType.COMMIT, "tip")
+        local right = HgRev(RevType.LOCAL)
 
-      local err, files = await(adapter:tracked_files(
-        left, right, {}, "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
+        local err, files = await(
+          adapter:tracked_files(
+            left,
+            right,
+            {},
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
+        )
 
-      assert.is_nil(err)
+        assert.is_nil(err)
 
-      local by_name = {}
-      for _, file in ipairs(files) do
-        local name = file.path:match("[^/]+$")
-        by_name[name] = file
-      end
+        local by_name = {}
+        for _, file in ipairs(files) do
+          local name = file.path:match("[^/]+$")
+          by_name[name] = file
+        end
 
-      assert.is_not_nil(by_name["main.lua"], "main.lua should appear (modified)")
-      assert.equals("M", by_name["main.lua"].status)
+        assert.is_not_nil(by_name["main.lua"], "main.lua should appear (modified)")
+        assert.equals("M", by_name["main.lua"].status)
 
-      assert.is_not_nil(by_name["new.lua"], "new.lua should appear (added)")
-      assert.equals("A", by_name["new.lua"].status)
+        assert.is_not_nil(by_name["new.lua"], "new.lua should appear (added)")
+        assert.equals("A", by_name["new.lua"].status)
 
-      assert.is_not_nil(by_name["utils.lua"], "utils.lua should appear (removed)")
-      assert.equals("R", by_name["utils.lua"].status)
-    end))
+        assert.is_not_nil(by_name["utils.lua"], "utils.lua should appear (removed)")
+        assert.equals("R", by_name["utils.lua"].status)
+      end)
+    )
 
-    it("shows file content at a revision without errors", helpers.async_test(function()
-      if not hg_available() then pending("hg not installed") return end
+    it(
+      "shows file content at a revision without errors",
+      helpers.async_test(function()
+        if not hg_available() then
+          pending("hg not installed")
+          return
+        end
 
-      repo.write("hello.txt", "hello world\n")
-      repo.hg({ "add", "hello.txt" })
-      repo.hg({ "commit", "-m", "add hello", "-u", "test <test@test.com>" })
+        repo.write("hello.txt", "hello world\n")
+        repo.hg({ "add", "hello.txt" })
+        repo.hg({ "commit", "-m", "add hello", "-u", "test <test@test.com>" })
 
-      local adapter = repo.adapter()
-      local HgRev = adapter.Rev
-      local rev = HgRev(RevType.COMMIT, "tip")
+        local adapter = repo.adapter()
+        local HgRev = adapter.Rev
+        local rev = HgRev(RevType.COMMIT, "tip")
 
-      local err, content = await(adapter:show("hello.txt", rev))
+        local err, content = await(adapter:show("hello.txt", rev))
 
-      assert.is_nil(err)
-      assert.is_not_nil(content)
-      assert.equals("hello world", vim.trim(table.concat(content, "\n")))
-    end))
+        assert.is_nil(err)
+        assert.is_not_nil(content)
+        assert.equals("hello world", vim.trim(table.concat(content, "\n")))
+      end)
+    )
 
-    it("paths do not contain revision specifiers", helpers.async_test(function()
-      if not hg_available() then pending("hg not installed") return end
+    it(
+      "paths do not contain revision specifiers",
+      helpers.async_test(function()
+        if not hg_available() then
+          pending("hg not installed")
+          return
+        end
 
-      repo.write("file.lua", "content\n")
-      repo.hg({ "add", "file.lua" })
-      repo.hg({ "commit", "-m", "add file", "-u", "test <test@test.com>" })
-      repo.write("file.lua", "updated\n")
+        repo.write("file.lua", "content\n")
+        repo.hg({ "add", "file.lua" })
+        repo.hg({ "commit", "-m", "add file", "-u", "test <test@test.com>" })
+        repo.write("file.lua", "updated\n")
 
-      local adapter = repo.adapter()
-      local HgRev = adapter.Rev
-      local left = HgRev(RevType.COMMIT, "tip")
-      local right = HgRev(RevType.LOCAL)
+        local adapter = repo.adapter()
+        local HgRev = adapter.Rev
+        local left = HgRev(RevType.COMMIT, "tip")
+        local right = HgRev(RevType.LOCAL)
 
-      local err, files = await(adapter:tracked_files(
-        left, right, {}, "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
+        local err, files = await(
+          adapter:tracked_files(
+            left,
+            right,
+            {},
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
+        )
 
-      assert.is_nil(err)
-      assert.is_true(#files > 0)
+        assert.is_nil(err)
+        assert.is_true(#files > 0)
 
-      for _, file in ipairs(files) do
-        -- Mercurial paths should never contain revision specifiers.
-        assert.is_nil(file.path:match("#%d+"), ("path %q contains #rev"):format(file.path))
-        assert.is_nil(file.path:match("@%d+"), ("path %q contains @rev"):format(file.path))
-      end
-    end))
+        for _, file in ipairs(files) do
+          -- Mercurial paths should never contain revision specifiers.
+          assert.is_nil(file.path:match("#%d+"), ("path %q contains #rev"):format(file.path))
+          assert.is_nil(file.path:match("@%d+"), ("path %q contains @rev"):format(file.path))
+        end
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -22,7 +22,9 @@ describe("diffview.scene.inline_diff", function()
         out[#out + 1] = { row = m[2], hl = m[4].line_hl_group }
       end
     end
-    table.sort(out, function(a, b) return a.row < b.row end)
+    table.sort(out, function(a, b)
+      return a.row < b.row
+    end)
     return out
   end
 
@@ -37,7 +39,9 @@ describe("diffview.scene.inline_diff", function()
         }
       end
     end
-    table.sort(out, function(a, b) return a.row < b.row end)
+    table.sort(out, function(a, b)
+      return a.row < b.row
+    end)
     return out
   end
 
@@ -49,7 +53,9 @@ describe("diffview.scene.inline_diff", function()
       end
     end
     table.sort(out, function(a, b)
-      if a.row == b.row then return a.start < b.start end
+      if a.row == b.row then
+        return a.start < b.start
+      end
       return a.row < b.row
     end)
     return out
@@ -67,7 +73,9 @@ describe("diffview.scene.inline_diff", function()
       end
     end
     table.sort(out, function(a, b)
-      if a.row == b.row then return a.col < b.col end
+      if a.row == b.row then
+        return a.col < b.col
+      end
       return a.row < b.row
     end)
     return out
@@ -85,7 +93,9 @@ describe("diffview.scene.inline_diff", function()
     return out
   end
 
-  before_each(function() created_bufs = {} end)
+  before_each(function()
+    created_bufs = {}
+  end)
 
   after_each(function()
     for _, b in ipairs(created_bufs) do
@@ -260,7 +270,9 @@ describe("diffview.scene.inline_diff", function()
       -- The deleted run should be on the modified line and contain "brave".
       local any = false
       for _, v in ipairs(inlines) do
-        if v.text:find("brave") then any = true end
+        if v.text:find("brave") then
+          any = true
+        end
       end
       assert.is_true(any, "expected deleted text to contain 'brave'")
     end)
@@ -393,7 +405,9 @@ describe("diffview.scene.inline_diff", function()
       -- From the top, next_hunk from -1 should be the first anchor.
       assert.are.equal(rows[1], inline_diff.next_hunk_row(bufnr, -1))
       -- From row[1], next should be rows[2].
-      if #rows >= 2 then assert.are.equal(rows[2], inline_diff.next_hunk_row(bufnr, rows[1])) end
+      if #rows >= 2 then
+        assert.are.equal(rows[2], inline_diff.next_hunk_row(bufnr, rows[1]))
+      end
     end)
 
     it("next_hunk_row returns nil past the last hunk", function()
@@ -539,10 +553,9 @@ describe("diffview.scene.inline_diff", function()
       assert.are.same({}, h.diff_units({ "a" }, {}))
     end)
 
-    it(
-      "INTRALINE_MAX_HUNKS is a positive integer",
-      function() assert.is_true(h.INTRALINE_MAX_HUNKS >= 1) end
-    )
+    it("INTRALINE_MAX_HUNKS is a positive integer", function()
+      assert.is_true(h.INTRALINE_MAX_HUNKS >= 1)
+    end)
 
     it("refinement_safe admits single-hunk sub-diffs regardless of overlap", function()
       -- One hunk cannot interleave, so even unrelated words (foo/bar) are safe.
@@ -568,10 +581,9 @@ describe("diffview.scene.inline_diff", function()
       )
     end)
 
-    it(
-      "refinement_safe rejects when hunk count exceeds the limit",
-      function() assert.is_false(h.refinement_safe({ "a" }, { "b" }, h.INTRALINE_MAX_HUNKS + 1)) end
-    )
+    it("refinement_safe rejects when hunk count exceeds the limit", function()
+      assert.is_false(h.refinement_safe({ "a" }, { "b" }, h.INTRALINE_MAX_HUNKS + 1))
+    end)
   end)
 
   describe("similarity gate", function()
@@ -580,8 +592,12 @@ describe("diffview.scene.inline_diff", function()
       local out = { hl = 0, inline = 0 }
       for _, m in ipairs(marks) do
         local d = m[4]
-        if d.hl_group == "DiffviewDiffText" then out.hl = out.hl + 1 end
-        if d.virt_text and d.virt_text_pos == "inline" then out.inline = out.inline + 1 end
+        if d.hl_group == "DiffviewDiffText" then
+          out.hl = out.hl + 1
+        end
+        if d.virt_text and d.virt_text_pos == "inline" then
+          out.inline = out.inline + 1
+        end
       end
       return out
     end

--- a/lua/diffview/tests/functional/jj_adapter_spec.lua
+++ b/lua/diffview/tests/functional/jj_adapter_spec.lua
@@ -40,7 +40,8 @@ describe("diffview.vcs.adapters.jj", function()
     end
 
     adapter.symmetric_diff_revs = function(_, _)
-      return adapter.Rev(RevType.COMMIT, "merge_base_hash"), adapter.Rev(RevType.COMMIT, adapter._rev_map["@"])
+      return adapter.Rev(RevType.COMMIT, "merge_base_hash"),
+        adapter.Rev(RevType.COMMIT, adapter._rev_map["@"])
     end
 
     adapter.has_bookmark = function(_, _)
@@ -200,10 +201,8 @@ describe("diffview.vcs.adapters.jj", function()
 
     it("returns --from for commit..LOCAL", function()
       local adapter = new_adapter()
-      local args = adapter:rev_to_args(
-        adapter.Rev(RevType.COMMIT, "left_hash"),
-        adapter.Rev(RevType.LOCAL)
-      )
+      local args =
+        adapter:rev_to_args(adapter.Rev(RevType.COMMIT, "left_hash"), adapter.Rev(RevType.LOCAL))
 
       eq({ "--from", "left_hash" }, args)
     end)
@@ -274,94 +273,130 @@ describe("diffview.vcs.adapters.jj", function()
     end)
 
     after_each(function()
-      if repo then repo.cleanup() end
+      if repo then
+        repo.cleanup()
+      end
     end)
 
-    it("lists modified, added, and deleted files", helpers.async_test(function()
-      if not jj_available() then pending("jj not installed") return end
+    it(
+      "lists modified, added, and deleted files",
+      helpers.async_test(function()
+        if not jj_available() then
+          pending("jj not installed")
+          return
+        end
 
-      -- Initial commit with two files.
-      repo.write("src/main.lua", 'print("v1")\n')
-      repo.write("src/utils.lua", "local M = {}\nreturn M\n")
-      repo.jj({ "describe", "-m", "initial" })
-      repo.jj({ "new" })
+        -- Initial commit with two files.
+        repo.write("src/main.lua", 'print("v1")\n')
+        repo.write("src/utils.lua", "local M = {}\nreturn M\n")
+        repo.jj({ "describe", "-m", "initial" })
+        repo.jj({ "new" })
 
-      -- Modify one, delete one, add one.
-      repo.write("src/main.lua", 'print("v2")\n')
-      os.remove(repo.dir .. "/src/utils.lua")
-      repo.write("src/new.lua", "new\n")
+        -- Modify one, delete one, add one.
+        repo.write("src/main.lua", 'print("v2")\n')
+        os.remove(repo.dir .. "/src/utils.lua")
+        repo.write("src/new.lua", "new\n")
 
-      local adapter = repo.adapter()
-      local left = adapter.Rev(RevType.COMMIT, run({ "jj", "show", "-T", "commit_id", "@-", "--no-patch" }, repo.dir))
-      local right = adapter.Rev(RevType.LOCAL)
-      local args = adapter:rev_to_args(left, right)
+        local adapter = repo.adapter()
+        local left = adapter.Rev(
+          RevType.COMMIT,
+          run({ "jj", "show", "-T", "commit_id", "@-", "--no-patch" }, repo.dir)
+        )
+        local right = adapter.Rev(RevType.LOCAL)
+        local args = adapter:rev_to_args(left, right)
 
-      local err, files = await(adapter:tracked_files(
-        left, right, args, "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
+        local err, files = await(
+          adapter:tracked_files(
+            left,
+            right,
+            args,
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
+        )
 
-      assert.is_nil(err)
+        assert.is_nil(err)
 
-      local by_name = {}
-      for _, file in ipairs(files) do
-        local name = file.path:match("[^/]+$")
-        by_name[name] = file
-      end
+        local by_name = {}
+        for _, file in ipairs(files) do
+          local name = file.path:match("[^/]+$")
+          by_name[name] = file
+        end
 
-      assert.is_not_nil(by_name["main.lua"], "main.lua should appear (modified)")
-      assert.equals("M", by_name["main.lua"].status)
+        assert.is_not_nil(by_name["main.lua"], "main.lua should appear (modified)")
+        assert.equals("M", by_name["main.lua"].status)
 
-      assert.is_not_nil(by_name["new.lua"], "new.lua should appear (added)")
-      assert.equals("A", by_name["new.lua"].status)
+        assert.is_not_nil(by_name["new.lua"], "new.lua should appear (added)")
+        assert.equals("A", by_name["new.lua"].status)
 
-      assert.is_not_nil(by_name["utils.lua"], "utils.lua should appear (deleted)")
-      assert.equals("D", by_name["utils.lua"].status)
-    end))
+        assert.is_not_nil(by_name["utils.lua"], "utils.lua should appear (deleted)")
+        assert.equals("D", by_name["utils.lua"].status)
+      end)
+    )
 
-    it("shows file content at a revision without errors", helpers.async_test(function()
-      if not jj_available() then pending("jj not installed") return end
+    it(
+      "shows file content at a revision without errors",
+      helpers.async_test(function()
+        if not jj_available() then
+          pending("jj not installed")
+          return
+        end
 
-      repo.write("hello.txt", "hello world\n")
-      repo.jj({ "describe", "-m", "add hello" })
+        repo.write("hello.txt", "hello world\n")
+        repo.jj({ "describe", "-m", "add hello" })
 
-      local adapter = repo.adapter()
-      local commit_id = run({ "jj", "show", "-T", "commit_id", "@", "--no-patch" }, repo.dir)
-      local rev = adapter.Rev(RevType.COMMIT, commit_id)
+        local adapter = repo.adapter()
+        local commit_id = run({ "jj", "show", "-T", "commit_id", "@", "--no-patch" }, repo.dir)
+        local rev = adapter.Rev(RevType.COMMIT, commit_id)
 
-      local err, content = await(adapter:show("hello.txt", rev))
+        local err, content = await(adapter:show("hello.txt", rev))
 
-      assert.is_nil(err)
-      assert.is_not_nil(content)
-      assert.equals("hello world", vim.trim(table.concat(content, "\n")))
-    end))
+        assert.is_nil(err)
+        assert.is_not_nil(content)
+        assert.equals("hello world", vim.trim(table.concat(content, "\n")))
+      end)
+    )
 
-    it("paths do not contain revision specifiers", helpers.async_test(function()
-      if not jj_available() then pending("jj not installed") return end
+    it(
+      "paths do not contain revision specifiers",
+      helpers.async_test(function()
+        if not jj_available() then
+          pending("jj not installed")
+          return
+        end
 
-      repo.write("file.lua", "content\n")
-      repo.jj({ "describe", "-m", "add file" })
-      repo.jj({ "new" })
-      repo.write("file.lua", "updated\n")
+        repo.write("file.lua", "content\n")
+        repo.jj({ "describe", "-m", "add file" })
+        repo.jj({ "new" })
+        repo.write("file.lua", "updated\n")
 
-      local adapter = repo.adapter()
-      local left = adapter.Rev(RevType.COMMIT, run({ "jj", "show", "-T", "commit_id", "@-", "--no-patch" }, repo.dir))
-      local right = adapter.Rev(RevType.LOCAL)
-      local args = adapter:rev_to_args(left, right)
+        local adapter = repo.adapter()
+        local left = adapter.Rev(
+          RevType.COMMIT,
+          run({ "jj", "show", "-T", "commit_id", "@-", "--no-patch" }, repo.dir)
+        )
+        local right = adapter.Rev(RevType.LOCAL)
+        local args = adapter:rev_to_args(left, right)
 
-      local err, files = await(adapter:tracked_files(
-        left, right, args, "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
+        local err, files = await(
+          adapter:tracked_files(
+            left,
+            right,
+            args,
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
+        )
 
-      assert.is_nil(err)
-      assert.is_true(#files > 0)
+        assert.is_nil(err)
+        assert.is_true(#files > 0)
 
-      for _, file in ipairs(files) do
-        -- Jujutsu paths should never contain revision specifiers.
-        assert.is_nil(file.path:match("@"), ("path %q contains @"):format(file.path))
-        assert.is_nil(file.path:match("#%d+"), ("path %q contains #rev"):format(file.path))
-      end
-    end))
+        for _, file in ipairs(files) do
+          -- Jujutsu paths should never contain revision specifiers.
+          assert.is_nil(file.path:match("@"), ("path %q contains @"):format(file.path))
+          assert.is_nil(file.path:match("#%d+"), ("path %q contains #rev"):format(file.path))
+        end
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/job_utils_spec.lua
+++ b/lua/diffview/tests/functional/job_utils_spec.lua
@@ -5,8 +5,12 @@ local eq = helpers.eq
 
 describe("diffview.job_utils.resolve_fail_cond", function()
   local mock_table = {
-    non_zero = function() return true end,
-    on_empty = function() return false end,
+    non_zero = function()
+      return true
+    end,
+    on_empty = function()
+      return false
+    end,
   }
 
   it("returns the named function for a string key", function()

--- a/lua/diffview/tests/functional/keymap_save_spec.lua
+++ b/lua/diffview/tests/functional/keymap_save_spec.lua
@@ -22,7 +22,9 @@ local function make_file(bufnr)
       toplevel = vim.uv.cwd(),
       dir = vim.uv.cwd(),
     },
-    is_binary = function() return false end,
+    is_binary = function()
+      return false
+    end,
   }
 
   local file = File({
@@ -120,7 +122,9 @@ describe("keymap save/restore on attach/detach", function()
   it("saves callback-based keymaps correctly", function()
     local bufnr = scratch_buf()
     local called = false
-    local original_cb = function() called = true end
+    local original_cb = function()
+      called = true
+    end
 
     vim.keymap.set("n", test_lhs, original_cb, {
       buffer = bufnr,
@@ -191,7 +195,9 @@ describe("keymap save/restore on attach/detach", function()
   it("restores a callback-based keymap on detach", function()
     local bufnr = scratch_buf()
     local call_count = 0
-    local original_cb = function() call_count = call_count + 1 end
+    local original_cb = function()
+      call_count = call_count + 1
+    end
 
     vim.keymap.set("n", test_lhs, original_cb, { buffer = bufnr })
 
@@ -246,7 +252,9 @@ describe("keymap save/restore on attach/detach", function()
 
       local au_id = api.nvim_create_autocmd("BufReadPost", {
         buffer = bufnr,
-        callback = function() fired = true end,
+        callback = function()
+          fired = true
+        end,
       })
 
       local file = make_file(bufnr)
@@ -265,7 +273,9 @@ describe("keymap save/restore on attach/detach", function()
 
       local au_id = api.nvim_create_autocmd("BufReadPost", {
         buffer = bufnr,
-        callback = function() count = count + 1 end,
+        callback = function()
+          count = count + 1
+        end,
       })
 
       local file = make_file(bufnr)
@@ -292,7 +302,9 @@ describe("keymap save/restore on attach/detach", function()
       local ft_fired = false
       local au_id = api.nvim_create_autocmd("FileType", {
         callback = function(ev)
-          if ev.buf == bufnr then ft_fired = true end
+          if ev.buf == bufnr then
+            ft_fired = true
+          end
         end,
       })
 

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -43,7 +43,9 @@ describe("diffview.layout null detection", function()
 end)
 
 describe("diffview.layout symbols", function()
-  it("Diff1 declares symbols { 'b' }", function() eq({ "b" }, Diff1.symbols) end)
+  it("Diff1 declares symbols { 'b' }", function()
+    eq({ "b" }, Diff1.symbols)
+  end)
 
   it("Diff1Inline inherits Diff1 and keeps symbols { 'b' }", function()
     -- Class-level relationship check avoids relying on the constructor's
@@ -97,7 +99,9 @@ describe("diffview.layout symbols", function()
     local debounced = setmetatable({}, {
       __call = function() end,
       __index = {
-        close = function() closed = true end,
+        close = function()
+          closed = true
+        end,
         cancel = function() end,
       },
     })
@@ -127,12 +131,21 @@ describe("diffview.layout symbols", function()
 
       local inst = setmetatable({}, { __index = Diff1Inline })
       inst.b = {
-        file = { bufnr = bufnr, is_valid = function() return true end },
-        is_valid = function() return true end,
+        file = {
+          bufnr = bufnr,
+          is_valid = function()
+            return true
+          end,
+        },
+        is_valid = function()
+          return true
+        end,
         id = winid,
       }
       inst._cached_old_lines = { "old content" }
-      inst._repaint = function() repaint_count = repaint_count + 1 end
+      inst._repaint = function()
+        repaint_count = repaint_count + 1
+      end
 
       async.await(inst:_render_inline())
 
@@ -169,12 +182,21 @@ describe("diffview.layout symbols", function()
 
       local inst = setmetatable({}, { __index = Diff1Inline })
       inst.b = {
-        file = { bufnr = bufnr, is_valid = function() return true end },
-        is_valid = function() return true end,
+        file = {
+          bufnr = bufnr,
+          is_valid = function()
+            return true
+          end,
+        },
+        is_valid = function()
+          return true
+        end,
         id = winid,
       }
       inst._cached_old_lines = { "old content" }
-      inst._repaint = function() repaint_count = repaint_count + 1 end
+      inst._repaint = function()
+        repaint_count = repaint_count + 1
+      end
 
       async.await(inst:_render_inline())
 
@@ -211,8 +233,15 @@ describe("diffview.layout symbols", function()
       inline_diff.render(bufnr, old, new)
 
       local win_mock = {
-        file = { bufnr = bufnr, is_valid = function() return true end },
-        is_valid = function() return true end,
+        file = {
+          bufnr = bufnr,
+          is_valid = function()
+            return true
+          end,
+        },
+        is_valid = function()
+          return true
+        end,
       }
       local inst = setmetatable({
         b = win_mock,
@@ -328,8 +357,15 @@ describe("diffview.layout symbols", function()
 
         local inst = setmetatable({}, { __index = Diff1Inline })
         inst.b = {
-          file = { bufnr = bufnr, is_valid = function() return true end },
-          is_valid = function() return true end,
+          file = {
+            bufnr = bufnr,
+            is_valid = function()
+              return true
+            end,
+          },
+          is_valid = function()
+            return true
+          end,
           id = winid,
         }
         inst._cached_old_lines = { "one", "two", "three", "four", "five" }
@@ -352,22 +388,24 @@ describe("diffview.layout symbols", function()
         inline_diff.render = original_render
         inst:teardown_render()
         pcall(api.nvim_buf_delete, bufnr, { force = true })
-        if not ok then error(err) end
+        if not ok then
+          error(err)
+        end
       end)
     )
   end)
 
-  it("Diff2 declares symbols { 'a', 'b' }", function() eq({ "a", "b" }, Diff2.symbols) end)
+  it("Diff2 declares symbols { 'a', 'b' }", function()
+    eq({ "a", "b" }, Diff2.symbols)
+  end)
 
-  it(
-    "Diff3 declares symbols { 'a', 'b', 'c' }",
-    function() eq({ "a", "b", "c" }, Diff3.symbols) end
-  )
+  it("Diff3 declares symbols { 'a', 'b', 'c' }", function()
+    eq({ "a", "b", "c" }, Diff3.symbols)
+  end)
 
-  it(
-    "Diff4 declares symbols { 'a', 'b', 'c', 'd' }",
-    function() eq({ "a", "b", "c", "d" }, Diff4.symbols) end
-  )
+  it("Diff4 declares symbols { 'a', 'b', 'c', 'd' }", function()
+    eq({ "a", "b", "c", "d" }, Diff4.symbols)
+  end)
 end)
 
 describe("diffview.scene.layouts.diff_1_inline diffopt forwarding", function()
@@ -378,14 +416,20 @@ describe("diffview.scene.layouts.diff_1_inline diffopt forwarding", function()
 
   local orig_diffopt
 
-  before_each(function() orig_diffopt = vim.deepcopy(vim.opt.diffopt:get()) end)
+  before_each(function()
+    orig_diffopt = vim.deepcopy(vim.opt.diffopt:get())
+  end)
 
-  after_each(function() vim.opt.diffopt = vim.deepcopy(orig_diffopt) end)
+  after_each(function()
+    vim.opt.diffopt = vim.deepcopy(orig_diffopt)
+  end)
 
   ---Reset `'diffopt'` to a fixed baseline so each test starts from the same
   ---state regardless of what the Neovim default (or a prior test) left behind.
   ---@param entries string[]
-  local function set_diffopt(entries) vim.opt.diffopt = entries end
+  local function set_diffopt(entries)
+    vim.opt.diffopt = entries
+  end
 
   it("maps iwhite to ignore_whitespace_change", function()
     set_diffopt({ "iwhite" })
@@ -464,7 +508,11 @@ end)
 describe("diffview.layout.set_file_for", function()
   it("sets the file on the window and tags it with the symbol", function()
     local stored_file
-    local mock_win = { set_file = function(_, f) stored_file = f end }
+    local mock_win = {
+      set_file = function(_, f)
+        stored_file = f
+      end,
+    }
     local mock_layout = { a = mock_win, windows = {}, symbols = { "a" } }
     setmetatable(mock_layout, { __index = Layout })
 
@@ -495,14 +543,20 @@ describe("diffview.layout.create_wins", function()
     next_win_id = 100
 
     -- Execute the callback immediately (simulating nvim_win_call).
-    vim.api.nvim_win_call = function(_, fn) fn() end
+    vim.api.nvim_win_call = function(_, fn)
+      fn()
+    end
     vim.api.nvim_win_close = function() end
     vim.api.nvim_get_current_win = function()
       next_win_id = next_win_id + 1
       return next_win_id
     end
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.cmd = function(c) cmds_recorded[#cmds_recorded + 1] = c end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.cmd = function(c)
+      cmds_recorded[#cmds_recorded + 1] = c
+    end
   end)
 
   after_each(function()
@@ -520,12 +574,22 @@ describe("diffview.layout.create_wins", function()
     local layout = {
       windows = {},
       state = {},
-      create_pre = function(self) self.state.save_equalalways = vim.o.equalalways end,
+      create_pre = function(self)
+        self.state.save_equalalways = vim.o.equalalways
+      end,
       create_post = async.void(function() end),
-      find_pivot = function() return 1 end,
+      find_pivot = function()
+        return 1
+      end,
     }
     for _, s in ipairs(syms) do
-      layout[s] = { set_id = function(self, id) self.id = id end, close = function() end, id = nil }
+      layout[s] = {
+        set_id = function(self, id)
+          self.id = id
+        end,
+        close = function() end,
+        id = nil,
+      }
     end
     setmetatable(layout, { __index = Layout })
     return layout
@@ -610,12 +674,18 @@ describe("diffview.layout.create_wins integration", function()
     }
     setmetatable(layout, { __index = Layout })
     for _, s in ipairs(syms) do
-      layout[s] = { set_id = function(self, id) self.id = id end, close = function() end, id = nil }
+      layout[s] = {
+        set_id = function(self, id)
+          self.id = id
+        end,
+        close = function() end,
+        id = nil,
+      }
     end
     -- Override create_post to skip file loading (no files to open).
-    layout.create_post = async.void(
-      function(self) vim.opt.equalalways = self.state.save_equalalways end
-    )
+    layout.create_post = async.void(function(self)
+      vim.opt.equalalways = self.state.save_equalalways
+    end)
     return layout
   end
 
@@ -646,7 +716,9 @@ describe("diffview.layout.create_wins integration", function()
       -- Clean up: close extra windows, keeping at least one.
       local wins = vim.api.nvim_tabpage_list_wins(0)
       for i = 2, #wins do
-        if vim.api.nvim_win_is_valid(wins[i]) then vim.api.nvim_win_close(wins[i], true) end
+        if vim.api.nvim_win_is_valid(wins[i]) then
+          vim.api.nvim_win_close(wins[i], true)
+        end
       end
     end)
   )
@@ -673,7 +745,9 @@ describe("diffview.layout.create_wins integration", function()
 
       local wins = vim.api.nvim_tabpage_list_wins(0)
       for i = 2, #wins do
-        if vim.api.nvim_win_is_valid(wins[i]) then vim.api.nvim_win_close(wins[i], true) end
+        if vim.api.nvim_win_is_valid(wins[i]) then
+          vim.api.nvim_win_close(wins[i], true)
+        end
       end
     end)
   )

--- a/lua/diffview/tests/functional/misc_fixes_spec.lua
+++ b/lua/diffview/tests/functional/misc_fixes_spec.lua
@@ -267,7 +267,7 @@ describe("hl.get_style multi-attribute fix (58f14a5)", function()
   it("tries multiple groups and returns the first with style attrs", function()
     hl.get_hl = function(name)
       if name == "GroupA" then
-        return { fg = 0xff0000 }  -- No style attrs.
+        return { fg = 0xff0000 } -- No style attrs.
       elseif name == "GroupB" then
         return { bold = true, reverse = true }
       end
@@ -313,8 +313,8 @@ describe("inverted panel guard conditions (58f14a5)", function()
 
   it("buggy guard misses early return when panel is closed and buffer is not loaded", function()
     -- is_open=false, buf_loaded=false -> should return early.
-    eq(false, buggy_guard(false, false))  -- Bug: incorrectly does NOT return early!
-    eq(true, fixed_guard(false, false))   -- Fix: correctly returns early.
+    eq(false, buggy_guard(false, false)) -- Bug: incorrectly does NOT return early!
+    eq(true, fixed_guard(false, false)) -- Fix: correctly returns early.
   end)
 
   it("buggy guard fails when panel is open but buffer is not loaded", function()
@@ -346,8 +346,11 @@ describe("inverted panel guard conditions (58f14a5)", function()
     }
     for _, case in ipairs(cases) do
       local is_open, buf_loaded, should_early_return = case[1], case[2], case[3]
-      eq(should_early_return, fixed_guard(is_open, buf_loaded),
-        string.format("is_open=%s, buf_loaded=%s", tostring(is_open), tostring(buf_loaded)))
+      eq(
+        should_early_return,
+        fixed_guard(is_open, buf_loaded),
+        string.format("is_open=%s, buf_loaded=%s", tostring(is_open), tostring(buf_loaded))
+      )
     end
   end)
 end)
@@ -369,7 +372,7 @@ describe("deprecated config warning loop fix (58f14a5)", function()
       if user_log_options[name] ~= nil then
         warned[#warned + 1] = name
       end
-      break  -- Bug: always breaks after first iteration.
+      break -- Bug: always breaks after first iteration.
     end
     return warned
   end
@@ -380,7 +383,7 @@ describe("deprecated config warning loop fix (58f14a5)", function()
     for _, name in ipairs(top_options) do
       if user_log_options[name] ~= nil then
         warned[#warned + 1] = name
-        break  -- Fix: only breaks when a warning is issued.
+        break -- Fix: only breaks when a warning is issued.
       end
     end
     return warned
@@ -460,7 +463,9 @@ describe("config merge_layouts typo fix (58f14a5)", function()
     require("diffview.utils").err = old_err
     config.setup(original)
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 end)
 

--- a/lua/diffview/tests/functional/nil_guards_spec.lua
+++ b/lua/diffview/tests/functional/nil_guards_spec.lua
@@ -50,7 +50,9 @@ describe("nil guards", function()
     end)
 
     it("does not crash when comp is nil (no component on line)", function()
-      vim.api.nvim_win_get_cursor = function() return { 1, 0 } end
+      vim.api.nvim_win_get_cursor = function()
+        return { 1, 0 }
+      end
       local panel = make_help_panel(nil)
 
       assert.has_no.errors(function()
@@ -59,7 +61,9 @@ describe("nil guards", function()
     end)
 
     it("does not crash when comp exists but has no context field", function()
-      vim.api.nvim_win_get_cursor = function() return { 1, 0 } end
+      vim.api.nvim_win_get_cursor = function()
+        return { 1, 0 }
+      end
       -- Simulate a component returned for a heading line: it has
       -- lstart/lend but no context.
       local panel = make_help_panel({ lstart = 0, lend = 1 })
@@ -70,7 +74,9 @@ describe("nil guards", function()
     end)
 
     it("does not crash when comp.context exists but mapping is nil", function()
-      vim.api.nvim_win_get_cursor = function() return { 1, 0 } end
+      vim.api.nvim_win_get_cursor = function()
+        return { 1, 0 }
+      end
       local panel = make_help_panel({ context = {} })
 
       assert.has_no.errors(function()
@@ -82,22 +88,34 @@ describe("nil guards", function()
       local feedkeys_called = false
       local close_called = false
 
-      vim.api.nvim_win_get_cursor = function() return { 3, 0 } end
-      vim.fn.win_getid = function() return 42 end
-      vim.fn.winnr = function() return 1 end
+      vim.api.nvim_win_get_cursor = function()
+        return { 3, 0 }
+      end
+      vim.fn.win_getid = function()
+        return 42
+      end
+      vim.fn.winnr = function()
+        return 1
+      end
 
       local orig_win_call = vim.api.nvim_win_call
       local orig_feedkeys = vim.api.nvim_feedkeys
 
-      vim.api.nvim_win_call = function(_winid, fn) fn() end
-      vim.api.nvim_feedkeys = function() feedkeys_called = true end
+      vim.api.nvim_win_call = function(_winid, fn)
+        fn()
+      end
+      vim.api.nvim_feedkeys = function()
+        feedkeys_called = true
+      end
 
       local panel = make_help_panel({
         context = {
           mapping = { "n", "q" },
         },
       })
-      panel.close = function() close_called = true end
+      panel.close = function()
+        close_called = true
+      end
 
       local ok, err = pcall(function()
         panel:apply_cmd()
@@ -106,7 +124,9 @@ describe("nil guards", function()
       vim.api.nvim_win_call = orig_win_call
       vim.api.nvim_feedkeys = orig_feedkeys
 
-      if not ok then error(err) end
+      if not ok then
+        error(err)
+      end
       assert.is_true(feedkeys_called)
       assert.is_true(close_called)
     end)
@@ -157,11 +177,15 @@ describe("nil guards", function()
     end
 
     it("does not crash when windows list is empty (target stays nil)", function()
-      vim.api.nvim_get_current_win = function() return 1 end
+      vim.api.nvim_get_current_win = function()
+        return 1
+      end
 
       -- get_main_win must return something with an id for the cursor read.
       local layout = make_layout({}, { id = 1 })
-      vim.api.nvim_win_get_cursor = function() return { 1, 0 } end
+      vim.api.nvim_win_get_cursor = function()
+        return { 1, 0 }
+      end
 
       assert.has_no.errors(function()
         layout:sync_scroll()
@@ -172,11 +196,21 @@ describe("nil guards", function()
       local win_a = { id = 10 }
       local win_b = { id = 20 }
 
-      vim.api.nvim_get_current_win = function() return 10 end
-      vim.api.nvim_win_get_buf = function() return 1 end
-      vim.api.nvim_buf_line_count = function() return 0 end
-      vim.api.nvim_win_get_cursor = function() return { 1, 0 } end
-      vim.api.nvim_win_call = function(_, fn) fn() end
+      vim.api.nvim_get_current_win = function()
+        return 10
+      end
+      vim.api.nvim_win_get_buf = function()
+        return 1
+      end
+      vim.api.nvim_buf_line_count = function()
+        return 0
+      end
+      vim.api.nvim_win_get_cursor = function()
+        return { 1, 0 }
+      end
+      vim.api.nvim_win_call = function(_, fn)
+        fn()
+      end
       vim.api.nvim_exec_autocmds = function() end
       vim.api.nvim_win_set_cursor = function() end
 
@@ -192,17 +226,27 @@ describe("nil guards", function()
       local win_b = { id = 20 }
       local set_cursor_calls = {}
 
-      vim.api.nvim_get_current_win = function() return 10 end
+      vim.api.nvim_get_current_win = function()
+        return 10
+      end
       vim.api.nvim_win_get_buf = function(winid)
-        if winid == 10 then return 1 end
+        if winid == 10 then
+          return 1
+        end
         return 2
       end
       vim.api.nvim_buf_line_count = function(bufnr)
-        if bufnr == 1 then return 5 end
+        if bufnr == 1 then
+          return 5
+        end
         return 100
       end
-      vim.api.nvim_win_get_cursor = function() return { 3, 0 } end
-      vim.api.nvim_win_call = function(_, fn) fn() end
+      vim.api.nvim_win_get_cursor = function()
+        return { 3, 0 }
+      end
+      vim.api.nvim_win_call = function(_, fn)
+        fn()
+      end
       vim.api.nvim_exec_autocmds = function() end
       vim.api.nvim_win_set_cursor = function(winid, cursor)
         set_cursor_calls[#set_cursor_calls + 1] = { winid = winid, cursor = cursor }
@@ -230,9 +274,15 @@ describe("nil guards", function()
     local function make_panel()
       local panel = {
         cur_file = nil,
-        set_cur_file = function(self, f) self.cur_file = f end,
-        ordered_file_list = function(self) return {} end,
-        prev_file = function(self) return nil end,
+        set_cur_file = function(self, f)
+          self.cur_file = f
+        end,
+        ordered_file_list = function(self)
+          return {}
+        end,
+        prev_file = function(self)
+          return nil
+        end,
       }
       return panel
     end
@@ -487,7 +537,9 @@ describe("nil guards", function()
       local new_files = { f2 }
 
       -- The diff algorithm produces NOOP for matching entries.
-      local diff = Diff(cur_files, new_files, function(a, b) return a.path == b.path end)
+      local diff = Diff(cur_files, new_files, function(a, b)
+        return a.path == b.path
+      end)
       local script = diff:create_edit_script()
       eq({ EditToken.NOOP }, script)
 
@@ -519,9 +571,8 @@ describe("nil guards", function()
   -- Same class of bug as #74 (FilePanel), but in FileHistoryPanel.
   -- update_components() called render_data:destroy() without a nil guard.
   describe("FileHistoryPanel update_components nil render_data", function()
-    local FileHistoryPanel = require(
-      "diffview.scene.views.file_history.file_history_panel"
-    ).FileHistoryPanel
+    local FileHistoryPanel =
+      require("diffview.scene.views.file_history.file_history_panel").FileHistoryPanel
 
     it("returns early without error when render_data is nil", function()
       -- Build a minimal panel-shaped object with the method under test.

--- a/lua/diffview/tests/functional/node_spec.lua
+++ b/lua/diffview/tests/functional/node_spec.lua
@@ -123,14 +123,18 @@ describe("diffview.ui.models.file_tree.node", function()
     end)
 
     it("custom sort_file returning true puts a before b", function()
-      stub_config(function() return true end)
+      stub_config(function()
+        return true
+      end)
       local a = make_file("z.lua")
       local b = make_file("a.lua")
       eq(true, Node.comparator(a, b))
     end)
 
     it("custom sort_file returning false puts b before a", function()
-      stub_config(function() return false end)
+      stub_config(function()
+        return false
+      end)
       local a = make_file("a.lua")
       local b = make_file("z.lua")
       eq(false, Node.comparator(a, b))

--- a/lua/diffview/tests/functional/null_adapter_spec.lua
+++ b/lua/diffview/tests/functional/null_adapter_spec.lua
@@ -9,7 +9,9 @@ describe("diffview.vcs.adapters.null", function()
   describe("NullAdapter", function()
     local adapter
 
-    before_each(function() adapter = NullAdapter.create({ toplevel = "/tmp/test" }) end)
+    before_each(function()
+      adapter = NullAdapter.create({ toplevel = "/tmp/test" })
+    end)
 
     it("sets ctx fields from toplevel", function()
       eq("/tmp/test", adapter.ctx.toplevel)
@@ -22,7 +24,9 @@ describe("diffview.vcs.adapters.null", function()
       assert.False(adapter:is_binary("any/file.txt", rev))
     end)
 
-    it("head_rev returns nil", function() assert.is_nil(adapter:head_rev()) end)
+    it("head_rev returns nil", function()
+      assert.is_nil(adapter:head_rev())
+    end)
 
     it("file_blob_hash returns nil", function()
       assert.is_nil(adapter:file_blob_hash("any/file.txt"))
@@ -47,18 +51,25 @@ describe("diffview.vcs.adapters.null", function()
       eq({}, adapter:rev_to_args(left, right))
     end)
 
-    it("get_merge_context returns nil", function() assert.is_nil(adapter:get_merge_context()) end)
+    it("get_merge_context returns nil", function()
+      assert.is_nil(adapter:get_merge_context())
+    end)
 
-    it("show_untracked returns false", function() assert.False(adapter:show_untracked()) end)
+    it("show_untracked returns false", function()
+      assert.False(adapter:show_untracked())
+    end)
 
-    it("stage_index_file returns false", function() assert.False(adapter:stage_index_file({})) end)
+    it("stage_index_file returns false", function()
+      assert.False(adapter:stage_index_file({}))
+    end)
 
-    it("add_files returns false", function() assert.False(adapter:add_files({ "file.txt" })) end)
+    it("add_files returns false", function()
+      assert.False(adapter:add_files({ "file.txt" }))
+    end)
 
-    it(
-      "reset_files returns false",
-      function() assert.False(adapter:reset_files({ "file.txt" })) end
-    )
+    it("reset_files returns false", function()
+      assert.False(adapter:reset_files({ "file.txt" }))
+    end)
 
     it("force_entry_refresh_on_noop returns false", function()
       local left = NullRev(RevType.LOCAL)
@@ -66,14 +77,17 @@ describe("diffview.vcs.adapters.null", function()
       assert.False(adapter:force_entry_refresh_on_noop(left, right))
     end)
 
-    it("rev_candidates returns empty table", function() eq({}, adapter:rev_candidates("")) end)
+    it("rev_candidates returns empty table", function()
+      eq({}, adapter:rev_candidates(""))
+    end)
 
-    it(
-      "get_show_args returns empty table",
-      function() eq({}, adapter:get_show_args("file.txt", NullRev(RevType.LOCAL))) end
-    )
+    it("get_show_args returns empty table", function()
+      eq({}, adapter:get_show_args("file.txt", NullRev(RevType.LOCAL)))
+    end)
 
-    it("get_log_args returns empty table", function() eq({}, adapter:get_log_args({})) end)
+    it("get_log_args returns empty table", function()
+      eq({}, adapter:get_log_args({}))
+    end)
 
     it("bootstrap succeeds", function()
       NullAdapter.run_bootstrap()
@@ -94,9 +108,13 @@ describe("diffview.vcs.adapters.null", function()
       assert.is_nil(NullRev.to_range(rev))
     end)
 
-    it("from_name returns nil", function() assert.is_nil(NullRev.from_name("HEAD")) end)
+    it("from_name returns nil", function()
+      assert.is_nil(NullRev.from_name("HEAD"))
+    end)
 
-    it("earliest_commit returns nil", function() assert.is_nil(NullRev.earliest_commit({})) end)
+    it("earliest_commit returns nil", function()
+      assert.is_nil(NullRev.earliest_commit({}))
+    end)
 
     it("new_null_tree returns a LOCAL rev", function()
       local rev = NullRev.new_null_tree()

--- a/lua/diffview/tests/functional/p4_adapter_spec.lua
+++ b/lua/diffview/tests/functional/p4_adapter_spec.lua
@@ -44,10 +44,7 @@ local function create_p4_repo()
   -- Create a client workspace.
   local spec = run({ "p4", "client", "-o", p4client }, workspace, env)
   spec = spec:gsub("Root:\t[^\n]+", "Root:\t" .. workspace)
-  vim.fn.system(
-    { "p4", "-p", p4port, "-u", p4user, "client", "-i" },
-    spec
-  )
+  vim.fn.system({ "p4", "-p", p4port, "-u", p4user, "client", "-i" }, spec)
   assert.equals(0, vim.v.shell_error, "p4 client -i failed")
 
   --- Build common p4 flags including -d for the workspace directory.
@@ -144,7 +141,10 @@ describe("diffview.vcs.adapters.p4", function()
     end)
 
     it("to_range formats single and double revision strings", function()
-      assert.equals("@1,@5", P4Rev.to_range(P4Rev(RevType.COMMIT, "@1"), P4Rev(RevType.COMMIT, "@5")))
+      assert.equals(
+        "@1,@5",
+        P4Rev.to_range(P4Rev(RevType.COMMIT, "@1"), P4Rev(RevType.COMMIT, "@5"))
+      )
       assert.equals("@1", P4Rev.to_range(P4Rev(RevType.COMMIT, "@1")))
       assert.equals("@1", P4Rev.to_range(P4Rev(RevType.COMMIT, "@1"), P4Rev(RevType.COMMIT, "@1")))
     end)
@@ -223,114 +223,145 @@ describe("diffview.vcs.adapters.p4", function()
     end)
 
     after_each(function()
-      if repo then repo:cleanup() end
+      if repo then
+        repo:cleanup()
+      end
     end)
 
-    it("parses p4 opened output without double revision specifiers", test_utils.async_test(function()
-      if not p4_available() then pending("p4/p4d not installed") return end
+    it(
+      "parses p4 opened output without double revision specifiers",
+      test_utils.async_test(function()
+        if not p4_available() then
+          pending("p4/p4d not installed")
+          return
+        end
 
-      -- Seed the depot with an initial file.
-      repo.write("src/main.lua", 'print("v1")\n')
-      repo.p4({ "add", "src/main.lua" })
-      repo.p4({ "submit", "-d", "CL 1: add main.lua" })
+        -- Seed the depot with an initial file.
+        repo.write("src/main.lua", 'print("v1")\n')
+        repo.p4({ "add", "src/main.lua" })
+        repo.p4({ "submit", "-d", "CL 1: add main.lua" })
 
-      -- Open the file for edit so it appears in `p4 opened`.
-      repo.p4({ "edit", "src/main.lua" })
-      repo.write("src/main.lua", 'print("v2")\n')
+        -- Open the file for edit so it appears in `p4 opened`.
+        repo.p4({ "edit", "src/main.lua" })
+        repo.write("src/main.lua", 'print("v2")\n')
 
-      local adapter = repo:adapter()
-      local left = P4Rev(RevType.COMMIT, "#head")
-      local right = P4Rev(RevType.LOCAL)
-      local args = adapter:rev_to_args(left, right)
+        local adapter = repo:adapter()
+        local left = P4Rev(RevType.COMMIT, "#head")
+        local right = P4Rev(RevType.LOCAL)
+        local args = adapter:rev_to_args(left, right)
 
-      local err, files = await(adapter:tracked_files(
-        left, right, args, "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
-
-      assert.is_nil(err)
-      assert.is_true(#files > 0)
-
-      -- Paths must be workspace-relative (no depot prefix, no #rev).
-      for _, file in ipairs(files) do
-        assert.is_nil(
-          file.path:match("#%d+"),
-          ("path %q should not contain a revision specifier"):format(file.path)
+        local err, files = await(
+          adapter:tracked_files(
+            left,
+            right,
+            args,
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
         )
-        assert.is_nil(
-          file.path:match("^//"),
-          ("path %q should not be a depot path"):format(file.path)
+
+        assert.is_nil(err)
+        assert.is_true(#files > 0)
+
+        -- Paths must be workspace-relative (no depot prefix, no #rev).
+        for _, file in ipairs(files) do
+          assert.is_nil(
+            file.path:match("#%d+"),
+            ("path %q should not contain a revision specifier"):format(file.path)
+          )
+          assert.is_nil(
+            file.path:match("^//"),
+            ("path %q should not be a depot path"):format(file.path)
+          )
+        end
+      end)
+    )
+
+    it(
+      "parses diff2 -ds output for commit-to-commit diffs",
+      test_utils.async_test(function()
+        if not p4_available() then
+          pending("p4/p4d not installed")
+          return
+        end
+
+        -- CL 1: add two files.
+        repo.write("src/main.lua", 'print("v1")\n')
+        repo.write("src/utils.lua", "local M = {}; return M\n")
+        repo.p4({ "add", "src/main.lua", "src/utils.lua" })
+        repo.p4({ "submit", "-d", "CL 1: initial" })
+
+        -- CL 2: edit main, delete utils, add new.
+        repo.p4({ "edit", "src/main.lua" })
+        repo.write("src/main.lua", 'print("v2")\n')
+        repo.p4({ "delete", "src/utils.lua" })
+        repo.write("src/new.lua", "new\n")
+        repo.p4({ "add", "src/new.lua" })
+        repo.p4({ "submit", "-d", "CL 2: modify, delete, add" })
+
+        local adapter = repo:adapter()
+        local left = P4Rev(RevType.COMMIT, "@1")
+        local right = P4Rev(RevType.COMMIT, "@2")
+        local args = adapter:rev_to_args(left, right)
+
+        local err, files = await(
+          adapter:tracked_files(
+            left,
+            right,
+            args,
+            "working",
+            { default_layout = Diff2, merge_layout = Diff2 }
+          )
         )
-      end
-    end))
 
-    it("parses diff2 -ds output for commit-to-commit diffs", test_utils.async_test(function()
-      if not p4_available() then pending("p4/p4d not installed") return end
+        assert.is_nil(err)
 
-      -- CL 1: add two files.
-      repo.write("src/main.lua", 'print("v1")\n')
-      repo.write("src/utils.lua", "local M = {}; return M\n")
-      repo.p4({ "add", "src/main.lua", "src/utils.lua" })
-      repo.p4({ "submit", "-d", "CL 1: initial" })
+        -- Build a status lookup keyed by the last component of the depot path.
+        local by_name = {}
+        for _, file in ipairs(files) do
+          local name = file.path:match("[^/]+$")
+          by_name[name] = file
 
-      -- CL 2: edit main, delete utils, add new.
-      repo.p4({ "edit", "src/main.lua" })
-      repo.write("src/main.lua", 'print("v2")\n')
-      repo.p4({ "delete", "src/utils.lua" })
-      repo.write("src/new.lua", "new\n")
-      repo.p4({ "add", "src/new.lua" })
-      repo.p4({ "submit", "-d", "CL 2: modify, delete, add" })
+          -- No path should contain a #rev suffix.
+          assert.is_nil(
+            file.path:match("#%d+"),
+            ("path %q should not contain a revision specifier"):format(file.path)
+          )
+        end
 
-      local adapter = repo:adapter()
-      local left = P4Rev(RevType.COMMIT, "@1")
-      local right = P4Rev(RevType.COMMIT, "@2")
-      local args = adapter:rev_to_args(left, right)
+        assert.is_not_nil(by_name["main.lua"], "main.lua should appear (modified)")
+        assert.equals("M", by_name["main.lua"].status)
 
-      local err, files = await(adapter:tracked_files(
-        left, right, args, "working",
-        { default_layout = Diff2, merge_layout = Diff2 }
-      ))
+        assert.is_not_nil(by_name["new.lua"], "new.lua should appear (added)")
+        assert.equals("A", by_name["new.lua"].status)
 
-      assert.is_nil(err)
+        assert.is_not_nil(by_name["utils.lua"], "utils.lua should appear (deleted)")
+        assert.equals("D", by_name["utils.lua"].status)
+      end)
+    )
 
-      -- Build a status lookup keyed by the last component of the depot path.
-      local by_name = {}
-      for _, file in ipairs(files) do
-        local name = file.path:match("[^/]+$")
-        by_name[name] = file
+    it(
+      "shows file content via get_show_args without errors",
+      test_utils.async_test(function()
+        if not p4_available() then
+          pending("p4/p4d not installed")
+          return
+        end
 
-        -- No path should contain a #rev suffix.
-        assert.is_nil(
-          file.path:match("#%d+"),
-          ("path %q should not contain a revision specifier"):format(file.path)
-        )
-      end
+        repo.write("hello.txt", "hello world\n")
+        repo.p4({ "add", "hello.txt" })
+        repo.p4({ "submit", "-d", "add hello" })
 
-      assert.is_not_nil(by_name["main.lua"], "main.lua should appear (modified)")
-      assert.equals("M", by_name["main.lua"].status)
+        local adapter = repo:adapter()
 
-      assert.is_not_nil(by_name["new.lua"], "new.lua should appear (added)")
-      assert.equals("A", by_name["new.lua"].status)
+        -- Simulate what the plugin does: show file at #head.
+        local err, content =
+          await(adapter:show("//depot/hello.txt", P4Rev(RevType.COMMIT, "#head")))
 
-      assert.is_not_nil(by_name["utils.lua"], "utils.lua should appear (deleted)")
-      assert.equals("D", by_name["utils.lua"].status)
-    end))
-
-    it("shows file content via get_show_args without errors", test_utils.async_test(function()
-      if not p4_available() then pending("p4/p4d not installed") return end
-
-      repo.write("hello.txt", "hello world\n")
-      repo.p4({ "add", "hello.txt" })
-      repo.p4({ "submit", "-d", "add hello" })
-
-      local adapter = repo:adapter()
-
-      -- Simulate what the plugin does: show file at #head.
-      local err, content = await(adapter:show("//depot/hello.txt", P4Rev(RevType.COMMIT, "#head")))
-
-      assert.is_nil(err)
-      assert.is_not_nil(content)
-      assert.equals("hello world", vim.trim(table.concat(content, "\n")))
-    end))
+        assert.is_nil(err)
+        assert.is_not_nil(content)
+        assert.equals("hello world", vim.trim(table.concat(content, "\n")))
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/panel_render_spec.lua
+++ b/lua/diffview/tests/functional/panel_render_spec.lua
@@ -111,7 +111,10 @@ describe("panel_render", function()
   describe("file count on collapsed folders", function()
     describe("Node:leaves()", function()
       it("returns leaf nodes for a flat directory", function()
-        local root = Node("root", { name = "root", path = "root", kind = "working", collapsed = false, status = "M" })
+        local root = Node(
+          "root",
+          { name = "root", path = "root", kind = "working", collapsed = false, status = "M" }
+        )
         root:add_child(Node("a.lua", { path = "root/a.lua", status = "M" }))
         root:add_child(Node("b.lua", { path = "root/b.lua", status = "A" }))
         root:add_child(Node("c.lua", { path = "root/c.lua", status = "D" }))
@@ -123,9 +126,21 @@ describe("panel_render", function()
       it("returns leaf nodes across nested directories", function()
         -- Structure: src/ -> components/ -> [a.lua, b.lua]
         --                  -> utils/ -> [c.lua]
-        local src = Node("src", { name = "src", path = "src", kind = "working", collapsed = false, status = "M" })
-        local components = Node("components", { name = "components", path = "src/components", kind = "working", collapsed = false, status = "M" })
-        local utils_dir = Node("utils", { name = "utils", path = "src/utils", kind = "working", collapsed = false, status = "A" })
+        local src = Node(
+          "src",
+          { name = "src", path = "src", kind = "working", collapsed = false, status = "M" }
+        )
+        local components = Node("components", {
+          name = "components",
+          path = "src/components",
+          kind = "working",
+          collapsed = false,
+          status = "M",
+        })
+        local utils_dir = Node(
+          "utils",
+          { name = "utils", path = "src/utils", kind = "working", collapsed = false, status = "A" }
+        )
         src:add_child(components)
         src:add_child(utils_dir)
         components:add_child(Node("a.lua", { path = "src/components/a.lua", status = "M" }))
@@ -138,9 +153,14 @@ describe("panel_render", function()
 
       it("returns only the deeply nested leaf in a long chain", function()
         -- Chain: a/ -> b/ -> c/ -> file.lua
-        local a = Node("a", { name = "a", path = "a", kind = "working", collapsed = false, status = "M" })
-        local b = Node("b", { name = "b", path = "a/b", kind = "working", collapsed = false, status = "M" })
-        local c = Node("c", { name = "c", path = "a/b/c", kind = "working", collapsed = false, status = "M" })
+        local a =
+          Node("a", { name = "a", path = "a", kind = "working", collapsed = false, status = "M" })
+        local b =
+          Node("b", { name = "b", path = "a/b", kind = "working", collapsed = false, status = "M" })
+        local c = Node(
+          "c",
+          { name = "c", path = "a/b/c", kind = "working", collapsed = false, status = "M" }
+        )
         a:add_child(b)
         b:add_child(c)
         c:add_child(Node("file.lua", { path = "a/b/c/file.lua", status = "M" }))
@@ -158,7 +178,10 @@ describe("panel_render", function()
         config.setup(conf)
 
         -- Build a directory node with 3 leaves.
-        local dir_node = Node("src", { name = "src", path = "src", kind = "working", collapsed = true, status = "M" })
+        local dir_node = Node(
+          "src",
+          { name = "src", path = "src", kind = "working", collapsed = true, status = "M" }
+        )
         dir_node:add_child(Node("a.lua", { path = "src/a.lua", status = "M" }))
         dir_node:add_child(Node("b.lua", { path = "src/b.lua", status = "M" }))
         dir_node:add_child(Node("c.lua", { path = "src/c.lua", status = "M" }))
@@ -187,7 +210,10 @@ describe("panel_render", function()
         conf.file_panel.tree_options.folder_count_style = "grouped"
         config.setup(conf)
 
-        local dir_node = Node("src", { name = "src", path = "src", kind = "working", collapsed = true, status = "M" })
+        local dir_node = Node(
+          "src",
+          { name = "src", path = "src", kind = "working", collapsed = true, status = "M" }
+        )
         dir_node:add_child(Node("a.lua", { path = "src/a.lua", status = "M" }))
         dir_node:add_child(Node("b.lua", { path = "src/b.lua", status = "A" }))
         dir_node:add_child(Node("c.lua", { path = "src/c.lua", status = "M" }))
@@ -203,7 +229,10 @@ describe("panel_render", function()
         assert.truthy(added_text:find("1"), "expected A-status highlight to contain count 1")
         assert.is_nil(added_text:find("2"), "did not expect A-status highlight to contain count 2")
         assert.truthy(modified_text:find("2"), "expected M-status highlight to contain count 2")
-        assert.is_nil(modified_text:find("1"), "did not expect M-status highlight to contain count 1")
+        assert.is_nil(
+          modified_text:find("1"),
+          "did not expect M-status highlight to contain count 1"
+        )
 
         -- The opening and closing parentheses should be DiffviewDim1.
         local dim_segs = comp:segments_by_hl("DiffviewDim1")
@@ -216,7 +245,10 @@ describe("panel_render", function()
         conf.file_panel.tree_options.folder_count_style = "grouped"
         config.setup(conf)
 
-        local dir_node = Node("src", { name = "src", path = "src", kind = "working", collapsed = true, status = "M" })
+        local dir_node = Node(
+          "src",
+          { name = "src", path = "src", kind = "working", collapsed = true, status = "M" }
+        )
         dir_node:add_child(Node("x.lua", { path = "src/x.lua", status = "D" }))
         dir_node:add_child(Node("y.lua", { path = "src/y.lua", status = "D" }))
         dir_node:add_child(Node("z.lua", { path = "src/z.lua", status = "A" }))
@@ -232,7 +264,10 @@ describe("panel_render", function()
         assert.truthy(added_text:find("1"), "expected A-status highlight to contain count 1")
         assert.is_nil(added_text:find("2"), "did not expect A-status highlight to contain count 2")
         assert.truthy(deleted_text:find("2"), "expected D-status highlight to contain count 2")
-        assert.is_nil(deleted_text:find("1"), "did not expect D-status highlight to contain count 1")
+        assert.is_nil(
+          deleted_text:find("1"),
+          "did not expect D-status highlight to contain count 1"
+        )
 
         -- The opening and closing parentheses should be DiffviewDim1.
         local dim_segs = comp:segments_by_hl("DiffviewDim1")
@@ -245,7 +280,10 @@ describe("panel_render", function()
         conf.file_panel.tree_options.folder_count_style = "none"
         config.setup(conf)
 
-        local dir_node = Node("src", { name = "src", path = "src", kind = "working", collapsed = true, status = "M" })
+        local dir_node = Node(
+          "src",
+          { name = "src", path = "src", kind = "working", collapsed = true, status = "M" }
+        )
         dir_node:add_child(Node("a.lua", { path = "src/a.lua", status = "M" }))
         dir_node:add_child(Node("b.lua", { path = "src/b.lua", status = "A" }))
 
@@ -258,7 +296,10 @@ describe("panel_render", function()
 
       it("does not show count when directory is expanded", function()
         -- When collapsed is false, the count section is skipped.
-        local dir_node = Node("src", { name = "src", path = "src", kind = "working", collapsed = false, status = "M" })
+        local dir_node = Node(
+          "src",
+          { name = "src", path = "src", kind = "working", collapsed = false, status = "M" }
+        )
         dir_node:add_child(Node("a.lua", { path = "src/a.lua", status = "M" }))
 
         local ctx = {
@@ -315,14 +356,20 @@ describe("panel_render", function()
       local files = { conflicting = {}, working = working or {}, staged = {} }
       function files:iter()
         local all = {}
-        for _, f in ipairs(self.working) do all[#all + 1] = f end
+        for _, f in ipairs(self.working) do
+          all[#all + 1] = f
+        end
         local i = 0
         return function()
           i = i + 1
-          if i <= #all then return i, all[i] end
+          if i <= #all then
+            return i, all[i]
+          end
         end
       end
-      function files:len() return #self.conflicting + #self.working + #self.staged end
+      function files:len()
+        return #self.conflicting + #self.working + #self.staged
+      end
       return files
     end
 
@@ -333,7 +380,9 @@ describe("panel_render", function()
 
       local adapter = {
         ctx = { toplevel = "/tmp", dir = "/tmp/.git" },
-        get_branch_name = function() return nil end,
+        get_branch_name = function()
+          return nil
+        end,
       }
       local panel = FilePanel(adapter, make_files(entries or {}), {})
       panel.listing_style = "list"
@@ -408,19 +457,30 @@ describe("panel_render", function()
     local FilePanel = require("diffview.scene.views.diff.file_panel").FilePanel
 
     local function make_files(conflicting, working, staged)
-      local files = { conflicting = conflicting or {}, working = working or {}, staged = staged or {} }
+      local files =
+        { conflicting = conflicting or {}, working = working or {}, staged = staged or {} }
       function files:iter()
         local all = {}
-        for _, f in ipairs(self.conflicting) do all[#all + 1] = f end
-        for _, f in ipairs(self.working) do all[#all + 1] = f end
-        for _, f in ipairs(self.staged) do all[#all + 1] = f end
+        for _, f in ipairs(self.conflicting) do
+          all[#all + 1] = f
+        end
+        for _, f in ipairs(self.working) do
+          all[#all + 1] = f
+        end
+        for _, f in ipairs(self.staged) do
+          all[#all + 1] = f
+        end
         local i = 0
         return function()
           i = i + 1
-          if i <= #all then return i, all[i] end
+          if i <= #all then
+            return i, all[i]
+          end
         end
       end
-      function files:len() return #self.conflicting + #self.working + #self.staged end
+      function files:len()
+        return #self.conflicting + #self.working + #self.staged
+      end
       return files
     end
 
@@ -430,7 +490,9 @@ describe("panel_render", function()
 
       local adapter = {
         ctx = { toplevel = "/tmp", dir = "/tmp/.git" },
-        get_branch_name = function() return nil end,
+        get_branch_name = function()
+          return nil
+        end,
       }
       local panel = FilePanel(adapter, make_files(conflicting, working, staged), {})
       panel.listing_style = "list"
@@ -459,7 +521,10 @@ describe("panel_render", function()
 
       local lines = vim.api.nvim_buf_get_lines(panel.bufid, 0, -1, false)
       local joined = table.concat(lines, "\n")
-      assert.falsy(joined:find("Working tree clean"), "should not show clean message with working files")
+      assert.falsy(
+        joined:find("Working tree clean"),
+        "should not show clean message with working files"
+      )
 
       panel:destroy()
     end)
@@ -475,8 +540,10 @@ describe("panel_render", function()
       local lines = vim.api.nvim_buf_get_lines(panel.bufid, 0, -1, false)
       local joined = table.concat(lines, "\n")
       -- "Working tree clean" should NOT appear because conflicts exist.
-      assert.falsy(joined:find("Working tree clean"),
-        "should not show clean message when conflicts exist")
+      assert.falsy(
+        joined:find("Working tree clean"),
+        "should not show clean message when conflicts exist"
+      )
 
       panel:destroy()
     end)
@@ -491,8 +558,10 @@ describe("panel_render", function()
       local joined = table.concat(lines, "\n")
       -- When staged files exist but working is empty, it should say "(empty)"
       -- for the working section, not "Working tree clean".
-      assert.falsy(joined:find("Working tree clean"),
-        "should not show clean message when staged files exist")
+      assert.falsy(
+        joined:find("Working tree clean"),
+        "should not show clean message when staged files exist"
+      )
 
       panel:destroy()
     end)
@@ -725,14 +794,20 @@ describe("panel_render", function()
       local files = { conflicting = {}, working = working or {}, staged = {} }
       function files:iter()
         local all = {}
-        for _, f in ipairs(self.working) do all[#all + 1] = f end
+        for _, f in ipairs(self.working) do
+          all[#all + 1] = f
+        end
         local i = 0
         return function()
           i = i + 1
-          if i <= #all then return i, all[i] end
+          if i <= #all then
+            return i, all[i]
+          end
         end
       end
-      function files:len() return #self.conflicting + #self.working + #self.staged end
+      function files:len()
+        return #self.conflicting + #self.working + #self.staged
+      end
       return files
     end
 
@@ -741,7 +816,9 @@ describe("panel_render", function()
 
       local adapter = {
         ctx = { toplevel = "/tmp", dir = "/tmp/.git" },
-        get_branch_name = function() return nil end,
+        get_branch_name = function()
+          return nil
+        end,
       }
       local panel = FilePanel(adapter, make_files(entries or {}), {})
       panel.listing_style = "list"
@@ -753,7 +830,11 @@ describe("panel_render", function()
     ---Get all sign extmarks in the selection signs namespace.
     local function get_signs(panel)
       return vim.api.nvim_buf_get_extmarks(
-        panel.bufid, selection_signs_ns, 0, -1, { details = true }
+        panel.bufid,
+        selection_signs_ns,
+        0,
+        -1,
+        { details = true }
       )
     end
 
@@ -842,48 +923,54 @@ describe("panel_render", function()
       panel:destroy()
     end)
 
-    it("sign_column mode places no signs when nothing is selected and always_show_marks is false", function()
-      local conf = config.get_config()
-      conf.file_panel.mark_placement = "sign_column"
-      conf.file_panel.always_show_marks = false
-      config.setup(conf)
+    it(
+      "sign_column mode places no signs when nothing is selected and always_show_marks is false",
+      function()
+        local conf = config.get_config()
+        conf.file_panel.mark_placement = "sign_column"
+        conf.file_panel.always_show_marks = false
+        config.setup(conf)
 
-      local f = make_entry("a.lua")
-      local panel = make_panel({ f })
-      -- No selections.
-      panel:update_components()
-      panel:render()
-      panel:redraw()
+        local f = make_entry("a.lua")
+        local panel = make_panel({ f })
+        -- No selections.
+        panel:update_components()
+        panel:render()
+        panel:redraw()
 
-      eq(0, #get_signs(panel))
+        eq(0, #get_signs(panel))
 
-      panel:destroy()
-    end)
-
-    it("sign_column mode places signs when always_show_marks is true even with no selections", function()
-      local conf = config.get_config()
-      conf.file_panel.mark_placement = "sign_column"
-      conf.file_panel.always_show_marks = true
-      config.setup(conf)
-
-      local f1 = make_entry("a.lua")
-      local f2 = make_entry("b.lua")
-      local panel = make_panel({ f1, f2 })
-      -- No selections.
-      panel:update_components()
-      panel:render()
-      panel:redraw()
-
-      local signs = get_signs(panel)
-      eq(2, #signs)
-
-      -- All signs should show the unselected mark.
-      for _, s in ipairs(signs) do
-        eq(conf.signs.unselected_file, vim.trim(s[4].sign_text))
+        panel:destroy()
       end
+    )
 
-      panel:destroy()
-    end)
+    it(
+      "sign_column mode places signs when always_show_marks is true even with no selections",
+      function()
+        local conf = config.get_config()
+        conf.file_panel.mark_placement = "sign_column"
+        conf.file_panel.always_show_marks = true
+        config.setup(conf)
+
+        local f1 = make_entry("a.lua")
+        local f2 = make_entry("b.lua")
+        local panel = make_panel({ f1, f2 })
+        -- No selections.
+        panel:update_components()
+        panel:render()
+        panel:redraw()
+
+        local signs = get_signs(panel)
+        eq(2, #signs)
+
+        -- All signs should show the unselected mark.
+        for _, s in ipairs(signs) do
+          eq(conf.signs.unselected_file, vim.trim(s[4].sign_text))
+        end
+
+        panel:destroy()
+      end
+    )
 
     it("sign_column mode uses DiffviewFilePanelMarked highlight for selected files", function()
       local conf = config.get_config()
@@ -1037,7 +1124,9 @@ describe("panel_render", function()
 
         local adapter = {
           ctx = { toplevel = "/tmp", dir = "/tmp/.git" },
-          get_branch_name = function() return nil end,
+          get_branch_name = function()
+            return nil
+          end,
         }
         local fd = FileDict()
         for i, e in ipairs(entries) do
@@ -1185,8 +1274,12 @@ describe("panel_render", function()
     ---Create a minimal panel stub exposing the methods render_file depends on.
     local function make_panel_stub()
       return {
-        is_selected = function(_, _) return false end,
-        has_any_selections = function(_) return false end,
+        is_selected = function(_, _)
+          return false
+        end,
+        has_any_selections = function(_)
+          return false
+        end,
       }
     end
 
@@ -1375,7 +1468,9 @@ describe("panel_render", function()
       -- installed in the test environment.
       saved_devicons = package.loaded["nvim-web-devicons"]
       package.loaded["nvim-web-devicons"] = {
-        get_icon = function() return "", nil end,
+        get_icon = function()
+          return "", nil
+        end,
       }
     end)
 
@@ -1396,7 +1491,9 @@ describe("panel_render", function()
 
       local adapter = {
         ctx = { toplevel = "/tmp", dir = "/tmp/.git" },
-        get_branch_name = function() return nil end,
+        get_branch_name = function()
+          return nil
+        end,
       }
       local fd = FileDict()
       for i, e in ipairs(entries) do

--- a/lua/diffview/tests/functional/panel_spec.lua
+++ b/lua/diffview/tests/functional/panel_spec.lua
@@ -159,7 +159,9 @@ describe("diffview.ui.panel", function()
 
       -- Mock a component covering only lines 1-2 (0-indexed: lstart=1, lend=3).
       local mock_comp = { lstart = 1, lend = 3 }
-      panel.get_autosize_components = function() return { mock_comp } end
+      panel.get_autosize_components = function()
+        return { mock_comp }
+      end
 
       local width = panel:compute_content_width()
       -- Should measure only "short file entry" (17 chars) + textoff(2) + 1 = 20.
@@ -169,26 +171,31 @@ describe("diffview.ui.panel", function()
       api.nvim_buf_delete(bufid, { force = true })
     end)
 
-    it("compute_content_width falls back to all lines when autosize components are empty", function()
-      local panel = make_panel("auto")
-      local bufid = api.nvim_create_buf(false, true)
-      panel.bufid = bufid
-      api.nvim_buf_set_lines(bufid, 0, -1, false, {
-        "header line",
-        "another line here!",
-      })
+    it(
+      "compute_content_width falls back to all lines when autosize components are empty",
+      function()
+        local panel = make_panel("auto")
+        local bufid = api.nvim_create_buf(false, true)
+        panel.bufid = bufid
+        api.nvim_buf_set_lines(bufid, 0, -1, false, {
+          "header line",
+          "another line here!",
+        })
 
-      -- Mock zero-height components (lend <= lstart), as during loading.
-      local mock_comp = { lstart = 0, lend = 0 }
-      panel.get_autosize_components = function() return { mock_comp } end
+        -- Mock zero-height components (lend <= lstart), as during loading.
+        local mock_comp = { lstart = 0, lend = 0 }
+        panel.get_autosize_components = function()
+          return { mock_comp }
+        end
 
-      local width = panel:compute_content_width()
-      -- Should fall back to measuring all lines.
-      local expected = api.nvim_strwidth("another line here!") + 2 + 1
-      eq(expected, width)
+        local width = panel:compute_content_width()
+        -- Should fall back to measuring all lines.
+        local expected = api.nvim_strwidth("another line here!") + 2 + 1
+        eq(expected, width)
 
-      api.nvim_buf_delete(bufid, { force = true })
-    end)
+        api.nvim_buf_delete(bufid, { force = true })
+      end
+    )
 
     it("compute_content_width clamps to half the editor width", function()
       local panel = make_panel("auto")
@@ -274,7 +281,9 @@ describe("diffview.ui.panel", function()
     it("stops treesitter on the panel buffer during init_buffer", function()
       local saved = vim.treesitter.stop
       local calls = {}
-      vim.treesitter.stop = function(buf) table.insert(calls, buf) end
+      vim.treesitter.stop = function(buf)
+        table.insert(calls, buf)
+      end
 
       local panel = make_panel()
       panel.update_components = function() end
@@ -321,7 +330,8 @@ describe("diffview.ui.panel", function()
     end
 
     local FilePanel = require("diffview.scene.views.diff.file_panel").FilePanel
-    local FileHistoryPanel = require("diffview.scene.views.file_history.file_history_panel").FileHistoryPanel
+    local FileHistoryPanel =
+      require("diffview.scene.views.file_history.file_history_panel").FileHistoryPanel
 
     assert_panel_interface(FilePanel, "FilePanel")
     assert_panel_interface(FileHistoryPanel, "FileHistoryPanel")
@@ -478,8 +488,12 @@ describe("diffview.ui.panel", function()
     local function make_panel()
       local adapter = { ctx = { toplevel = "/tmp", dir = "/tmp/.git" } }
       local files = {}
-      function files:iter() return function() end end
-      function files:len() return 0 end
+      function files:iter()
+        return function() end
+      end
+      function files:len()
+        return 0
+      end
       return FilePanel(adapter, files, {})
     end
 
@@ -638,19 +652,30 @@ describe("diffview.ui.panel", function()
 
     ---Build a mock FileDict with named sub-lists.
     local function make_files(conflicting, working, staged)
-      local files = { conflicting = conflicting or {}, working = working or {}, staged = staged or {} }
+      local files =
+        { conflicting = conflicting or {}, working = working or {}, staged = staged or {} }
       function files:iter()
         local all = {}
-        for _, f in ipairs(self.conflicting) do all[#all + 1] = f end
-        for _, f in ipairs(self.working) do all[#all + 1] = f end
-        for _, f in ipairs(self.staged) do all[#all + 1] = f end
+        for _, f in ipairs(self.conflicting) do
+          all[#all + 1] = f
+        end
+        for _, f in ipairs(self.working) do
+          all[#all + 1] = f
+        end
+        for _, f in ipairs(self.staged) do
+          all[#all + 1] = f
+        end
         local i = 0
         return function()
           i = i + 1
-          if i <= #all then return i, all[i] end
+          if i <= #all then
+            return i, all[i]
+          end
         end
       end
-      function files:len() return #self.conflicting + #self.working + #self.staged end
+      function files:len()
+        return #self.conflicting + #self.working + #self.staged
+      end
       return files
     end
 
@@ -676,7 +701,9 @@ describe("diffview.ui.panel", function()
           }
         end,
       }
-      renderer.create_cursor_constraint = function() return function() end end
+      renderer.create_cursor_constraint = function()
+        return function() end
+      end
 
       local ok, err = pcall(function()
         panel:update_components()
@@ -692,7 +719,9 @@ describe("diffview.ui.panel", function()
       end)
 
       renderer.create_cursor_constraint = orig_create_cursor_constraint
-      if not ok then error(err) end
+      if not ok then
+        error(err)
+      end
     end)
 
     it("tree mode calls update_statuses and create_comp_schema on each tree", function()
@@ -704,7 +733,9 @@ describe("diffview.ui.panel", function()
 
       local function mock_tree(name)
         return {
-          update_statuses = function() statuses_updated[#statuses_updated + 1] = name end,
+          update_statuses = function()
+            statuses_updated[#statuses_updated + 1] = name
+          end,
           create_comp_schema = function(_, opts)
             schemas_created[#schemas_created + 1] = { name = name, opts = opts }
             return { { name = "directory", context = {} } }
@@ -713,16 +744,22 @@ describe("diffview.ui.panel", function()
       end
 
       local files = {
-        conflicting = {}, working = {}, staged = {},
+        conflicting = {},
+        working = {},
+        staged = {},
         conflicting_tree = mock_tree("conflicting"),
         working_tree = mock_tree("working"),
         staged_tree = mock_tree("staged"),
       }
       function files:iter()
         local i = 0
-        return function() i = i + 1 end
+        return function()
+          i = i + 1
+        end
       end
-      function files:len() return 0 end
+      function files:len()
+        return 0
+      end
 
       local adapter = { ctx = { toplevel = "/tmp", dir = "/tmp/.git" } }
       local panel = FilePanel(adapter, files, {})
@@ -737,7 +774,9 @@ describe("diffview.ui.panel", function()
           }
         end,
       }
-      renderer.create_cursor_constraint = function() return function() end end
+      renderer.create_cursor_constraint = function()
+        return function() end
+      end
 
       local ok, err = pcall(function()
         panel:update_components()
@@ -754,7 +793,9 @@ describe("diffview.ui.panel", function()
       end)
 
       renderer.create_cursor_constraint = orig_create_cursor_constraint
-      if not ok then error(err) end
+      if not ok then
+        error(err)
+      end
     end)
   end)
 
@@ -809,7 +850,9 @@ describe("diffview.ui.panel", function()
       pcall(vim.api.nvim_buf_delete, panel.bufid, { force = true })
       vim.keymap.set = orig_keymap_set
       config.get_config = orig_get_config
-      if not ok then error(err) end
+      if not ok then
+        error(err)
+      end
     end)
 
     it("apply_keymaps without extra_defaults omits nowait", function()
@@ -848,7 +891,9 @@ describe("diffview.ui.panel", function()
       pcall(vim.api.nvim_buf_delete, panel.bufid, { force = true })
       vim.keymap.set = orig_keymap_set
       config.get_config = orig_get_config
-      if not ok then error(err) end
+      if not ok then
+        error(err)
+      end
     end)
   end)
 
@@ -857,24 +902,37 @@ describe("diffview.ui.panel", function()
 
     ---Build a mock FileDict with named sub-lists and an iter method.
     local function make_files(conflicting, working, staged)
-      local files = { conflicting = conflicting or {}, working = working or {}, staged = staged or {} }
+      local files =
+        { conflicting = conflicting or {}, working = working or {}, staged = staged or {} }
       function files:iter()
         local all = {}
-        for _, f in ipairs(self.conflicting) do all[#all + 1] = f end
-        for _, f in ipairs(self.working) do all[#all + 1] = f end
-        for _, f in ipairs(self.staged) do all[#all + 1] = f end
+        for _, f in ipairs(self.conflicting) do
+          all[#all + 1] = f
+        end
+        for _, f in ipairs(self.working) do
+          all[#all + 1] = f
+        end
+        for _, f in ipairs(self.staged) do
+          all[#all + 1] = f
+        end
         local i = 0
         return function()
           i = i + 1
-          if i <= #all then return i, all[i] end
+          if i <= #all then
+            return i, all[i]
+          end
         end
       end
-      function files:len() return #self.conflicting + #self.working + #self.staged end
+      function files:len()
+        return #self.conflicting + #self.working + #self.staged
+      end
       function files:update_file_trees() end
       return files
     end
 
-    local function make_entry(path) return { path = path, set_active = function() end } end
+    local function make_entry(path)
+      return { path = path, set_active = function() end }
+    end
 
     local function make_panel(entries)
       local adapter = { ctx = { toplevel = "/tmp", dir = "/tmp/.git" } }
@@ -890,26 +948,34 @@ describe("diffview.ui.panel", function()
     it("update_components is safe when render_data is nil", function()
       local panel = make_panel()
       eq(nil, panel.render_data)
-      assert.has_no.errors(function() panel:update_components() end)
+      assert.has_no.errors(function()
+        panel:update_components()
+      end)
       eq(nil, panel.components)
     end)
 
     it("render is safe when render_data is nil", function()
       local panel = make_panel()
       eq(nil, panel.render_data)
-      assert.has_no.errors(function() panel:render() end)
+      assert.has_no.errors(function()
+        panel:render()
+      end)
     end)
 
     it("redraw is safe when render_data is nil", function()
       local panel = make_panel()
       eq(nil, panel.render_data)
-      assert.has_no.errors(function() panel:redraw() end)
+      assert.has_no.errors(function()
+        panel:redraw()
+      end)
     end)
 
     it("reconstrain_cursor is safe when panel is not open", function()
       local panel = make_panel({ make_entry("a.lua") })
       assert.falsy(panel:is_open())
-      assert.has_no.errors(function() panel:reconstrain_cursor() end)
+      assert.has_no.errors(function()
+        panel:reconstrain_cursor()
+      end)
     end)
 
     it("ordered_file_list works without components", function()
@@ -937,7 +1003,9 @@ describe("diffview.ui.panel", function()
       local f = make_entry("a.lua")
       local panel = make_panel({ f })
       assert.falsy(panel:is_open())
-      assert.has_no.errors(function() panel:highlight_file(f) end)
+      assert.has_no.errors(function()
+        panel:highlight_file(f)
+      end)
     end)
 
     it("toggling on after show=false initialises the panel fully", function()

--- a/lua/diffview/tests/functional/pathlib_spec.lua
+++ b/lua/diffview/tests/functional/pathlib_spec.lua
@@ -140,7 +140,10 @@ describe("diffview.path", function()
       eq([[D:\foo\bar\baz]], pl:absolute([[\foo\bar\baz]], [[D:\lorem\ipsum]]))
 
       eq([[\\wsl.localhost\foo\bar\baz]], pl:absolute([[bar\baz]], [[\\wsl.localhost\foo]]))
-      eq([[\\wsl.localhost\foo\bar\baz]], pl:absolute([[\\wsl.localhost\foo\bar\baz]], [[\\wsl.localhost\foo]]))
+      eq(
+        [[\\wsl.localhost\foo\bar\baz]],
+        pl:absolute([[\\wsl.localhost\foo\bar\baz]], [[\\wsl.localhost\foo]])
+      )
 
       eq([[\\.\foo\bar\baz]], pl:absolute([[bar\baz]], [[\\.\foo]]))
       eq([[\\.\foo\bar\baz]], pl:absolute([[\\.\foo\bar\baz]], [[\\.\foo]]))
@@ -241,7 +244,9 @@ describe("diffview.path", function()
     end)
 
     after_each(function()
-      for k, v in pairs(save_env) do vim.env[k] = v end
+      for k, v in pairs(save_env) do
+        vim.env[k] = v
+      end
     end)
 
     it("works", function()
@@ -287,9 +292,9 @@ describe("diffview.path", function()
     it("works for URIs", function()
       local pl = PathLib({ os = "unix" })
 
-      eq([[test:///foo/bar/baz]], pl:join({ "test://", "/", "foo", "bar", "baz"}))
-      eq([[test://foo/bar/baz]], pl:join({ "test://", "foo", "bar", "baz"}))
-      eq([[test://foo/bar/baz]], pl:join({ "test://", "foo/", "//bar/", "baz"}))
+      eq([[test:///foo/bar/baz]], pl:join({ "test://", "/", "foo", "bar", "baz" }))
+      eq([[test://foo/bar/baz]], pl:join({ "test://", "foo", "bar", "baz" }))
+      eq([[test://foo/bar/baz]], pl:join({ "test://", "foo/", "//bar/", "baz" }))
     end)
   end)
 

--- a/lua/diffview/tests/functional/selection_store_spec.lua
+++ b/lua/diffview/tests/functional/selection_store_spec.lua
@@ -85,12 +85,16 @@ describe("diffview.selection_store", function()
     -- silently leaving a .tmp file behind.
     it("logs warning when rename fails", function()
       local target = tmpdir .. "/store.json"
-      SelectionStore.get_path = function() return target end
+      SelectionStore.get_path = function()
+        return target
+      end
 
       local warns = {}
       local orig_warn = DiffviewGlobal.logger.warn
       local orig_rename = vim.uv.fs_rename
-      DiffviewGlobal.logger.warn = function(_, msg) table.insert(warns, msg) end
+      DiffviewGlobal.logger.warn = function(_, msg)
+        table.insert(warns, msg)
+      end
       vim.uv.fs_rename = function()
         return nil, "mock fs_rename failure"
       end
@@ -138,7 +142,9 @@ describe("diffview.selection_store", function()
       local f = { path = "a.lua", kind = "working" }
       local panel = make_panel({ f })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       panel:toggle_selection(f)
       eq(1, called)
@@ -150,7 +156,9 @@ describe("diffview.selection_store", function()
       local f = { path = "a.lua", kind = "working" }
       local panel = make_panel({ f })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       panel:select_file(f)
       eq(1, called)
@@ -162,7 +170,9 @@ describe("diffview.selection_store", function()
       local f = { path = "a.lua", kind = "working" }
       local panel = make_panel({ f })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       -- Clear when empty: should not fire.
       panel:clear_selections()
@@ -179,7 +189,9 @@ describe("diffview.selection_store", function()
       local b = { path = "b.lua", kind = "working" }
       local panel = make_panel({ a, b })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       panel:batch_selection(function()
         panel:select_file(a)
@@ -192,7 +204,9 @@ describe("diffview.selection_store", function()
       local a = { path = "a.lua", kind = "working" }
       local panel = make_panel({ a })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       panel:batch_selection(function()
         -- No mutations inside the batch.
@@ -204,7 +218,9 @@ describe("diffview.selection_store", function()
       local a = { path = "a.lua", kind = "working" }
       local panel = make_panel({ a })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       -- Error inside batch: flags must be restored so future notifications work.
       pcall(function()
@@ -228,7 +244,9 @@ describe("diffview.selection_store", function()
       local b = { path = "b.lua", kind = "working" }
       local panel = make_panel({ a, b })
       local called = 0
-      panel.on_selection_changed = function() called = called + 1 end
+      panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       panel:select_file(a)
       panel:select_file(b)

--- a/lua/diffview/tests/functional/selections_api_spec.lua
+++ b/lua/diffview/tests/functional/selections_api_spec.lua
@@ -8,7 +8,17 @@ describe("diffview.api.selections", function()
 
   it("is accessible via the public api entrypoint", function()
     -- The public entrypoint is a lazy proxy; verify it exposes the same functions.
-    for _, name in ipairs({ "get", "get_paths", "is_selected", "select", "deselect", "set", "clear", "any", "count" }) do
+    for _, name in ipairs({
+      "get",
+      "get_paths",
+      "is_selected",
+      "select",
+      "deselect",
+      "set",
+      "clear",
+      "any",
+      "count",
+    }) do
       eq("function", type(selections[name]), "missing function: " .. name)
     end
   end)
@@ -183,7 +193,9 @@ describe("diffview.api.selections", function()
       local b = make_entry("b.lua")
       local view = make_view({ a, b })
       local called = 0
-      view.panel.on_selection_changed = function() called = called + 1 end
+      view.panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       selections.select({ "a.lua", "b.lua" }, { view = view })
       eq(1, called)
@@ -265,7 +277,9 @@ describe("diffview.api.selections", function()
       local view = make_view({ a, b })
       view.panel:select_file(a)
       local called = 0
-      view.panel.on_selection_changed = function() called = called + 1 end
+      view.panel.on_selection_changed = function()
+        called = called + 1
+      end
 
       selections.set({ "b.lua" }, { view = view })
       eq(1, called)

--- a/lua/diffview/tests/functional/set_revs_spec.lua
+++ b/lua/diffview/tests/functional/set_revs_spec.lua
@@ -16,8 +16,12 @@ describe("DiffView:set_revs", function()
       commit = commit,
       track_head = false,
       stage = nil,
-      abbrev = function(self, len) return self.commit:sub(1, len or 7) end,
-      object_name = function(self) return self.commit end,
+      abbrev = function(self, len)
+        return self.commit:sub(1, len or 7)
+      end,
+      object_name = function(self)
+        return self.commit
+      end,
     }
   end
 
@@ -31,10 +35,14 @@ describe("DiffView:set_revs", function()
       local i = 0
       return function()
         i = i + 1
-        if i <= #all then return i, all[i] end
+        if i <= #all then
+          return i, all[i]
+        end
       end
     end
-    function files:len() return #all end
+    function files:len()
+      return #all
+    end
     return files
   end
 
@@ -54,7 +62,9 @@ describe("DiffView:set_revs", function()
       rev_to_pretty_string = function(_, left, right)
         return (left.commit or "?") .. ".." .. (right.commit or "?")
       end,
-      instanceof = function() return false end,
+      instanceof = function()
+        return false
+      end,
     }
   end
 
@@ -127,7 +137,7 @@ describe("DiffView:set_revs", function()
     it("does nothing when parse_revs fails", function()
       local left = make_rev("aaa111")
       local right = make_rev("bbb222")
-      local adapter = make_adapter({})  -- No valid results for any rev_arg.
+      local adapter = make_adapter({}) -- No valid results for any rev_arg.
 
       local view = make_view(adapter, left, right, "aaa111..bbb222")
 
@@ -148,7 +158,9 @@ describe("DiffView:set_revs", function()
 
       local update_called = false
       local view = make_view(adapter, make_rev("aaa111"), make_rev("bbb222"), "aaa111..bbb222")
-      view.update_files = function() update_called = true end
+      view.update_files = function()
+        update_called = true
+      end
 
       view:set_revs("ccc333..ddd444")
 
@@ -159,7 +171,9 @@ describe("DiffView:set_revs", function()
       local adapter = make_adapter({})
       local update_called = false
       local view = make_view(adapter, make_rev("aaa111"), make_rev("bbb222"), "aaa111..bbb222")
-      view.update_files = function() update_called = true end
+      view.update_files = function()
+        update_called = true
+      end
 
       view:set_revs("invalid..ref")
 
@@ -194,7 +208,9 @@ describe("DiffView:set_revs", function()
       tmpdir = vim.fn.tempname()
       vim.fn.mkdir(tmpdir, "p")
       saved_get_path = selection_store.get_path
-      selection_store.get_path = function() return tmpdir .. "/test.json" end
+      selection_store.get_path = function()
+        return tmpdir .. "/test.json"
+      end
     end)
 
     after_each(function()
@@ -331,7 +347,7 @@ describe("diffview.api.set_revs", function()
     local lib = require("diffview.lib")
     local saved = lib.get_current_view
     lib.get_current_view = function()
-      return { panel = {} }  -- Not a DiffView, no set_revs.
+      return { panel = {} } -- Not a DiffView, no set_revs.
     end
 
     assert.has_no.errors(function()

--- a/lua/diffview/tests/functional/standard_view_spec.lua
+++ b/lua/diffview/tests/functional/standard_view_spec.lua
@@ -23,7 +23,9 @@ describe("diffview.standard_view panel cursor", function()
     local view = {
       panel = {
         winid = winid or 42,
-        is_open = function() return panel_open end,
+        is_open = function()
+          return panel_open
+        end,
       },
       panel_cursor = nil,
     }
@@ -33,8 +35,12 @@ describe("diffview.standard_view panel cursor", function()
 
   it("save_panel_cursor stores the cursor when panel is open", function()
     local view = make_view(true, 42)
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.api.nvim_win_get_cursor = function() return { 5, 3 } end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.api.nvim_win_get_cursor = function()
+      return { 5, 3 }
+    end
 
     view:save_panel_cursor()
     eq({ 5, 3 }, view.panel_cursor)
@@ -42,8 +48,12 @@ describe("diffview.standard_view panel cursor", function()
 
   it("save_panel_cursor is a no-op when panel is closed", function()
     local view = make_view(false)
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.api.nvim_win_get_cursor = function() error("should not be called") end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.api.nvim_win_get_cursor = function()
+      error("should not be called")
+    end
 
     view:save_panel_cursor()
     eq(nil, view.panel_cursor)
@@ -51,8 +61,12 @@ describe("diffview.standard_view panel cursor", function()
 
   it("save_panel_cursor is a no-op when winid is invalid", function()
     local view = make_view(true, 42)
-    vim.api.nvim_win_is_valid = function() return false end
-    vim.api.nvim_win_get_cursor = function() error("should not be called") end
+    vim.api.nvim_win_is_valid = function()
+      return false
+    end
+    vim.api.nvim_win_get_cursor = function()
+      error("should not be called")
+    end
 
     view:save_panel_cursor()
     eq(nil, view.panel_cursor)
@@ -62,8 +76,12 @@ describe("diffview.standard_view panel cursor", function()
     local set_args
     local view = make_view(true, 42)
     view.panel_cursor = { 10, 2 }
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.api.nvim_win_set_cursor = function(w, c) set_args = { w, c } end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.api.nvim_win_set_cursor = function(w, c)
+      set_args = { w, c }
+    end
 
     view:restore_panel_cursor()
     eq({ 42, { 10, 2 } }, set_args)
@@ -71,8 +89,12 @@ describe("diffview.standard_view panel cursor", function()
 
   it("restore_panel_cursor is a no-op when panel_cursor is nil", function()
     local view = make_view(true, 42)
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.api.nvim_win_set_cursor = function() error("should not be called") end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.api.nvim_win_set_cursor = function()
+      error("should not be called")
+    end
 
     view:restore_panel_cursor()
   end)
@@ -80,9 +102,15 @@ describe("diffview.standard_view panel cursor", function()
   it("round-trips: save then restore preserves cursor position", function()
     local restored
     local view = make_view(true, 42)
-    vim.api.nvim_win_is_valid = function() return true end
-    vim.api.nvim_win_get_cursor = function() return { 7, 4 } end
-    vim.api.nvim_win_set_cursor = function(_, c) restored = c end
+    vim.api.nvim_win_is_valid = function()
+      return true
+    end
+    vim.api.nvim_win_get_cursor = function()
+      return { 7, 4 }
+    end
+    vim.api.nvim_win_set_cursor = function(_, c)
+      restored = c
+    end
 
     view:save_panel_cursor()
     view:restore_panel_cursor()

--- a/lua/diffview/tests/functional/stream_spec.lua
+++ b/lua/diffview/tests/functional/stream_spec.lua
@@ -28,7 +28,7 @@ describe("diffview.stream", function()
       local s1 = {}
 
       for i, v in ipairs(arr1) do
-        s0[#s0+1] = { i, v }
+        s0[#s0 + 1] = { i, v }
       end
 
       for i, v in Stream(arr1):iter() do
@@ -39,10 +39,7 @@ describe("diffview.stream", function()
     end)
 
     it("can slice", function()
-      eq(
-        vim.list_slice(arr1, 2, 4),
-        Stream(arr1):slice(2, 4):collect()
-      )
+      eq(vim.list_slice(arr1, 2, 4), Stream(arr1):slice(2, 4):collect())
     end)
 
     it("can map", function()
@@ -50,10 +47,7 @@ describe("diffview.stream", function()
         return item.name:upper():rep(5)
       end
 
-      eq(
-        vim.tbl_map(f, arr1),
-        Stream(arr1):map(f):collect()
-      )
+      eq(vim.tbl_map(f, arr1), Stream(arr1):map(f):collect())
     end)
 
     it("can filter", function()
@@ -61,10 +55,7 @@ describe("diffview.stream", function()
         return item.i % 2 ~= 0
       end
 
-      eq(
-        vim.tbl_filter(f, arr1),
-        Stream(arr1):filter(f):collect()
-      )
+      eq(vim.tbl_filter(f, arr1), Stream(arr1):filter(f):collect())
     end)
 
     it("can reduce without an init value", function()
@@ -109,7 +100,9 @@ describe("diffview.stream", function()
       local i = 0
 
       return async.wrap(function(callback)
-        if i == #src_arr then return callback(nil) end
+        if i == #src_arr then
+          return callback(nil)
+        end
         await(async.timeout(1))
         local _, ret = iter(src_arr, i)
         i = i + 1
@@ -117,25 +110,31 @@ describe("diffview.stream", function()
       end)
     end
 
-    it("can iterate", async_test(function()
-      local s0 = {}
-      local s1 = {}
+    it(
+      "can iterate",
+      async_test(function()
+        local s0 = {}
+        local s1 = {}
 
-      for i, v in ipairs(arr1) do
-        s0[#s0+1] = { i, v }
-      end
+        for i, v in ipairs(arr1) do
+          s0[#s0 + 1] = { i, v }
+        end
 
-      for i, v in AsyncStream(mock_iter(arr1)):iter() do
-        s1[#s1 + 1] = { i, v }
-      end
+        for i, v in AsyncStream(mock_iter(arr1)):iter() do
+          s1[#s1 + 1] = { i, v }
+        end
 
-      eq(s0, s1)
-    end))
+        eq(s0, s1)
+      end)
+    )
 
-    it("can be awaited", async_test(function()
-      local stream = AsyncStream(mock_iter(arr1))
-      eq(arr1, await(stream))
-    end))
+    it(
+      "can be awaited",
+      async_test(function()
+        local stream = AsyncStream(mock_iter(arr1))
+        eq(arr1, await(stream))
+      end)
+    )
   end)
 
   describe("AsyncListStream", function()
@@ -147,99 +146,121 @@ describe("diffview.stream", function()
       stream:close()
     end)
 
-    it("can iterate", async_test(function()
-      local s0 = {}
-      local s1 = {}
+    it(
+      "can iterate",
+      async_test(function()
+        local s0 = {}
+        local s1 = {}
 
-      for i, v in ipairs(arr1) do
-        s0[#s0+1] = { i, v }
-      end
+        for i, v in ipairs(arr1) do
+          s0[#s0 + 1] = { i, v }
+        end
 
-      local stream = AsyncListStream()
-      mock_worker(stream)
+        local stream = AsyncListStream()
+        mock_worker(stream)
 
-      for i, v in stream:iter() do
-        s1[#s1 + 1] = { i, v }
-      end
+        for i, v in stream:iter() do
+          s1[#s1 + 1] = { i, v }
+        end
 
-      eq(s0, s1)
-    end))
+        eq(s0, s1)
+      end)
+    )
 
-    it("can be awaited", async_test(function()
-      local stream = AsyncListStream()
-      mock_worker(stream)
+    it(
+      "can be awaited",
+      async_test(function()
+        local stream = AsyncListStream()
+        mock_worker(stream)
 
-      eq(arr1, await(stream))
-    end))
+        eq(arr1, await(stream))
+      end)
+    )
 
-    it("can close early", async_test(function()
-      local stream = AsyncListStream()
-      mock_worker(stream)
+    it(
+      "can close early",
+      async_test(function()
+        local stream = AsyncListStream()
+        mock_worker(stream)
 
-      local ret = {}
-      for i, v in stream:iter() do
-        ret[i] = v
-        if i == 3 then stream:close() end
-      end
+        local ret = {}
+        for i, v in stream:iter() do
+          ret[i] = v
+          if i == 3 then
+            stream:close()
+          end
+        end
 
-      eq(vim.list_slice(arr1, 1, 3), ret)
-    end))
+        eq(vim.list_slice(arr1, 1, 3), ret)
+      end)
+    )
 
-    it("can't push items after close", async_test(function()
-      local stream = AsyncListStream()
-      stream:push(1, 2, 3)
-      stream:close()
-      stream:push(4, 5, 6)
+    it(
+      "can't push items after close",
+      async_test(function()
+        local stream = AsyncListStream()
+        stream:push(1, 2, 3)
+        stream:close()
+        stream:push(4, 5, 6)
 
-      eq({ 1, 2, 3 }, stream:collect())
-    end))
+        eq({ 1, 2, 3 }, stream:collect())
+      end)
+    )
 
-    it("can push final items during on_close()", async_test(function()
-      local final_arr = { "final_1", "final_2", "final_3" }
-      local stream
-      stream = AsyncListStream({
-        on_close = function()
-          stream:push(unpack(final_arr))
-        end,
-      })
-      mock_worker(stream)
+    it(
+      "can push final items during on_close()",
+      async_test(function()
+        local final_arr = { "final_1", "final_2", "final_3" }
+        local stream
+        stream = AsyncListStream({
+          on_close = function()
+            stream:push(unpack(final_arr))
+          end,
+        })
+        mock_worker(stream)
 
-      local ret = {}
-      for i, v in stream:iter() do
-        ret[i] = v
-        if i == 3 then stream:close() end
-      end
+        local ret = {}
+        for i, v in stream:iter() do
+          ret[i] = v
+          if i == 3 then
+            stream:close()
+          end
+        end
 
-      eq(
-        vim.list_extend(vim.list_slice(arr1, 1, 3), final_arr),
-        ret
-      )
-    end))
+        eq(vim.list_extend(vim.list_slice(arr1, 1, 3), final_arr), ret)
+      end)
+    )
 
-    it("calls on_close() callbacks with the appropriate args", async.sync_wrap(function(done)
-      local stream = AsyncListStream({
-        on_close = function(...)
-          eq({ nil, 1, nil, 2, 3 }, { ... })
-          done()
-        end,
-      })
-      stream:close(nil, 1, nil, 2, 3)
-    end))
+    it(
+      "calls on_close() callbacks with the appropriate args",
+      async.sync_wrap(function(done)
+        local stream = AsyncListStream({
+          on_close = function(...)
+            eq({ nil, 1, nil, 2, 3 }, { ... })
+            done()
+          end,
+        })
+        stream:close(nil, 1, nil, 2, 3)
+      end)
+    )
 
-    it("calls the event callbacks in the appropriate order", async_test(function()
-      local ret = {}
-      local stream = AsyncListStream({
-        on_close = function()
-          table.insert(ret, 1)
-        end,
-        on_post_close = function()
-          table.insert(ret, 2)
-        end,
-      })
+    it(
+      "calls the event callbacks in the appropriate order",
+      async_test(function()
+        local ret = {}
+        local stream = AsyncListStream({
+          on_close = function()
+            table.insert(ret, 1)
+          end,
+          on_post_close = function()
+            table.insert(ret, 2)
+          end,
+        })
 
-      stream:close()
-      await(stream)
-      eq({ 1, 2 }, ret)
-    end))
+        stream:close()
+        await(stream)
+        eq({ 1, 2 }, ret)
+      end)
+    )
   end)
 end)

--- a/lua/diffview/tests/functional/toggle_spec.lua
+++ b/lua/diffview/tests/functional/toggle_spec.lua
@@ -35,7 +35,9 @@ describe("diffview.toggle", function()
   end)
 
   it("calls open when no view exists", function()
-    stub(lib, "get_current_view", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
 
     diffview.toggle({})
 
@@ -44,7 +46,9 @@ describe("diffview.toggle", function()
   end)
 
   it("calls close when a view exists", function()
-    stub(lib, "get_current_view", function() return { tabpage = 1 } end)
+    stub(lib, "get_current_view", function()
+      return { tabpage = 1 }
+    end)
 
     diffview.toggle({})
 
@@ -53,7 +57,9 @@ describe("diffview.toggle", function()
   end)
 
   it("passes args through to open", function()
-    stub(lib, "get_current_view", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
 
     local args = { "--staged", "HEAD~2" }
     diffview.toggle(args)
@@ -64,7 +70,9 @@ describe("diffview.toggle", function()
   end)
 
   it("does not call open when a view exists", function()
-    stub(lib, "get_current_view", function() return { tabpage = 1 } end)
+    stub(lib, "get_current_view", function()
+      return { tabpage = 1 }
+    end)
 
     diffview.toggle({})
 
@@ -74,7 +82,9 @@ describe("diffview.toggle", function()
   end)
 
   it("does not call close when no view exists", function()
-    stub(lib, "get_current_view", function() return nil end)
+    stub(lib, "get_current_view", function()
+      return nil
+    end)
 
     diffview.toggle({})
 

--- a/lua/diffview/tests/functional/utils_spec.lua
+++ b/lua/diffview/tests/functional/utils_spec.lua
@@ -63,8 +63,12 @@ describe("diffview.utils.set_win_buf", function()
 
     local calls = 0
     local ok, err = pcall(function()
-      vim.api.nvim_win_set_buf = function() calls = calls + 1 end
-      utils.no_win_event_call = function() error("should not be called") end
+      vim.api.nvim_win_set_buf = function()
+        calls = calls + 1
+      end
+      utils.no_win_event_call = function()
+        error("should not be called")
+      end
 
       local success, msg, recovered = utils.set_win_buf(1, 1)
 
@@ -77,7 +81,9 @@ describe("diffview.utils.set_win_buf", function()
     vim.api.nvim_win_set_buf = original_set_win_buf
     utils.no_win_event_call = original_no_win_event_call
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 
   it("retries with ignored events when the first set fails", function()
@@ -113,7 +119,9 @@ describe("diffview.utils.set_win_buf", function()
     vim.api.nvim_win_set_buf = original_set_win_buf
     utils.no_win_event_call = original_no_win_event_call
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 
   it("returns an error when both attempts fail", function()
@@ -152,7 +160,9 @@ describe("diffview.utils.set_win_buf", function()
     vim.api.nvim_win_set_buf = original_set_win_buf
     utils.no_win_event_call = original_no_win_event_call
 
-    if not ok then error(err) end
+    if not ok then
+      error(err)
+    end
   end)
 end)
 

--- a/lua/diffview/tests/functional/view_spec.lua
+++ b/lua/diffview/tests/functional/view_spec.lua
@@ -136,15 +136,17 @@ describe("diffview.scene.view", function()
     local function find_linematch(opts)
       for _, v in ipairs(opts) do
         local n = v:match("^linematch:(%d+)$")
-        if n then return tonumber(n) end
+        if n then
+          return tonumber(n)
+        end
       end
       return nil
     end
 
     it("applies linematch:N when configured", function()
-      vim.opt.diffopt:remove(
-        vim.tbl_filter(function(v) return v:match("^linematch:") end, vim.opt.diffopt:get())
-      )
+      vim.opt.diffopt:remove(vim.tbl_filter(function(v)
+        return v:match("^linematch:")
+      end, vim.opt.diffopt:get()))
       config.setup({ diffopt = { linematch = 60 } })
 
       local view = View({ default_layout = {} })
@@ -157,9 +159,9 @@ describe("diffview.scene.view", function()
     end)
 
     it("replaces an existing linematch:N entry", function()
-      vim.opt.diffopt:remove(
-        vim.tbl_filter(function(v) return v:match("^linematch:") end, vim.opt.diffopt:get())
-      )
+      vim.opt.diffopt:remove(vim.tbl_filter(function(v)
+        return v:match("^linematch:")
+      end, vim.opt.diffopt:get()))
       vim.opt.diffopt:append({ "linematch:30" })
       config.setup({ diffopt = { linematch = 60 } })
 
@@ -167,10 +169,9 @@ describe("diffview.scene.view", function()
       view_mod._test.apply_diffopt(view)
 
       -- Only the configured value should remain (no duplicate).
-      local matches = vim.tbl_filter(
-        function(v) return v:match("^linematch:") end,
-        vim.opt.diffopt:get()
-      )
+      local matches = vim.tbl_filter(function(v)
+        return v:match("^linematch:")
+      end, vim.opt.diffopt:get())
       assert.are.equal(1, #matches)
       assert.are.equal(60, find_linematch(vim.opt.diffopt:get()))
 
@@ -180,9 +181,9 @@ describe("diffview.scene.view", function()
     end)
 
     it("leaves linematch untouched when not configured", function()
-      vim.opt.diffopt:remove(
-        vim.tbl_filter(function(v) return v:match("^linematch:") end, vim.opt.diffopt:get())
-      )
+      vim.opt.diffopt:remove(vim.tbl_filter(function(v)
+        return v:match("^linematch:")
+      end, vim.opt.diffopt:get()))
       vim.opt.diffopt:append({ "linematch:45" })
       config.setup({ diffopt = { algorithm = "patience" } })
 

--- a/lua/diffview/tests/functional/window_spec.lua
+++ b/lua/diffview/tests/functional/window_spec.lua
@@ -18,7 +18,9 @@ local function mock_adapter(overrides)
       toplevel = vim.uv.cwd(),
       dir = vim.uv.cwd(),
     },
-    is_binary = function() return false end,
+    is_binary = function()
+      return false
+    end,
   }, overrides or {})
 end
 
@@ -43,24 +45,27 @@ local function make_window(adapter, file_opts)
 end
 
 describe("diffview.scene.window", function()
-  it("load_file bails out if the file is inactive", helpers.async_test(function()
-    local show_called = false
-    local adapter = mock_adapter({
-      show = async.wrap(function(_, _, _, callback)
-        show_called = true
-        callback(nil, { "data" })
-      end),
-    })
+  it(
+    "load_file bails out if the file is inactive",
+    helpers.async_test(function()
+      local show_called = false
+      local adapter = mock_adapter({
+        show = async.wrap(function(_, _, _, callback)
+          show_called = true
+          callback(nil, { "data" })
+        end),
+      })
 
-    local win, file = make_window(adapter)
-    file.active = false
+      local win, file = make_window(adapter)
+      file.active = false
 
-    local ok = async.await(win:load_file())
+      local ok = async.await(win:load_file())
 
-    assert.False(ok)
-    -- show should never have been called since we bailed before create_buffer.
-    assert.False(show_called)
-  end))
+      assert.False(ok)
+      -- show should never have been called since we bailed before create_buffer.
+      assert.False(show_called)
+    end)
+  )
 
   describe("_save_winopts global-only options", function()
     -- The global_only_opts set (e.g., "scrollopt") must be read via vim.o
@@ -203,34 +208,40 @@ describe("diffview.scene.window", function()
     local function stub_parent()
       return {
         name = "test",
-        instanceof = function() return false end,
+        instanceof = function()
+          return false
+        end,
       }
     end
 
-    it("propagates the configured value to the window", helpers.async_test(function()
-      config.setup({ view = { foldlevel = 77 } })
+    it(
+      "propagates the configured value to the window",
+      helpers.async_test(function()
+        config.setup({ view = { foldlevel = 77 } })
 
-      local adapter = mock_adapter()
-      local bufnr = vim.api.nvim_create_buf(false, true)
-      local win, file = make_window(adapter)
-      file.bufnr = bufnr
-      win.parent = stub_parent()
+        local adapter = mock_adapter()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local win, file = make_window(adapter)
+        file.bufnr = bufnr
+        win.parent = stub_parent()
 
-      async.await(win:open_file())
+        async.await(win:open_file())
 
-      assert.equals(77, vim.wo[win.id].foldlevel)
+        assert.equals(77, vim.wo[win.id].foldlevel)
 
-      -- Close the dedicated window before deleting the buffer it displays,
-      -- so buffer deletion does not force an unrelated window onto `bufnr`.
-      if vim.api.nvim_win_is_valid(test_winid) then
-        vim.api.nvim_win_close(test_winid, true)
-      end
-      test_winid = nil
-      Window.winopt_store[bufnr] = nil
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end))
+        -- Close the dedicated window before deleting the buffer it displays,
+        -- so buffer deletion does not force an unrelated window onto `bufnr`.
+        if vim.api.nvim_win_is_valid(test_winid) then
+          vim.api.nvim_win_close(test_winid, true)
+        end
+        test_winid = nil
+        Window.winopt_store[bufnr] = nil
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+    )
 
-    it("applies the configured value even when `file.winopts` omits `foldlevel`",
+    it(
+      "applies the configured value even when `file.winopts` omits `foldlevel`",
       helpers.async_test(function()
         config.setup({ view = { foldlevel = 77 } })
 
@@ -253,42 +264,46 @@ describe("diffview.scene.window", function()
         test_winid = nil
         Window.winopt_store[bufnr] = nil
         vim.api.nvim_buf_delete(bufnr, { force = true })
-      end))
+      end)
+    )
   end)
 
-  it("load_file suppresses error when create_buffer is cancelled mid-async", helpers.async_test(function()
-    local yield_signal = Signal("yield")
-    local produce_data_started = Signal("produce_data_started")
+  it(
+    "load_file suppresses error when create_buffer is cancelled mid-async",
+    helpers.async_test(function()
+      local yield_signal = Signal("yield")
+      local produce_data_started = Signal("produce_data_started")
 
-    local adapter = mock_adapter({
-      show = async.wrap(function(_, _, _, callback)
-        produce_data_started:send()
-        async.await(yield_signal)
-        callback(nil, { "data" })
-      end),
-    })
+      local adapter = mock_adapter({
+        show = async.wrap(function(_, _, _, callback)
+          produce_data_started:send()
+          async.await(yield_signal)
+          callback(nil, { "data" })
+        end),
+      })
 
-    local win, file = make_window(adapter)
+      local win, file = make_window(adapter)
 
-    -- Start load_file in a separate thread so we can deactivate mid-flight.
-    local load_ok
+      -- Start load_file in a separate thread so we can deactivate mid-flight.
+      local load_ok
 
-    local load_thread = async.void(function()
-      load_ok = async.await(win:load_file())
+      local load_thread = async.void(function()
+        load_ok = async.await(win:load_file())
+      end)
+
+      load_thread()
+
+      -- Wait until we're inside produce_data (the show mock).
+      async.await(produce_data_started)
+
+      -- Deactivate and let the show mock finish.
+      file.active = false
+      yield_signal:send()
+      async.await(async.scheduler())
+
+      -- load_file should report failure without a user-visible error.
+      assert.False(load_ok)
+      assert.is_nil(file.bufnr)
     end)
-
-    load_thread()
-
-    -- Wait until we're inside produce_data (the show mock).
-    async.await(produce_data_started)
-
-    -- Deactivate and let the show mock finish.
-    file.active = false
-    yield_signal:send()
-    async.await(async.scheduler())
-
-    -- load_file should report failure without a user-visible error.
-    assert.False(load_ok)
-    assert.is_nil(file.bufnr)
-  end))
+  )
 end)

--- a/lua/diffview/tests/functional/wrap_entries_spec.lua
+++ b/lua/diffview/tests/functional/wrap_entries_spec.lua
@@ -11,7 +11,9 @@ local function make_file(name)
   return {
     name = name,
     active = false,
-    set_active = function(self, v) self.active = v end,
+    set_active = function(self, v)
+      self.active = v
+    end,
   }
 end
 
@@ -33,9 +35,8 @@ end
 ---@param file_idx integer
 ---@return table
 local function make_panel(entries, entry_idx, file_idx)
-  local FileHistoryPanel = require(
-    "diffview.scene.views.file_history.file_history_panel"
-  ).FileHistoryPanel
+  local FileHistoryPanel =
+    require("diffview.scene.views.file_history.file_history_panel").FileHistoryPanel
 
   local panel = {
     entries = entries,
@@ -193,12 +194,16 @@ describe("diffview.wrap_entries", function()
         listing_style = "list",
         cur_file = files[cur_idx],
         files = {
-          len = function() return #files end,
+          len = function()
+            return #files
+          end,
           iter = function()
             local i = 0
             return function()
               i = i + 1
-              if i <= #files then return i, files[i] end
+              if i <= #files then
+                return i, files[i]
+              end
             end
           end,
         },

--- a/lua/diffview/tests/helpers.lua
+++ b/lua/diffview/tests/helpers.lua
@@ -6,12 +6,16 @@ local await, pawait = async.await, async.pawait
 local M = {}
 
 function M.eq(a, b)
-  if a == nil or b == nil then return assert.are.equal(a, b) end
+  if a == nil or b == nil then
+    return assert.are.equal(a, b)
+  end
   return assert.are.same(a, b)
 end
 
 function M.neq(a, b)
-  if a == nil or b == nil then return assert.are_not.equal(a, b) end
+  if a == nil or b == nil then
+    return assert.are_not.equal(a, b)
+  end
   return assert.are_not.same(a, b)
 end
 

--- a/lua/diffview/ui/model.lua
+++ b/lua/diffview/ui/model.lua
@@ -10,11 +10,15 @@ local Model = oop.create_class("Model")
 ---@abstract
 ---@param data table
 ---@return CompSchema
-function Model:create_comp_schema(data) oop.abstract_stub() end
+function Model:create_comp_schema(data)
+  oop.abstract_stub()
+end
 
 ---@abstract
 ---@param render_data RenderData
-function Model:render(render_data) oop.abstract_stub() end
+function Model:render(render_data)
+  oop.abstract_stub()
+end
 
 ---@diagnostic enable unused-local
 

--- a/lua/diffview/ui/models/file_tree/node.lua
+++ b/lua/diffview/ui/models/file_tree/node.lua
@@ -194,7 +194,7 @@ function Node:next_sibling()
 
   local i = utils.vec_indexof(self.parent.children, self)
 
-  if i > -1 and  i < #self.parent.children then
+  if i > -1 and i < #self.parent.children then
     return self.parent.children[i + 1]
   end
 end

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -78,7 +78,7 @@ Panel.default_config_split = {
   position = "left",
   relative = "editor",
   win = 0,
-  win_opts = {}
+  win_opts = {},
 }
 
 ---@class PanelFloatSpec
@@ -104,7 +104,7 @@ Panel.default_config_float = {
   zindex = 50,
   style = "minimal",
   border = "single",
-  win_opts = {}
+  win_opts = {},
 }
 
 Panel.au = {
@@ -157,8 +157,15 @@ function Panel:get_config()
   local function valid_enum(arg, values, optional)
     return {
       arg,
-      function(v) return (optional and v == nil) or vim.tbl_contains(values, v) end,
-      table.concat(vim.tbl_map(function(v) return ([['%s']]):format(v) end, values), "|"),
+      function(v)
+        return (optional and v == nil) or vim.tbl_contains(values, v)
+      end,
+      table.concat(
+        vim.tbl_map(function(v)
+          return ([['%s']]):format(v)
+        end, values),
+        "|"
+      ),
     }
   end
 
@@ -173,11 +180,13 @@ function Panel:get_config()
       relative = valid_enum(config.relative, { "editor", "win" }),
       width = {
         config.width,
-        function(v) return v == nil or v == "auto" or type(v) == "number" end,
+        function(v)
+          return v == nil or v == "auto" or type(v) == "number"
+        end,
         "'auto' or number",
       },
       height = { config.height, "number", true },
-      win_opts = { config.win_opts, "table" }
+      win_opts = { config.win_opts, "table" },
     })
   else
     ---@cast config PanelFloatSpec
@@ -197,7 +206,9 @@ function Panel:get_config()
       border = {
         config.border,
         function(v)
-          if v == nil then return true end
+          if v == nil then
+            return true
+          end
 
           if type(v) == "table" then
             return #v >= 2
@@ -205,11 +216,12 @@ function Panel:get_config()
 
           return vim.tbl_contains(border, v)
         end,
-        ("%s or a list of length >=2"):format(
-          table.concat(vim.tbl_map(function(v)
+        ("%s or a list of length >=2"):format(table.concat(
+          vim.tbl_map(function(v)
             return ([['%s']]):format(v)
-          end, border), "|")
-        )
+          end, border),
+          "|"
+        )),
       },
     })
   end
@@ -306,8 +318,8 @@ function Panel:open()
     local split_dir = vim.tbl_contains({ "top", "left" }, position) and "aboveleft" or "belowright"
     local split_cmd = self.state.form == "row" and "sp" or "vsp"
     local rel_winid = config.relative == "win"
-      and api.nvim_win_is_valid(config.win or -1)
-      and config.win
+        and api.nvim_win_is_valid(config.win or -1)
+        and config.win
       or 0
 
     api.nvim_win_call(rel_winid, function()
@@ -324,7 +336,6 @@ function Panel:open()
         vim.cmd("wincmd =")
       end
     end)
-
   elseif config.type == "float" then
     self.winid = vim.api.nvim_open_win(self.bufid, false, utils.sanitize_float_config(config))
     if self.winid == 0 then
@@ -343,8 +354,12 @@ function Panel:open()
     self._win_resized_au = api.nvim_create_autocmd("WinResized", {
       group = Panel.au.group,
       callback = function()
-        if self._programmatic_resize then return end
-        if not self:is_open() or not self:buf_loaded() then return end
+        if self._programmatic_resize then
+          return
+        end
+        if not self:is_open() or not self:buf_loaded() then
+          return
+        end
         for _, w in ipairs(vim.v.event.windows) do
           if w == self.winid then
             self:render()
@@ -418,7 +433,9 @@ end
 ---spans on `_word_` patterns in file paths and commit subjects.
 ---@param bufid integer
 local function stop_external_treesitter(bufid)
-  if not api.nvim_buf_is_valid(bufid) then return end
+  if not api.nvim_buf_is_valid(bufid) then
+    return
+  end
   pcall(vim.treesitter.stop, bufid)
 end
 
@@ -461,7 +478,9 @@ function Panel:init_buffer()
     group = Panel.au.group,
     buffer = bn,
     callback = function()
-      vim.schedule(function() stop_external_treesitter(bn) end)
+      vim.schedule(function()
+        stop_external_treesitter(bn)
+      end)
     end,
   })
 
@@ -479,7 +498,8 @@ end
 function Panel:apply_keymaps(keymap_key, extra_defaults)
   local config = require("diffview.config")
   local conf = config.get_config()
-  local default_opt = vim.tbl_extend("force", { silent = true, buffer = self.bufid }, extra_defaults or {})
+  local default_opt =
+    vim.tbl_extend("force", { silent = true, buffer = self.bufid }, extra_defaults or {})
   for _, mapping in ipairs(conf.keymaps[keymap_key]) do
     local opt = vim.tbl_extend("force", default_opt, mapping[4] or {}, { buffer = self.bufid })
     vim.keymap.set(mapping[1], mapping[2], mapping[3], opt)
@@ -487,9 +507,13 @@ function Panel:apply_keymaps(keymap_key, extra_defaults)
   return conf
 end
 
-function Panel:update_components() oop.abstract_stub() end
+function Panel:update_components()
+  oop.abstract_stub()
+end
 
-function Panel:render() oop.abstract_stub() end
+function Panel:render()
+  oop.abstract_stub()
+end
 
 function Panel:redraw()
   if not self.render_data then
@@ -601,8 +625,9 @@ function Panel:on_autocmd(event, opts)
   local callback = function(_, state)
     local win_match, buf_match
     if state.event:match("^Win") then
-      if vim.tbl_contains({ "WinLeave", "WinEnter" }, state.event)
-          and api.nvim_get_current_win() == self.winid
+      if
+        vim.tbl_contains({ "WinLeave", "WinEnter" }, state.event)
+        and api.nvim_get_current_win() == self.winid
       then
         buf_match = state.buf
       else
@@ -612,9 +637,8 @@ function Panel:on_autocmd(event, opts)
       buf_match = state.buf
     end
 
-    if (win_match and win_match == self.winid)
-      or (buf_match and buf_match == self.bufid) then
-        opts.callback(state)
+    if (win_match and win_match == self.winid) or (buf_match and buf_match == self.bufid) then
+      opts.callback(state)
     end
   end
 
@@ -690,14 +714,20 @@ function Panel:infer_width()
   -- for the initial measurement pass.
   if config.width == "auto" then
     local cur_width = self:get_width()
-    if cur_width then return cur_width end
+    if cur_width then
+      return cur_width
+    end
     return vim.o.columns
   end
 
   local cur_width = self:get_width()
-  if cur_width then return cur_width end
+  if cur_width then
+    return cur_width
+  end
 
-  if config.width then return config.width end
+  if config.width then
+    return config.width
+  end
 
   -- PanelFloatSpec requires both width and height to be defined. If we get
   -- here then the panel is a split.
@@ -720,10 +750,14 @@ end
 
 function Panel:infer_height()
   local cur_height = self:get_height()
-  if cur_height then return cur_height end
+  if cur_height then
+    return cur_height
+  end
 
   local config = self:get_config()
-  if config.height then return config.height end
+  if config.height then
+    return config.height
+  end
 
   -- PanelFloatSpec requires both width and height to be defined. If we get
   -- here then the panel is a split.

--- a/lua/diffview/ui/panels/commit_log_panel.lua
+++ b/lua/diffview/ui/panels/commit_log_panel.lua
@@ -61,7 +61,7 @@ function CommitLogPanel:init(parent, adapter, opt)
   self.adapter = adapter
   self.args = opt.args or { "-n256" }
 
-  self:on_autocmd("BufWinEnter" , {
+  self:on_autocmd("BufWinEnter", {
     callback = function()
       vim.bo[self.bufid].bufhidden = "wipe"
     end,
@@ -126,8 +126,7 @@ CommitLogPanel.update = async.void(function(self, args)
   vim.cmd("norm! gg")
 end)
 
-function CommitLogPanel:update_components()
-end
+function CommitLogPanel:update_components() end
 
 function CommitLogPanel:render()
   self.render_data:clear()

--- a/lua/diffview/ui/panels/help_panel.lua
+++ b/lua/diffview/ui/panels/help_panel.lua
@@ -123,7 +123,9 @@ function HelpPanel:update_components()
       utils.err(("help_panel :: Unknown keymap group '%s'!"):format(group))
     else
       maps = utils.tbl_fmap(maps, function(v)
-        if v[1] ~= "n" then return nil end
+        if v[1] ~= "n" then
+          return nil
+        end
         local desc = v[4] and v[4].desc
 
         if not desc then
@@ -141,14 +143,20 @@ function HelpPanel:update_components()
         return ret
       end)
 
-      if #maps == 0 then goto continue end
+      if #maps == 0 then
+        goto continue
+      end
 
       -- Sort mappings by description
       table.sort(maps, function(a, b)
         a, b = a[5], b[5]
         -- Ensure lua functions are sorted last
-        if a:match("^<Lua") then a = "~" .. a end
-        if b:match("^<Lua") then b = "~" .. b end
+        if a:match("^<Lua") then
+          a = "~" .. a
+        end
+        if b:match("^<Lua") then
+          b = "~" .. b
+        end
         return a < b
       end)
 
@@ -158,7 +166,7 @@ function HelpPanel:update_components()
         {
           name = "section_heading",
           context = {
-            label = group:upper():gsub("_", "-")
+            label = group:upper():gsub("_", "-"),
           },
         },
         items,
@@ -212,7 +220,8 @@ function HelpPanel:render()
     -- Section heading
     comp = section.section_heading.comp
     comp:add_line()
-    s = string.rep(" ", math.floor(self.state.width * 0.5 - #comp.context.label * 0.5)) .. comp.context.label
+    s = string.rep(" ", math.floor(self.state.width * 0.5 - #comp.context.label * 0.5))
+      .. comp.context.label
     comp:add_line(s, "Statement")
     comp:add_line(("%14s    CALLBACK"):format("KEYS"), "DiffviewFilePanelCounter")
 

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -28,7 +28,9 @@ end
 ---@param level integer
 function M.notify(msg, level, schedule)
   if schedule then
-    vim.schedule(function() M.notify(msg, level, false) end)
+    vim.schedule(function()
+      M.notify(msg, level, false)
+    end)
     return
   end
   if type(msg) == "table" then
@@ -349,7 +351,9 @@ function M.job(cmd, cwd_or_opt)
   local code = job.code
 
   if not ok then
-    if opt.fail_on_empty then code = 1 end
+    if opt.fail_on_empty then
+      code = 1
+    end
   end
 
   return job.stdout, code, job.stderr
@@ -407,7 +411,6 @@ function M.set_local(winids, option_map, opt)
 
         if o.method == "set" then
           vim.opt_local[option] = value
-
         else
           if o.method == "remove" then
             if is_list_like then
@@ -415,7 +418,6 @@ function M.set_local(winids, option_map, opt)
             else
               vim.opt_local[fullname]:remove(value)
             end
-
           elseif o.method == "append" then
             if is_list_like then
               vim.opt_local[fullname] = ("%s%s"):format(
@@ -425,7 +427,6 @@ function M.set_local(winids, option_map, opt)
             else
               vim.opt_local[fullname]:append(value)
             end
-
           elseif o.method == "prepend" then
             if is_list_like then
               vim.opt_local[fullname] = ("%s%s%s"):format(
@@ -533,9 +534,8 @@ end
 ---@param table_path string|any[] Either a `.` separated string of table keys, or a list.
 ---@return any?
 function M.tbl_access(t, table_path)
-  local keys = type(table_path) == "table"
-      and table_path
-      or vim.split(table_path --[[@as string ]], ".", { plain = true })
+  local keys = type(table_path) == "table" and table_path
+    or vim.split(table_path --[[@as string ]], ".", { plain = true })
 
   local cur = t
 
@@ -589,7 +589,7 @@ end
 function M.tbl_merge(t, ...)
   local ret = M.tbl_clone(t)
 
-  for _, theirs in ipairs({...}) do
+  for _, theirs in ipairs({ ... }) do
     for k, v in pairs(theirs) do
       if type(k) == "number" and k % 1 == 0 then
         ret[#ret + 1] = v
@@ -653,9 +653,8 @@ end
 ---@param value T
 ---@return T
 function M.tbl_set(t, table_path, value)
-  local keys = type(table_path) == "table"
-      and table_path
-      or vim.split(table_path --[[@as string ]], ".", { plain = true })
+  local keys = type(table_path) == "table" and table_path
+    or vim.split(table_path --[[@as string ]], ".", { plain = true })
 
   local cur = t
 
@@ -679,9 +678,8 @@ end
 ---@param table_path string|any[] Either a `.` separated string of table keys, or a list.
 ---@return table
 function M.tbl_ensure(t, table_path)
-  local keys = type(table_path) == "table"
-      and table_path
-      or vim.split(table_path --[[@as string ]], ".", { plain = true })
+  local keys = type(table_path) == "table" and table_path
+    or vim.split(table_path --[[@as string ]], ".", { plain = true })
 
   local ret = M.tbl_access(t, keys)
   if not ret then
@@ -756,7 +754,7 @@ end
 ---@return vector
 function M.vec_union(...)
   local result = {}
-  local args = {...}
+  local args = { ... }
   local seen = {}
 
   for i = 1, select("#", ...) do
@@ -782,13 +780,13 @@ end
 ---@param ... vector
 ---@return vector
 function M.vec_diff(...)
-  local args = {...}
+  local args = { ... }
   local seen = {}
 
   for i = 1, select("#", ...) do
     if type(args[i]) ~= "nil" then
       if type(args[i]) ~= "table" then
-        if i == 1  then
+        if i == 1 then
           seen[args[i]] = true
         elseif seen[args[i]] then
           seen[args[i]] = nil
@@ -813,7 +811,7 @@ end
 ---@return vector
 function M.vec_symdiff(...)
   local result = {}
-  local args = {...}
+  local args = { ... }
   local seen = {}
 
   for i = 1, select("#", ...) do
@@ -830,7 +828,7 @@ function M.vec_symdiff(...)
 
   for v, state in pairs(seen) do
     if state == 1 then
-      result[#result+1] = v
+      result[#result + 1] = v
     end
   end
 
@@ -857,7 +855,7 @@ end
 ---@param ... any
 ---@return vector t
 function M.vec_push(t, ...)
-  local args = {...}
+  local args = { ... }
 
   for i = 1, select("#", ...) do
     t[#t + 1] = args[i]
@@ -917,9 +915,7 @@ function M.buf_search(bufnr, pattern, opt)
   local ret = {}
 
   api.nvim_buf_call(bufnr, function()
-    local flags = ("n%s"):format(
-      opt.reverse and "b" or ""
-    )
+    local flags = ("n%s"):format(opt.reverse and "b" or "")
     local pos = vim.fn.searchpos(pattern, flags)
 
     if not (pos[1] == 0 and pos[2] == 0) then
@@ -941,7 +937,9 @@ function M.buf_search(bufnr, pattern, opt)
 
       if count.incomplete == 2 then
         total = ">" .. count.maxcount
-        if current > count.maxcount then current = total end
+        if current > count.maxcount then
+          current = total
+        end
       end
 
       ret.s_count = ("[%s/%s]"):format(current, total)
@@ -971,7 +969,7 @@ function M.list_bufs(opt)
     for _, winid in ipairs(wins) do
       bufnr = api.nvim_win_get_buf(winid)
       if not seen[bufnr] then
-        bufs[#bufs+1] = bufnr
+        bufs[#bufs + 1] = bufnr
       end
       seen[bufnr] = true
     end
@@ -1100,7 +1098,9 @@ end
 ---@param winid integer
 ---@return integer
 function M.win_content_height(winid)
-  if winid == 0 then winid = api.nvim_get_current_win() end
+  if winid == 0 then
+    winid = api.nvim_get_current_win()
+  end
   ---@diagnostic disable-next-line: redundant-parameter
   local topline = vim.fn.line("w0", winid)
   ---@diagnostic disable-next-line: redundant-parameter
@@ -1136,7 +1136,7 @@ function M.set_cursor(winid, line, column)
 
   pcall(api.nvim_win_set_cursor, winid, {
     M.clamp(line or 1, 1, api.nvim_buf_line_count(bufnr)),
-    math.max(0, column or 0)
+    math.max(0, column or 0),
   })
 end
 
@@ -1356,7 +1356,9 @@ end
 ---@param t T[]
 ---@param comparator? (fun(a: T, b: T): boolean)
 function M.merge_sort(t, comparator)
-  comparator = comparator or function(a, b) return a < b end
+  comparator = comparator or function(a, b)
+    return a < b
+  end
   split_merge(t, 1, #t, comparator)
 end
 
@@ -1372,7 +1374,7 @@ function M.flatten(t)
     local n = #_t
     for i = 1, n do
       local v = _t[i]
-      if type(v) == 'table' then
+      if type(v) == "table" then
         recurse(v)
       elseif v then
         table.insert(result, v)
@@ -1391,7 +1393,9 @@ M.path_sep = path_sep
 --- @return table t
 function M.add_reverse_lookup(t)
   local keys = vim.tbl_keys(t)
-  for _, k in ipairs(keys) do t[t[k]] = k end
+  for _, k in ipairs(keys) do
+    t[t[k]] = k
+  end
   return t
 end
 

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -91,7 +91,9 @@ end
 ---@param cpath string? # Cwd path given by the `-C` flag option
 ---@return string[] path_args # Resolved path args
 ---@return string[] top_indicators # Top-level indicators
-function VCSAdapter.get_repo_paths(path_args, cpath) oop.abstract_stub() end
+function VCSAdapter.get_repo_paths(path_args, cpath)
+  oop.abstract_stub()
+end
 
 ---Try to find the top-level of a working tree by using the given indicative
 ---paths.
@@ -99,7 +101,9 @@ function VCSAdapter.get_repo_paths(path_args, cpath) oop.abstract_stub() end
 ---@param top_indicators string[] A list of paths that might indicate what working tree we are in.
 ---@return string? err
 ---@return string toplevel # Absolute path
-function VCSAdapter.find_toplevel(top_indicators) oop.abstract_stub() end
+function VCSAdapter.find_toplevel(top_indicators)
+  oop.abstract_stub()
+end
 
 ---@diagnostic enable: unused-local, missing-return
 
@@ -115,7 +119,9 @@ function VCSAdapter.build_top_indicators(path_args, cpath)
   local top_indicators = {}
 
   for _, path_arg in ipairs(path_args) do
-    for _, path in ipairs(pl:vim_expand(path_arg, false, true) --[[@as string[] ]]) do
+    for _, path in
+      ipairs(pl:vim_expand(path_arg, false, true) --[[@as string[] ]])
+    do
       path = pl:readlink(path) or path
       table.insert(paths, path)
     end
@@ -129,11 +135,10 @@ function VCSAdapter.build_top_indicators(path_args, cpath)
     break
   end
 
-  table.insert(top_indicators, cpath and pl:realpath(cpath) or (
-    vim.bo.buftype == ""
-    and pl:absolute(cfile)
-    or nil
-  ))
+  table.insert(
+    top_indicators,
+    cpath and pl:realpath(cpath) or (vim.bo.buftype == "" and pl:absolute(cfile) or nil)
+  )
 
   if not cpath then
     table.insert(top_indicators, pl:realpath("."))
@@ -241,7 +246,6 @@ function VCSAdapter:args()
   return utils.vec_slice(self:get_command(), 2)
 end
 
-
 ---Execute a VCS command synchronously.
 ---@param args string[]
 ---@param cwd_or_opt? string|utils.job.Opt
@@ -251,21 +255,23 @@ end
 ---@overload fun(self: VCSAdapter, args: string[], cwd?: string)
 ---@overload fun(self: VCSAdapter, args: string[], opt?: utils.job.Opt)
 function VCSAdapter:exec_sync(args, cwd_or_opt)
-  if not self.class.bootstrap.done then self.class.run_bootstrap() end
+  if not self.class.bootstrap.done then
+    self.class.run_bootstrap()
+  end
 
   local cmd = utils.flatten({ self:get_command(), args })
 
   if not self.class.bootstrap.ok then
     logger:error(
-      ("[VCSAdapter] Can't exec adapter command because bootstrap failed! Cmd: %s")
-      :format(table.concat(cmd, " "))
+      ("[VCSAdapter] Can't exec adapter command because bootstrap failed! Cmd: %s"):format(
+        table.concat(cmd, " ")
+      )
     )
     return
   end
 
   return utils.job(cmd, cwd_or_opt)
 end
-
 
 ---@param thread thread
 ---@param ok boolean
@@ -274,10 +280,7 @@ end
 ---@return any result
 function VCSAdapter:handle_co(thread, ok, result)
   if not ok then
-    local err_msg = utils.vec_join(
-      "Coroutine failed!",
-      debug.traceback(thread, result, 1)
-    )
+    local err_msg = utils.vec_join("Coroutine failed!", debug.traceback(thread, result, 1))
     utils.err(err_msg, true)
     logger:error(table.concat(err_msg, "\n"))
   end

--- a/lua/diffview/vcs/adapters/git/commit.lua
+++ b/lua/diffview/vcs/adapters/git/commit.lua
@@ -1,12 +1,11 @@
 local lazy = require("diffview.lazy")
-local oop = require('diffview.oop')
+local oop = require("diffview.oop")
 
 local Commit = lazy.access("diffview.vcs.commit", "Commit") ---@type Commit|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
 local M = {}
-
 
 ---@class GitCommit : Commit
 ---@field reflog_selector? string

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -42,9 +42,10 @@ GitAdapter.bootstrap = {
     major = 2,
     minor = 31,
     patch = 0,
-  }
+  },
 }
 
+-- stylua: ignore start
 GitAdapter.COMMIT_PRETTY_FMT = (
   "%H %P"      -- Commit hash followed by parent hashes
   .. "%n%an"   -- Author name
@@ -58,6 +59,7 @@ GitAdapter.COMMIT_PRETTY_FMT = (
   -- won't ever be completetely empty. This way the lines will be
   -- distinguishable from other empty lines outputted by Git.
 )
+-- stylua: ignore end
 
 ---@return string, string
 function GitAdapter.pathspec_split(pathspec)
@@ -87,7 +89,9 @@ function GitAdapter.run_bootstrap()
   local git_cmd = config.get_config().git_cmd
   local bs = GitAdapter.bootstrap
   local err = VCSAdapter.bootstrap_preamble(bs, git_cmd, "GitAdapter", "git_cmd")
-  if not err then return end
+  if not err then
+    return
+  end
 
   local out = utils.job(utils.flatten({ git_cmd, "version" }))
   bs.version_string = out[1] and out[1]:match("git version (%S+)") or nil
@@ -107,12 +111,14 @@ function GitAdapter.run_bootstrap()
   local version_ok = vcs_utils.check_semver(v, target)
 
   if not version_ok then
-    return err(string.format(
-      "Git version is outdated! Some functionality might not work as expected, "
-        .. "or not at all! Current: %s, wanted: %s",
-      bs.version_string,
-      bs.target_version_string
-    ))
+    return err(
+      string.format(
+        "Git version is outdated! Some functionality might not work as expected, "
+          .. "or not at all! Current: %s, wanted: %s",
+        bs.version_string,
+        bs.target_version_string
+      )
+    )
   end
 
   bs.ok = true
@@ -127,7 +133,9 @@ function GitAdapter.get_repo_paths(path_args, cpath)
   local top_indicators = {}
 
   for _, path_arg in ipairs(path_args) do
-    for _, path in ipairs(pl:vim_expand(path_arg, false, true) --[[@as string[] ]]) do
+    for _, path in
+      ipairs(pl:vim_expand(path_arg, false, true) --[[@as string[] ]])
+    do
       local magic, pattern = GitAdapter.pathspec_split(path)
       pattern = pl:readlink(pattern) or pattern
       table.insert(paths, magic .. pattern)
@@ -144,11 +152,10 @@ function GitAdapter.get_repo_paths(path_args, cpath)
     end
   end
 
-  table.insert(top_indicators, cpath and pl:realpath(cpath) or (
-    vim.bo.buftype == ""
-    and pl:absolute(cfile)
-    or nil
-  ))
+  table.insert(
+    top_indicators,
+    cpath and pl:realpath(cpath) or (vim.bo.buftype == "" and pl:absolute(cfile) or nil)
+  )
 
   if not cpath then
     table.insert(top_indicators, pl:realpath("."))
@@ -195,10 +202,13 @@ end
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
-  local out, code = utils.job(utils.flatten({
-    config.get_config().git_cmd,
-    { "rev-parse", "--path-format=absolute", "--show-toplevel" },
-  }), path)
+  local out, code = utils.job(
+    utils.flatten({
+      config.get_config().git_cmd,
+      { "rev-parse", "--path-format=absolute", "--show-toplevel" },
+    }),
+    path
+  )
   if code ~= 0 then
     return nil
   end
@@ -252,7 +262,7 @@ function GitAdapter:init(opt)
     dir = self:get_dir(opt.toplevel),
     path_args = vim.tbl_map(function(pathspec)
       return GitAdapter.pathspec_expand(opt.toplevel, cwd, pathspec)
-    end, opt.path_args or {}) --[[@as string[] ]]
+    end, opt.path_args or {}) --[[@as string[] ]],
   }
 
   self:init_completion()
@@ -265,7 +275,12 @@ end
 ---@param path string
 ---@param rev Rev?
 function GitAdapter:get_show_args(path, rev)
-  return utils.vec_join(self:args(), "show", "--no-show-signature", fmt("%s:%s", rev and rev:object_name() or "", path))
+  return utils.vec_join(
+    self:args(),
+    "show",
+    "--no-show-signature",
+    fmt("%s:%s", rev and rev:object_name() or "", path)
+  )
 end
 
 function GitAdapter:get_log_args(args)
@@ -309,14 +324,20 @@ function GitAdapter:get_merge_context()
   end
 
   local ret = {}
-  local out, code = self:exec_sync({ "show", "-s", "--no-show-signature", "--pretty=format:%H%n%D", "HEAD", "--" }, self.ctx.toplevel)
+  local out, code = self:exec_sync(
+    { "show", "-s", "--no-show-signature", "--pretty=format:%H%n%D", "HEAD", "--" },
+    self.ctx.toplevel
+  )
 
   ret.ours = code ~= 0 and {} or {
     hash = out[1],
     ref_names = out[2],
   }
 
-  out, code = self:exec_sync({ "show", "-s", "--no-show-signature", "--pretty=format:%H%n%D", their_head, "--" }, self.ctx.toplevel)
+  out, code = self:exec_sync(
+    { "show", "-s", "--no-show-signature", "--pretty=format:%H%n%D", their_head, "--" },
+    self.ctx.toplevel
+  )
 
   ret.theirs = code ~= 0 and {} or {
     hash = out[1],
@@ -331,7 +352,10 @@ function GitAdapter:get_merge_context()
   else
     ret.base = {
       hash = out[1],
-      ref_names = self:exec_sync({ "show", "-s", "--no-show-signature", "--pretty=format:%D", out[1] }, self.ctx.toplevel)[1],
+      ref_names = self:exec_sync(
+        { "show", "-s", "--no-show-signature", "--pretty=format:%D", out[1] },
+        self.ctx.toplevel
+      )[1],
     }
   end
 
@@ -408,7 +432,7 @@ function GitAdapter:prepare_fh_options(log_options, single_file)
       o.S and { "-S" .. o.S, "--pickaxe-regex" } or nil,
       o.after and { "--after=" .. o.after } or nil,
       o.before and { "--before=" .. o.before } or nil
-    )
+    ),
   }
 end
 
@@ -462,18 +486,20 @@ function GitAdapter:stream_fh_data(state)
       end
 
       local ok, err = job:is_success()
-      if job:is_done() and ok and job.code == 0 then on_stdout(nil, "\0") end
+      if job:is_done() and ok and job.code == 0 then
+        on_stdout(nil, "\0")
+      end
 
       if not ok then
         stream:push({
           JobStatus.ERROR,
           nil,
-          table.concat(utils.vec_join(err, job.stderr), "\n")
+          table.concat(utils.vec_join(err, job.stderr), "\n"),
         })
       else
         stream:push({ JobStatus.SUCCESS })
       end
-    end
+    end,
   })
 
   job = Job({
@@ -546,18 +572,20 @@ function GitAdapter:stream_line_trace_data(state)
       end
 
       local ok, err = job:is_success()
-      if job:is_done() and ok and job.code == 0 then on_stdout(nil, "\0") end
+      if job:is_done() and ok and job.code == 0 then
+        on_stdout(nil, "\0")
+      end
 
       if not ok then
         stream:push({
           JobStatus.ERROR,
           nil,
-          table.concat(utils.vec_join(err, job.stderr), "\n")
+          table.concat(utils.vec_join(err, job.stderr), "\n"),
         })
       else
         stream:push({ JobStatus.SUCCESS })
       end
-    end
+    end,
   })
 
   job = Job({
@@ -602,11 +630,14 @@ function GitAdapter:is_single_file(path_args, lflags)
       end
       seen[path] = true
     end
-
   elseif path_args and self.ctx.toplevel then
     return #path_args == 1
-        and not pl:is_dir(path_args[1])
-        and #self:exec_sync({ "-c", "core.quotePath=false", "ls-files", "--", path_args }, self.ctx.toplevel) < 2
+      and not pl:is_dir(path_args[1])
+      and #self:exec_sync(
+          { "-c", "core.quotePath=false", "ls-files", "--", path_args },
+          self.ctx.toplevel
+        )
+        < 2
   end
 
   return true
@@ -664,7 +695,6 @@ function GitAdapter:file_history_dry_run(log_opt)
   end
 
   return ok, table.concat(description, ", ")
-
 end
 
 ---@param range? { [1]: integer, [2]: integer }
@@ -730,7 +760,7 @@ function GitAdapter:file_history_options(range, paths, argo)
   if range then
     paths, rel_paths = {}, {}
     log_options.L = {
-      fmt("%d,%d:%s", range[1], range[2], pl:relative(pl:absolute(cfile), self.ctx.toplevel))
+      fmt("%d,%d:%s", range[1], range[2], pl:relative(pl:absolute(cfile), self.ctx.toplevel)),
     }
   end
 
@@ -758,10 +788,7 @@ function GitAdapter:file_history_options(range, paths, argo)
 
   if not self.ctx.dir then
     utils.err(
-      fmt(
-        "Failed to find the git dir for the repository: %s",
-        utils.str_quote(self.ctx.toplevel)
-      )
+      fmt("Failed to find the git dir for the repository: %s", utils.str_quote(self.ctx.toplevel))
     )
     return
   end
@@ -781,10 +808,8 @@ end
 ---@param out_stream AsyncListStream
 ---@param opt vcs.adapter.FileHistoryWorkerSpec
 GitAdapter.file_history_worker = async.void(function(self, out_stream, opt)
-  local single_file = self:is_single_file(
-    opt.log_opt.single_file.path_args,
-    opt.log_opt.single_file.L
-  )
+  local single_file =
+    self:is_single_file(opt.log_opt.single_file.path_args, opt.log_opt.single_file.L)
 
   ---@type GitLogOptions
   local log_options = config.get_log_options(
@@ -820,7 +845,9 @@ GitAdapter.file_history_worker = async.void(function(self, out_stream, opt)
 
   ---@param shutdown? SignalConsumer
   out_stream:on_close(function(shutdown)
-    if shutdown then in_stream:close(shutdown) end
+    if shutdown then
+      in_stream:close(shutdown)
+    end
   end)
 
   local last_wait = uv.hrtime()
@@ -833,7 +860,7 @@ GitAdapter.file_history_worker = async.void(function(self, out_stream, opt)
     -- Make sure to yield to the scheduler periodically to keep the editor
     -- responsive.
     local now = uv.hrtime()
-    if (now - last_wait > interval) then
+    if now - last_wait > interval then
       last_wait = now
       await(async.schedule_now())
     end
@@ -869,17 +896,17 @@ GitAdapter.file_history_worker = async.void(function(self, out_stream, opt)
       local rev_arg = new_data.right_hash
       local is_merge = new_data.merge_hash ~= nil
 
-      if is_trace and is_merge then goto continue end
+      if is_trace and is_merge then
+        goto continue
+      end
 
       logger:fmt_warn("Received malformed or insufficient data for '%s'! Retrying...", rev_arg)
       logger:debug(new_data)
-      err, new_data = await(
-        self:fh_retry_commit(rev_arg, state, {
-          is_merge = is_merge,
-          retry_count = not is_merge and 2,
-          keep_diff = is_trace,
-        })
-      )
+      err, new_data = await(self:fh_retry_commit(rev_arg, state, {
+        is_merge = is_merge,
+        retry_count = not is_merge and 2,
+        keep_diff = is_trace,
+      }))
 
       if err then
         if err.name == "job_fail" then
@@ -927,7 +954,9 @@ GitAdapter.file_history_worker = async.void(function(self, out_stream, opt)
 
     -- Some commits might not have file data. In that case we simply ignore it,
     -- as the fh panel doesn't support such entries at the moment.
-    if ok then out_stream:push({ JobStatus.PROGRESS, entry }) end
+    if ok then
+      out_stream:push({ JobStatus.PROGRESS, entry })
+    end
 
     ::continue::
   end
@@ -978,7 +1007,9 @@ GitAdapter.fh_retry_commit = async.wrap(function(self, rev_arg, state, opt, call
 
     if not err and job.code == 0 then
       data = structure_fh_data(job.stdout, opt.keep_diff)
-      if data.valid then break end
+      if data.valid then
+        break
+      end
     end
 
     await(async.timeout(10))
@@ -1060,32 +1091,30 @@ function GitAdapter:parse_fh_data(data, commit, state)
 
     table.insert(
       files,
-      FileEntry.with_layout(
-        state.layout_opt.default_layout or Diff2Hor,
-        {
-          adapter = self,
-          path = entry.name,
-          oldpath = entry.oldname,
-          status = entry.status,
-          stats = entry.stats,
-          kind = "working",
-          commit = commit,
-          revs = {
-            a = data.left_hash and GitRev(RevType.COMMIT, data.left_hash) or GitRev.new_null_tree(),
-            b = state.prepared_log_opts.base or GitRev(RevType.COMMIT, data.right_hash),
-          },
-        }
-      )
+      FileEntry.with_layout(state.layout_opt.default_layout or Diff2Hor, {
+        adapter = self,
+        path = entry.name,
+        oldpath = entry.oldname,
+        status = entry.status,
+        stats = entry.stats,
+        kind = "working",
+        commit = commit,
+        revs = {
+          a = data.left_hash and GitRev(RevType.COMMIT, data.left_hash) or GitRev.new_null_tree(),
+          b = state.prepared_log_opts.base or GitRev(RevType.COMMIT, data.right_hash),
+        },
+      })
     )
   end
 
   if files[1] then
-    return true, LogEntry({
-      path_args = state.path_args,
-      commit = commit,
-      files = files,
-      single_file = state.single_file,
-    })
+    return true,
+      LogEntry({
+        path_args = state.path_args,
+        commit = commit,
+        files = files,
+        single_file = state.single_file,
+      })
   end
 
   if state.path_args[1] then
@@ -1095,11 +1124,12 @@ function GitAdapter:parse_fh_data(data, commit, state)
   end
 
   -- Commit is likely identical to it's parent. Return an empty log entry.
-  return true, LogEntry.new_null_entry(self, {
-    path_args = state.path_args,
-    commit = commit,
-    single_file = state.single_file,
-  })
+  return true,
+    LogEntry.new_null_entry(self, {
+      path_args = state.path_args,
+      commit = commit,
+      single_file = state.single_file,
+    })
 end
 
 ---@param data GitAdapter.LogData
@@ -1119,31 +1149,28 @@ function GitAdapter:parse_fh_line_trace_data(data, commit, state)
 
     table.insert(
       files,
-      FileEntry.with_layout(state.layout_opt.default_layout or Diff2Hor,
-        {
-          adapter = self,
-          path = entry.path_new,
-          oldpath = oldpath,
-          kind = "working",
-          commit = commit,
-          revs = {
-            a = data.left_hash
-                and GitRev(RevType.COMMIT, data.left_hash)
-                or GitRev.new_null_tree(),
-            b = state.prepared_log_opts.base or GitRev(RevType.COMMIT, data.right_hash),
-          },
-        }
-      )
+      FileEntry.with_layout(state.layout_opt.default_layout or Diff2Hor, {
+        adapter = self,
+        path = entry.path_new,
+        oldpath = oldpath,
+        kind = "working",
+        commit = commit,
+        revs = {
+          a = data.left_hash and GitRev(RevType.COMMIT, data.left_hash) or GitRev.new_null_tree(),
+          b = state.prepared_log_opts.base or GitRev(RevType.COMMIT, data.right_hash),
+        },
+      })
     )
   end
 
   if files[1] then
-    return true, LogEntry({
-      path_args = state.path_args,
-      commit = commit,
-      files = files,
-      single_file = state.single_file,
-    })
+    return true,
+      LogEntry({
+        path_args = state.path_args,
+        commit = commit,
+        files = files,
+        single_file = state.single_file,
+      })
   end
 
   logger:debug("[GitAdapter:parse_fh_data] Encountered commit with no file data:", data)
@@ -1181,7 +1208,7 @@ function GitAdapter:diffview_options(argo)
     selected_row = tonumber(argo:get_flag("selected-row", { no_empty = true })),
   }
 
-  return {left = left, right = right, options = options}
+  return { left = left, right = right, options = options }
 end
 
 ---@return Rev?
@@ -1270,7 +1297,9 @@ end
 ---@return string? url The web URL, or nil if the hosting service is not recognized.
 function GitAdapter:get_commit_url(commit_hash)
   local remote_url = self:get_remote_url()
-  if not remote_url then return nil end
+  if not remote_url then
+    return nil
+  end
 
   -- Normalize the URL to extract host and repo path.
   local host, repo
@@ -1289,7 +1318,9 @@ function GitAdapter:get_commit_url(commit_hash)
     end
   end
 
-  if not host or not repo then return nil end
+  if not host or not repo then
+    return nil
+  end
 
   -- Remove .git suffix if present.
   repo = repo:gsub("%.git$", "")
@@ -1314,14 +1345,16 @@ function GitAdapter:file_blob_hash(path, rev_arg)
   local out, code = self:exec_sync({
     "rev-parse",
     "--revs-only",
-    fmt("%s:%s", rev_arg or "", path)
+    fmt("%s:%s", rev_arg or "", path),
   }, {
     cwd = self.ctx.toplevel,
     retry = 2,
     fail_on_empty = true,
   })
 
-  if code ~= 0 then return end
+  if code ~= 0 then
+    return
+  end
 
   return vim.trim(out[1])
 end
@@ -1336,11 +1369,7 @@ function GitAdapter:symmetric_diff_revs(rev_arg)
   local out, code, stderr
 
   local function err()
-    utils.err(utils.vec_join(
-      fmt("Failed to parse rev '%s'!", rev_arg),
-      "Git output: ",
-      stderr
-    ))
+    utils.err(utils.vec_join(fmt("Failed to parse rev '%s'!", rev_arg), "Git output: ", stderr))
   end
 
   out, code, stderr = self:exec_sync(
@@ -1416,11 +1445,13 @@ function GitAdapter:parse_revs(rev_arg, opt)
       { cwd = self.ctx.toplevel, fail_on_empty = true, retry = 2 }
     )
     if code ~= 0 then
-      utils.err(utils.vec_join(
-        fmt("Failed to parse rev %s!", utils.str_quote(rev_arg)),
-        "Git output: ",
-        stderr
-      ))
+      utils.err(
+        utils.vec_join(
+          fmt("Failed to parse rev %s!", utils.str_quote(rev_arg)),
+          "Git output: ",
+          stderr
+        )
+      )
       return
     elseif #rev_strings == 0 then
       utils.err("Bad revision: " .. utils.str_quote(rev_arg))
@@ -1504,17 +1535,14 @@ function GitAdapter:rev_to_args(left, right)
 
   if left.type == RevType.COMMIT and right.type == RevType.COMMIT then
     return { left.commit .. ".." .. right.commit }
-
   elseif left.type == RevType.COMMIT and right.type == RevType.STAGE then
     return { "--cached", left.commit }
-
   elseif right.type == RevType.LOCAL then
     if left.type == RevType.STAGE then
       return {}
     elseif left.type == RevType.COMMIT then
       return { left.commit }
     end
-
   elseif left.type == RevType.LOCAL then
     -- WARN: these require special handling when creating the diff file list.
     -- I.e. the stats for 'additions' and 'deletions' need to be swapped.
@@ -1527,7 +1555,6 @@ function GitAdapter:rev_to_args(left, right)
 
   error(fmt("InvalidArgument :: Unsupported rev range: '%s..%s'!", left, right))
 end
-
 
 ---@param self GitAdapter
 ---@param path string
@@ -1551,7 +1578,10 @@ GitAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback
     -- Wite file blob into db
     out, code = self:exec_sync({ "hash-object", "-w", "--", path }, self.ctx.toplevel)
     if code ~= 0 then
-      utils.err("Failed to write file blob into the object database. Aborting file restoration.", true)
+      utils.err(
+        "Failed to write file blob into the object database. Aborting file restoration.",
+        true
+      )
       callback(false)
       return
     end
@@ -1573,7 +1603,7 @@ GitAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback
       if not ok then
         utils.err({
           fmt("Failed to delete buffer '%d'! Aborting file restoration. Error message:", bn),
-          err
+          err,
         }, true)
         callback(false)
         return
@@ -1586,17 +1616,14 @@ GitAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback
       if not ok then
         utils.err({
           fmt("Failed to delete file '%s'! Aborting file restoration. Error message:", abs_path),
-          err
+          err,
         }, true)
         callback(false)
         return
       end
     else
       -- File only exists in index
-      out, code = self:exec_sync(
-        { "rm", "-f", "--", path },
-        self.ctx.toplevel
-      )
+      out, code = self:exec_sync({ "rm", "-f", "--", path }, self.ctx.toplevel)
     end
   else
     -- File exists in history: checkout
@@ -1607,7 +1634,9 @@ GitAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback
 
     await(async.scheduler())
     local bn = utils.find_file_buffer(abs_path)
-    if bn then vim.cmd(fmt("checktime %d", bn)) end
+    if bn then
+      vim.cmd(fmt("checktime %d", bn))
+    end
   end
 
   callback(true, undo)
@@ -1637,7 +1666,10 @@ function GitAdapter:stage_index_file(file)
 
     local blob_hash = out[1]
 
-    out, code = self:exec_sync({ "-c", "core.quotePath=false", "ls-files", "--stage", file.path }, self.ctx.toplevel)
+    out, code = self:exec_sync(
+      { "-c", "core.quotePath=false", "ls-files", "--stage", file.path },
+      self.ctx.toplevel
+    )
     local old_mode = out[1]:match("^(%d+)")
 
     if not old_mode then
@@ -1662,7 +1694,9 @@ function GitAdapter:stage_index_file(file)
   end)
 
   vim.fn.delete(temp)
-  if not ok then error(ret) end
+  if not ok then
+    error(ret)
+  end
 
   return ret
 end
@@ -1751,10 +1785,7 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
   local numstat_count
 
   for attempt = 1, max_attempts do
-    local multi_job = MultiJob(
-      { namestat_job, numstat_job },
-      { retry = 2 }
-    )
+    local multi_job = MultiJob({ namestat_job, numstat_job }, { retry = 2 })
 
     local ok, err = await(multi_job)
 
@@ -1766,7 +1797,8 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
     -- Both jobs use `-z` for NUL-delimited output, which is safe for
     -- filenames containing tabs or newlines.  Reassemble stdout into a
     -- single string and split on NUL.
-    local namestat_fields = vim.split(table.concat(namestat_job.stdout, "\n"), "\0", { plain = true })
+    local namestat_fields =
+      vim.split(table.concat(namestat_job.stdout, "\n"), "\0", { plain = true })
     local numstat_fields = vim.split(table.concat(numstat_job.stdout, "\n"), "\0", { plain = true })
 
     -- Parse NUL-delimited --name-status: status\0name[\0oldname]\0...
@@ -1825,7 +1857,7 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
           -- table.insert(t, nil) is a no-op in Lua.
           numstat_count = numstat_count + 1
           numstat_entries[numstat_count] = (additions and deletions)
-            and { additions = additions, deletions = deletions }
+              and { additions = additions, deletions = deletions }
             or nil
         end
       end
@@ -1837,9 +1869,11 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
 
     -- Imbalance detected; retry unless we have exhausted all attempts.
     if attempt == max_attempts then
-      local msg = ("Imbalance in diff data: name-status has %d entries, numstat has %d. "
+      local msg = (
+        "Imbalance in diff data: name-status has %d entries, numstat has %d. "
         .. "This may indicate malformed or truncated git output and can be intermittent. "
-        .. "kind=%s"):format(#namestat_entries, numstat_count, tostring(kind))
+        .. "kind=%s"
+      ):format(#namestat_entries, numstat_count, tostring(kind))
       callback({ msg }, nil)
       return
     end
@@ -1871,19 +1905,22 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
     end, data)
 
     for _, v in pairs(conflict_map) do
-      table.insert(conflicts, FileEntry.with_layout(opt.merge_layout, {
-        adapter = self,
-        path = v.name,
-        oldpath = v.oldname,
-        status = "U",
-        kind = "conflicting",
-        revs = {
-          a = self.Rev(RevType.STAGE, 2),  -- ours
-          b = self.Rev(RevType.LOCAL),     -- local
-          c = self.Rev(RevType.STAGE, 3),  -- theirs
-          d = self.Rev(RevType.STAGE, 1),  -- base
-        },
-      }))
+      table.insert(
+        conflicts,
+        FileEntry.with_layout(opt.merge_layout, {
+          adapter = self,
+          path = v.name,
+          oldpath = v.oldname,
+          status = "U",
+          kind = "conflicting",
+          revs = {
+            a = self.Rev(RevType.STAGE, 2), -- ours
+            b = self.Rev(RevType.LOCAL), -- local
+            c = self.Rev(RevType.STAGE, 3), -- theirs
+            d = self.Rev(RevType.STAGE, 1), -- base
+          },
+        })
+      )
     end
   end
 
@@ -1898,7 +1935,7 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
       revs = {
         a = left,
         b = right,
-      }
+      },
     })
 
     if left and left.type == RevType.LOCAL and file.stats then
@@ -1927,7 +1964,7 @@ GitAdapter.untracked_files = async.wrap(function(self, left, right, opt, callbac
       "--exclude-standard"
     ),
     cwd = self.ctx.toplevel,
-    log_opt = { label = "GitAdapter:untracked_files()", }
+    log_opt = { label = "GitAdapter:untracked_files()" },
   })
 
   local ok = await(job)
@@ -1939,16 +1976,19 @@ GitAdapter.untracked_files = async.wrap(function(self, left, right, opt, callbac
 
   local files = {}
   for _, s in ipairs(job.stdout) do
-    table.insert(files, FileEntry.with_layout(opt.default_layout, {
-      adapter = self,
-      path = s,
-      status = "?",
-      kind = "working",
-      revs = {
-        a = left,
-        b = right,
-      }
-    }))
+    table.insert(
+      files,
+      FileEntry.with_layout(opt.default_layout, {
+        adapter = self,
+        path = s,
+        status = "?",
+        kind = "working",
+        revs = {
+          a = left,
+          b = right,
+        },
+      })
+    )
   end
 
   callback(nil, files)
@@ -1986,14 +2026,24 @@ function GitAdapter:is_binary(path, rev)
     return false
   end
 
-  local cmd = { "-c", "submodule.recurse=false", "-c", "core.quotePath=false", "grep", "-I", "--name-only", "-e", "." }
+  local cmd = {
+    "-c",
+    "submodule.recurse=false",
+    "-c",
+    "core.quotePath=false",
+    "grep",
+    "-I",
+    "--name-only",
+    "-e",
+    ".",
+  }
   if rev.type == RevType.LOCAL then
-    cmd[#cmd+1] = "--untracked"
-    cmd[#cmd+1] = "--no-exclude-standard"
+    cmd[#cmd + 1] = "--untracked"
+    cmd[#cmd + 1] = "--no-exclude-standard"
   elseif rev.type == RevType.STAGE then
-    cmd[#cmd+1] = "--cached"
+    cmd[#cmd + 1] = "--cached"
   else
-    cmd[#cmd+1] = rev.commit
+    cmd[#cmd + 1] = rev.commit
   end
 
   utils.vec_push(cmd, "--", path)
@@ -2007,7 +2057,11 @@ GitAdapter.flags = {
   switches = {
     FlagOption("-f", "--follow", "Follow renames (only for single file)"),
     FlagOption("-p", "--first-parent", "Follow only the first parent upon seeing a merge commit"),
-    FlagOption("-s", "--show-pulls", "Show merge commits the first introduced a change to a branch"),
+    FlagOption(
+      "-s",
+      "--show-pulls",
+      "Show merge commits the first introduced a change to a branch"
+    ),
     FlagOption("-R", "--reflog", "Include all reachable objects mentioned by reflogs"),
     FlagOption("-g", "--walk-reflogs", "Walk reflogs instead of the commit ancestry chain"),
     FlagOption("-a", "--all", "Include all refs"),
@@ -2016,7 +2070,11 @@ GitAdapter.flags = {
     FlagOption("-r", "--reverse", "List commits in reverse order"),
     FlagOption("-cp", "--cherry-pick", "Omit commits that introduce the same change as another"),
     FlagOption("-lo", "--left-only", "List only the commits on the left side of a symmetric diff"),
-    FlagOption("-ro", "--right-only", "List only the commits on the right side of a symmetric diff"),
+    FlagOption(
+      "-ro",
+      "--right-only",
+      "List only the commits on the right side of a symmetric diff"
+    ),
   },
   ---@type FlagOption[]
   options = {
@@ -2042,7 +2100,7 @@ GitAdapter.flags = {
         end
       end,
     }),
-    FlagOption("=n", "--max-count=", "Limit the number of commits" ),
+    FlagOption("=n", "--max-count=", "Limit the number of commits"),
     FlagOption("=L", "-L", "Trace line evolution", {
       expect_list = true,
       prompt_label = "(Accepts multiple values)",
@@ -2067,22 +2125,22 @@ GitAdapter.flags = {
       },
     }),
     FlagOption("=a", "--author=", "List only commits from a given author", {
-      prompt_label = "(Extended regular expression)"
+      prompt_label = "(Extended regular expression)",
     }),
     FlagOption("=g", "--grep=", "Filter commit messages", {
-      prompt_label = "(Extended regular expression)"
+      prompt_label = "(Extended regular expression)",
     }),
     FlagOption("=G", "-G", "Search changes", {
-      prompt_label = "(Extended regular expression)"
+      prompt_label = "(Extended regular expression)",
     }),
     FlagOption("=S", "-S", "Search occurrences", {
-      prompt_label = "(Extended regular expression)"
+      prompt_label = "(Extended regular expression)",
     }),
     FlagOption("=A", "--after=", "List only commits after a certain date", {
-      prompt_label = "(YYYY-mm-dd, YYYY-mm-dd HH:mm:ss)"
+      prompt_label = "(YYYY-mm-dd, YYYY-mm-dd HH:mm:ss)",
     }),
     FlagOption("=B", "--before=", "List only commits before a certain date", {
-      prompt_label = "(YYYY-mm-dd, YYYY-mm-dd HH:mm:ss)"
+      prompt_label = "(YYYY-mm-dd, YYYY-mm-dd HH:mm:ss)",
     }),
     FlagOption("--", "--", "Limit to files", {
       key = "path_args",
@@ -2137,11 +2195,12 @@ function GitAdapter:rev_candidates(arg_lead, opt)
   -- stylua: ignore end
 
   local heads = vim.tbl_filter(
-    function(name) return vim.tbl_contains(targets, name) end,
-    vim.tbl_map(
-      function(v) return pl:basename(v) end,
-      vim.fn.glob(self.ctx.dir .. "/*", false, true)
-    )
+    function(name)
+      return vim.tbl_contains(targets, name)
+    end,
+    vim.tbl_map(function(v)
+      return pl:basename(v)
+    end, vim.fn.glob(self.ctx.dir .. "/*", false, true))
   )
   local revs = self:exec_sync(
     { "rev-parse", "--symbolic", "--branches", "--tags", "--remotes" },
@@ -2191,7 +2250,6 @@ function GitAdapter.line_trace_candidates(arg_lead)
   end
 end
 
-
 function GitAdapter:init_completion()
   self.comp.open:put({ "u", "untracked-files" }, { "true", "normal", "all", "false", "no" })
   self.comp.open:put({ "cached", "staged" })
@@ -2200,7 +2258,7 @@ function GitAdapter:init_completion()
   self.comp.open:put({ "C" }, function(_, arg_lead)
     return vim.fn.getcompletion(arg_lead, "dir")
   end)
-  self.comp.open:put({ "selected-file" }, function (_, arg_lead)
+  self.comp.open:put({ "selected-file" }, function(_, arg_lead)
     return vim.fn.getcompletion(arg_lead, "file")
   end)
   self.comp.open:put({ "selected-row" })
@@ -2227,7 +2285,7 @@ function GitAdapter:init_completion()
   self.comp.file_history:put({ "--left-only" })
   self.comp.file_history:put({ "--right-only" })
   self.comp.file_history:put({ "--max-count", "-n" }, {})
-  self.comp.file_history:put({ "-L" }, function (_, arg_lead)
+  self.comp.file_history:put({ "-L" }, function(_, arg_lead)
     return GitAdapter.line_trace_candidates(arg_lead)
   end)
   self.comp.file_history:put({ "--diff-merges" }, {

--- a/lua/diffview/vcs/adapters/git/parser.lua
+++ b/lua/diffview/vcs/adapters/git/parser.lua
@@ -81,9 +81,8 @@ function M.structure_fh_data(stat_data, keep_diff)
   end
 
   -- Soft validate the data.
-  ret.valid = #namestat == #numstat and pcall(
-    vim.validate,
-    {
+  ret.valid = #namestat == #numstat
+    and pcall(vim.validate, {
       left_hash = { ret.left_hash, "string", true },
       right_hash = { ret.right_hash, "string" },
       merge_hash = { ret.merge_hash, "string", true },
@@ -94,8 +93,7 @@ function M.structure_fh_data(stat_data, keep_diff)
       ref_names = { ret.ref_names, "string" },
       reflog_selector = { ret.reflog_selector, "string" },
       subject = { ret.subject, "string" },
-    }
-  )
+    })
 
   return ret
 end
@@ -126,8 +124,12 @@ function M.parse_namestat_entry(namestat_line, numstat_line)
   end
 
   if not namestat_fields then
-    error(("Malformed namestat line: insufficient fields (expected %d whitespace-separated groups): %s")
-      :format(offset - 1, namestat_line))
+    error(
+      ("Malformed namestat line: insufficient fields (expected %d whitespace-separated groups): %s"):format(
+        offset - 1,
+        namestat_line
+      )
+    )
   end
 
   local status = namestat_fields[1]:match("^%a%a?")

--- a/lua/diffview/vcs/adapters/git/rev.lua
+++ b/lua/diffview/vcs/adapters/git/rev.lua
@@ -1,6 +1,6 @@
 local oop = require("diffview.oop")
-local Rev = require('diffview.vcs.rev').Rev
-local RevType = require('diffview.vcs.rev').RevType
+local Rev = require("diffview.vcs.rev").Rev
+local RevType = require("diffview.vcs.rev").RevType
 
 local M = {}
 
@@ -24,10 +24,7 @@ function GitRev:init(rev_type, revision, track_head)
   if t == "string" then
     assert(revision ~= "", "'revision' cannot be an empty string!")
   elseif t == "number" then
-    assert(
-      revision >= 0 and revision <= 3,
-      "'revision' must be a valid stage number ([0-3])!"
-    )
+    assert(revision >= 0 and revision <= 3, "'revision' must be a valid stage number ([0-3])!")
   end
 
   t = type(track_head)
@@ -95,7 +92,10 @@ end
 ---@return Rev?
 function GitRev.earliest_commit(adapter)
   local out, code = adapter:exec_sync({
-    "rev-list", "--max-parents=0", "--first-parent", "HEAD"
+    "rev-list",
+    "--max-parents=0",
+    "--first-parent",
+    "HEAD",
   }, adapter.ctx.toplevel)
 
   if code ~= 0 then
@@ -138,7 +138,7 @@ function GitRev:object_name(abbrev_len)
 
     return self.commit
   elseif self.type == RevType.STAGE then
-    return ":" ..  self.stage
+    return ":" .. self.stage
   end
 
   return "UNKNOWN"

--- a/lua/diffview/vcs/adapters/hg/commit.lua
+++ b/lua/diffview/vcs/adapters/hg/commit.lua
@@ -1,12 +1,12 @@
 local lazy = require("diffview.lazy")
-local oop = require('diffview.oop')
+local oop = require("diffview.oop")
 local utils = require("diffview.utils")
-local Commit = require('diffview.vcs.commit').Commit
+local Commit = require("diffview.vcs.commit").Commit
 
 local M = {}
 
 ---@class HgCommit : Commit
-local HgCommit = oop.create_class('HgCommit', Commit)
+local HgCommit = oop.create_class("HgCommit", Commit)
 
 function HgCommit:init(opt)
   self:super(opt)

--- a/lua/diffview/vcs/adapters/hg/init.lua
+++ b/lua/diffview/vcs/adapters/hg/init.lua
@@ -3,19 +3,19 @@ local Commit = require("diffview.vcs.adapters.hg.commit").HgCommit
 local Diff2Hor = require("diffview.scene.layouts.diff_2_hor").Diff2Hor
 local FileEntry = require("diffview.scene.file_entry").FileEntry
 local FlagOption = require("diffview.vcs.flag_option").FlagOption
-local HgRev = require('diffview.vcs.adapters.hg.rev').HgRev
+local HgRev = require("diffview.vcs.adapters.hg.rev").HgRev
 local Job = require("diffview.job").Job
 local MultiJob = require("diffview.multi_job").MultiJob
-local JobStatus = require('diffview.vcs.utils').JobStatus
+local JobStatus = require("diffview.vcs.utils").JobStatus
 local LogEntry = require("diffview.vcs.log_entry").LogEntry
 local RevType = require("diffview.vcs.rev").RevType
-local VCSAdapter = require('diffview.vcs.adapter').VCSAdapter
+local VCSAdapter = require("diffview.vcs.adapter").VCSAdapter
 local arg_parser = require("diffview.arg_parser")
 local async = require("diffview.async")
-local config = require('diffview.config')
-local lazy = require('diffview.lazy')
-local oop = require('diffview.oop')
-local utils = require('diffview.utils')
+local config = require("diffview.config")
+local lazy = require("diffview.lazy")
+local oop = require("diffview.oop")
+local utils = require("diffview.utils")
 local vcs_utils = require("diffview.vcs.utils")
 
 local await, pawait = async.await, async.pawait
@@ -27,7 +27,7 @@ local uv = vim.uv
 local M = {}
 
 ---@class HgAdapter : VCSAdapter
-local HgAdapter = oop.create_class('HgAdapter', VCSAdapter)
+local HgAdapter = oop.create_class("HgAdapter", VCSAdapter)
 
 HgAdapter.Rev = HgRev
 HgAdapter.config_key = "hg"
@@ -39,14 +39,16 @@ HgAdapter.bootstrap = {
     major = 5,
     minor = 4,
     patch = 0,
-  }
+  },
 }
 
 function HgAdapter.run_bootstrap()
   local hg_cmd = config.get_config().hg_cmd
   local bs = HgAdapter.bootstrap
   local err = VCSAdapter.bootstrap_preamble(bs, hg_cmd, "HgAdapter", "hg_cmd")
-  if not err then return end
+  if not err then
+    return
+  end
 
   local out = utils.job(utils.flatten({ hg_cmd, "version" }))
   local line = out[1]
@@ -81,12 +83,14 @@ function HgAdapter.run_bootstrap()
   local version_ok = is_sapling or vcs_utils.check_semver(v, target)
 
   if not version_ok then
-    return err(string.format(
-      "Mercurial version is outdated! Some functionality might not work as expected, "
-        .. "or not at all! Current: %s, wanted: %s",
-      bs.version_string,
-      bs.target_version_string
-    ))
+    return err(
+      string.format(
+        "Mercurial version is outdated! Some functionality might not work as expected, "
+          .. "or not at all! Current: %s, wanted: %s",
+        bs.version_string,
+        bs.target_version_string
+      )
+    )
   end
 
   bs.ok = true
@@ -99,7 +103,7 @@ end
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
-  local out, code = utils.job(utils.flatten({config.get_config().hg_cmd, {"root"}}), path)
+  local out, code = utils.job(utils.flatten({ config.get_config().hg_cmd, { "root" } }), path)
   if code ~= 0 then
     return nil
   end
@@ -154,7 +158,7 @@ function HgAdapter:get_show_args(path, rev)
 end
 
 function HgAdapter:get_log_args(args)
-  return utils.vec_join("log", "--stat", '--rev', args)
+  return utils.vec_join("log", "--stat", "--rev", args)
 end
 
 function HgAdapter:get_dir(path)
@@ -171,7 +175,7 @@ function HgAdapter:get_merge_context()
   local out, code = self:exec_sync({ "debugmergestate", "-Tjson" }, self.ctx.toplevel)
 
   if code ~= 0 then
-    return {ours = {}, theirs = {}, base = {}}
+    return { ours = {}, theirs = {}, base = {} }
   end
 
   local data = vim.json.decode(table.concat(out, ""))
@@ -181,13 +185,15 @@ function HgAdapter:get_merge_context()
   for _, commit in ipairs(data[1].commits) do
     if commit.name == "other" then
       ret.theirs = { hash = commit.node }
-      out, code = self:exec_sync({ "log", "--template={branch}", "--rev", commit.node }, self.ctx.toplevel)
+      out, code =
+        self:exec_sync({ "log", "--template={branch}", "--rev", commit.node }, self.ctx.toplevel)
       if code == 0 then
         ret.theirs.ref_names = out[1]
       end
     elseif commit.name == "local" then
       ret.ours = { hash = commit.node }
-      out, code = self:exec_sync({ "log", "--template={branch}", "--rev", commit.node }, self.ctx.toplevel)
+      out, code =
+        self:exec_sync({ "log", "--template={branch}", "--rev", commit.node }, self.ctx.toplevel)
       if code == 0 then
         ret.ours.ref_names = out[1]
       end
@@ -196,7 +202,7 @@ function HgAdapter:get_merge_context()
 
   for _, file in ipairs(data[1].files) do
     for _, extra in ipairs(file.extras) do
-      if (extra.key == 'ancestorlinknode' and extra.value ~= HgAdapter.Rev.NULL_TREE_SHA) then
+      if extra.key == "ancestorlinknode" and extra.value ~= HgAdapter.Rev.NULL_TREE_SHA then
         ret.base.hash = extra.value
         break
       end
@@ -217,7 +223,7 @@ function HgAdapter:file_history_options(range, paths, argo)
     return v == "." and "." or pl:relative(v, ".")
   end, paths) --[[@as string[] ]]
 
-  local range_arg = argo:get_flag('rev', { no_empty = true })
+  local range_arg = argo:get_flag("rev", { no_empty = true })
   -- if range_arg then
   --   -- TODO: check if range is valid
   -- end
@@ -363,7 +369,7 @@ end
 
 local function structure_fh_data(namestat_data, numstat_data)
   local right_hash, left_hash, merge_hash = unpack(utils.str_split(namestat_data[1]))
-  local time, time_offset = namestat_data[3]:match('(%d+.%d*)([-+]?%d*)')
+  local time, time_offset = namestat_data[3]:match("(%d+.%d*)([-+]?%d*)")
 
   return {
     left_hash = left_hash ~= "" and left_hash or nil,
@@ -379,7 +385,6 @@ local function structure_fh_data(namestat_data, numstat_data)
     numstat = numstat_data,
   }
 end
-
 
 ---@param state HgAdapter.FHState
 function HgAdapter:stream_fh_data(state)
@@ -412,15 +417,9 @@ function HgAdapter:stream_fh_data(state)
         local raw_entry = raw[handler_state.idx]
         raw_entry[handler_state.key] = handler_state.data
 
-        if not raw_entry.done
-            and raw_entry.namestat
-            and raw_entry.numstat
-        then
+        if not raw_entry.done and raw_entry.namestat and raw_entry.numstat then
           raw_entry.done = true
-          local log_data = structure_fh_data(
-            raw_entry.namestat,
-            raw_entry.numstat
-          )
+          local log_data = structure_fh_data(raw_entry.namestat, raw_entry.numstat)
           stream:push({ JobStatus.PROGRESS, log_data })
         end
       end
@@ -448,21 +447,25 @@ function HgAdapter:stream_fh_data(state)
       end
 
       local ok, err = mjob:is_success()
-      if mjob:is_done() and ok then on_stdout(nil, "\0") end
+      if mjob:is_done() and ok then
+        on_stdout(nil, "\0")
+      end
 
       if not ok then
         stream:push({
           JobStatus.ERROR,
           nil,
-          table.concat(utils.vec_join(err, mjob:stderr()), "\n")
+          table.concat(utils.vec_join(err, mjob:stderr()), "\n"),
         })
       else
         stream:push({ JobStatus.SUCCESS })
       end
-    end
+    end,
   })
 
-  local rev_range = state.prepared_log_opts.rev_range and '--rev=' .. state.prepared_log_opts.rev_range or nil
+  local rev_range = state.prepared_log_opts.rev_range
+      and "--rev=" .. state.prepared_log_opts.rev_range
+    or nil
   local log_opt = { label = "HgAdapter:incremental_fh_data()" }
 
   namestat_job = Job({
@@ -471,14 +474,14 @@ function HgAdapter:stream_fh_data(state)
       self:args(),
       "log",
       rev_range,
-      '--template=\\x00\n'
-      .. '{node} {p1.node} {ifeq(p2.rev, -1 ,\"\", \"{p2.node}\")}\n'
-      .. '{author|person}\n'
-      .. '{date}\n'
-      .. '{date|age}\n'
-      .. '  {separate(", ", tags, topics)}\n'
-      .. '  {desc|firstline}\n'
-      .. '{files % "{status} {file}\n"}',
+      "--template=\\x00\n"
+        .. '{node} {p1.node} {ifeq(p2.rev, -1 ,"", "{p2.node}")}\n'
+        .. "{author|person}\n"
+        .. "{date}\n"
+        .. "{date|age}\n"
+        .. '  {separate(", ", tags, topics)}\n'
+        .. "  {desc|firstline}\n"
+        .. '{files % "{status} {file}\n"}',
       state.prepared_log_opts.flags,
       "--",
       state.path_args
@@ -495,7 +498,7 @@ function HgAdapter:stream_fh_data(state)
       "log",
       rev_range,
       "--template=\\x00\n",
-      '--stat',
+      "--stat",
       state.prepared_log_opts.flags,
       "--",
       state.path_args
@@ -527,10 +530,8 @@ end
 ---@param out_stream AsyncListStream
 ---@param opt vcs.adapter.FileHistoryWorkerSpec
 HgAdapter.file_history_worker = async.void(function(self, out_stream, opt)
-  local single_file = self:is_single_file(
-    opt.log_opt.single_file.path_args,
-    opt.log_opt.single_file.L
-  )
+  local single_file =
+    self:is_single_file(opt.log_opt.single_file.path_args, opt.log_opt.single_file.L)
 
   ---@type HgLogOptions
   local log_options = config.get_log_options(
@@ -567,7 +568,9 @@ HgAdapter.file_history_worker = async.void(function(self, out_stream, opt)
 
   ---@param shutdown? SignalConsumer
   out_stream:on_close(function(shutdown)
-    if shutdown then in_stream:close(shutdown) end
+    if shutdown then
+      in_stream:close(shutdown)
+    end
   end)
 
   local last_wait = uv.hrtime()
@@ -580,7 +583,7 @@ HgAdapter.file_history_worker = async.void(function(self, out_stream, opt)
     -- Make sure to yield to the scheduler periodically to keep the editor
     -- responsive.
     local now = uv.hrtime()
-    if (now - last_wait > interval) then
+    if now - last_wait > interval then
       last_wait = now
       await(async.schedule_now())
     end
@@ -609,9 +612,9 @@ HgAdapter.file_history_worker = async.void(function(self, out_stream, opt)
     -- lists only an incomplete list of files at best. We need to use 'hg
     -- show' to get file statuses for merge commits. And merges do not always
     -- have changes.
-    if new_data.merge_hash
-      and new_data.numstat[1]
-      or (#new_data.numstat -1) ~= #new_data.namestat
+    if
+      new_data.merge_hash and new_data.numstat[1]
+      or (#new_data.numstat - 1) ~= #new_data.namestat
     then
       local job = Job({
         command = self:bin(),
@@ -648,7 +651,7 @@ HgAdapter.file_history_worker = async.void(function(self, out_stream, opt)
         out_stream:push({
           JobStatus.ERROR,
           nil,
-          fmt("Failed to get log data for merge commit '%s'!", new_data.right_hash)
+          fmt("Failed to get log data for merge commit '%s'!", new_data.right_hash),
         })
         return
       end
@@ -676,7 +679,9 @@ HgAdapter.file_history_worker = async.void(function(self, out_stream, opt)
 
     -- Some commits might not have file data. In that case we simply ignore it,
     -- as the fh panel doesn't support such entries at the moment.
-    if ok then out_stream:push({ JobStatus.PROGRESS, entry }) end
+    if ok then
+      out_stream:push({ JobStatus.PROGRESS, entry })
+    end
   end
 end)
 
@@ -690,11 +695,10 @@ function HgAdapter:parse_fh_data(data, commit, state)
 
   for i = 1, #data.numstat - 1 do
     local status = data.namestat[i]:sub(1, 1):gsub("%s", " ")
-    if status == 'R' then
+    if status == "R" then
       -- R is for Removed in mercurial
-      status = 'D'
+      status = "D"
     end
-
 
     -- TODO(zegervdv): Cannot get diffstats from mercurial reliably
     -- see https://github.com/sindrets/diffview.nvim/issues/366
@@ -703,42 +707,40 @@ function HgAdapter:parse_fh_data(data, commit, state)
     name = vim.trim(name)
 
     local oldname
-    if name:match('=>') ~= nil then
-      oldname, name = name:match('(.*) => (.*)')
+    if name:match("=>") ~= nil then
+      oldname, name = name:match("(.*) => (.*)")
       oldname = vim.trim(oldname)
       name = vim.trim(name)
       -- Mark as Renamed
-      status = 'R'
+      status = "R"
     end
 
     table.insert(
       files,
-      FileEntry.with_layout(
-        state.layout_opt.default_layout or Diff2Hor,
-        {
-          adapter = self,
-          path = name,
-          oldpath = oldname,
-          status = status,
-          stats = stats,
-          kind = "working",
-          commit = commit,
-          revs = {
-            a = data.left_hash and HgRev(RevType.COMMIT, data.left_hash) or HgRev.new_null_tree(),
-            b = state.prepared_log_opts.base or HgRev(RevType.COMMIT, data.right_hash),
-          }
-        }
-      )
+      FileEntry.with_layout(state.layout_opt.default_layout or Diff2Hor, {
+        adapter = self,
+        path = name,
+        oldpath = oldname,
+        status = status,
+        stats = stats,
+        kind = "working",
+        commit = commit,
+        revs = {
+          a = data.left_hash and HgRev(RevType.COMMIT, data.left_hash) or HgRev.new_null_tree(),
+          b = state.prepared_log_opts.base or HgRev(RevType.COMMIT, data.right_hash),
+        },
+      })
     )
   end
 
   if files[1] then
-    return true, LogEntry({
-      path_args = state.path_args,
-      commit = commit,
-      files = files,
-      single_file = state.single_file,
-    })
+    return true,
+      LogEntry({
+        path_args = state.path_args,
+        commit = commit,
+        files = files,
+        single_file = state.single_file,
+      })
   end
 
   if state.path_args[1] then
@@ -748,13 +750,14 @@ function HgAdapter:parse_fh_data(data, commit, state)
   end
 
   -- Commit is likely identical to it's parent. Return an empty log entry.
-  return true, LogEntry({
-    path_args = state.path_args,
-    commit = commit,
-    single_file = state.single_file,
-    nulled = true,
-    files = { FileEntry.new_null_entry(self) },
-  })
+  return true,
+    LogEntry({
+      path_args = state.path_args,
+      commit = commit,
+      single_file = state.single_file,
+      nulled = true,
+      files = { FileEntry.new_null_entry(self) },
+    })
 end
 
 ---@param argo ArgObject
@@ -774,12 +777,12 @@ function HgAdapter:diffview_options(argo)
       { "no", "false" }
     ),
     selected_file = argo:get_flag("selected-file", { no_empty = true, expand = true })
-        or (vim.bo.buftype == "" and pl:vim_expand("%:p"))
-        or nil,
+      or (vim.bo.buftype == "" and pl:vim_expand("%:p"))
+      or nil,
     selected_row = tonumber(argo:get_flag("selected-row", { no_empty = true })),
   }
 
-  return {left = left, right = right, options = options}
+  return { left = left, right = right, options = options }
 end
 
 function HgAdapter:rev_to_pretty_string(left, right)
@@ -812,10 +815,7 @@ end
 ---Get the current branch name.
 ---@return string? branch_name The branch name, or nil if not available.
 function HgAdapter:get_branch_name()
-  local out, code = self:exec_sync(
-    { "branch" },
-    { cwd = self.ctx.toplevel, silent = true }
-  )
+  local out, code = self:exec_sync({ "branch" }, { cwd = self.ctx.toplevel, silent = true })
 
   if code == 0 and out[1] then
     return vim.trim(out[1])
@@ -837,14 +837,13 @@ function HgAdapter:rev_to_args(left, right)
     "Can't diff LOCAL against LOCAL!"
   )
   if left.type == RevType.COMMIT and right.type == RevType.COMMIT then
-    return { '--rev=' .. left.commit .. '::' .. right.commit}
+    return { "--rev=" .. left.commit .. "::" .. right.commit }
   elseif left.type == RevType.STAGE and right.type == RevType.LOCAL then
     return {}
   else
-    return { '--rev=' .. left.commit }
+    return { "--rev=" .. left.commit }
   end
 end
-
 
 ---Determine whether a rev arg is a range.
 ---@param rev_arg string
@@ -876,7 +875,7 @@ function HgAdapter:parse_revs(rev_arg, opt)
   else
     local from, to = rev_arg:match("([^:]*)%:%:?(.*)$")
 
-    if from and from ~= ""  and to and to ~= "" then
+    if from and from ~= "" and to and to ~= "" then
       left = HgRev(RevType.COMMIT, from)
       right = HgRev(RevType.COMMIT, to)
     elseif from and from ~= "" then
@@ -886,23 +885,41 @@ function HgAdapter:parse_revs(rev_arg, opt)
       left = HgRev.new_null_tree()
       right = HgRev(RevType.COMMIT, to)
     else
-      local node, code, stderr = self:exec_sync({"log", "--limit=1", "--template={node}",  "--rev=" .. rev_arg}, self.ctx.toplevel)
+      local node, code, stderr = self:exec_sync(
+        { "log", "--limit=1", "--template={node}", "--rev=" .. rev_arg },
+        self.ctx.toplevel
+      )
       if not code or code ~= 0 then
-        utils.err(fmt("Failed to parse rev %s: %s", utils.str_quote(rev_arg), table.concat(stderr or {}, "\n")))
+        utils.err(
+          fmt(
+            "Failed to parse rev %s: %s",
+            utils.str_quote(rev_arg),
+            table.concat(stderr or {}, "\n")
+          )
+        )
         return
       end
       left = HgRev(RevType.COMMIT, node[1])
 
-      node, code, stderr = self:exec_sync({"log", "--limit=1", "--template={node}",  "--rev=reverse(" .. rev_arg .. ")"}, self.ctx.toplevel)
+      node, code, stderr = self:exec_sync(
+        { "log", "--limit=1", "--template={node}", "--rev=reverse(" .. rev_arg .. ")" },
+        self.ctx.toplevel
+      )
       if not code or code ~= 0 then
-        utils.err(fmt("Failed to parse rev %s: %s", utils.str_quote(rev_arg), table.concat(stderr or {}, "\n")))
+        utils.err(
+          fmt(
+            "Failed to parse rev %s: %s",
+            utils.str_quote(rev_arg),
+            table.concat(stderr or {}, "\n")
+          )
+        )
         return
       end
 
       right = HgRev(RevType.COMMIT, node[1])
       -- If we refer to a single revision, show diff with working directory
       if node[1] == left.commit then
-        right = HgRev(RevType.LOCAL )
+        right = HgRev(RevType.LOCAL)
       end
     end
   end
@@ -919,7 +936,7 @@ HgAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback)
   local _, code
   local abs_path = pl:join(self.ctx.toplevel, path)
 
-  _, code = self:exec_sync({"cat", "--", path}, self.ctx.toplevel)
+  _, code = self:exec_sync({ "cat", "--", path }, self.ctx.toplevel)
 
   local exists_hg = code == 0
   local undo
@@ -932,7 +949,7 @@ HgAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback)
       if not ok then
         utils.err({
           fmt("Failed to delete buffer '%d'! Aborting file restoration. Error message:", bn),
-          err
+          err,
         }, true)
         callback(false)
         return
@@ -945,17 +962,14 @@ HgAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback)
       if not ok then
         utils.err({
           fmt("Failed to delete file '%s'! Aborting file restoration. Error message:", abs_path),
-          err
+          err,
         }, true)
         callback(false)
         return
       end
     else
       -- File only exists in index
-      _, code = self:exec_sync(
-        { "rm", "-f", "--", path },
-        self.ctx.toplevel
-      )
+      _, code = self:exec_sync({ "rm", "-f", "--", path }, self.ctx.toplevel)
     end
   else
     -- File exists in history: revert
@@ -1000,10 +1014,18 @@ function HgAdapter:show_untracked(opt)
 end
 
 function HgAdapter:get_files_args(args)
-  return utils.vec_join(self:args(), "status", "--print0", "--unknown", "--no-status", "--template={path}\\n", args)
+  return utils.vec_join(
+    self:args(),
+    "status",
+    "--print0",
+    "--unknown",
+    "--no-status",
+    "--template={path}\\n",
+    args
+  )
 end
 
-HgAdapter.tracked_files = async.wrap(function (self, left, right, args, kind, opt, callback)
+HgAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, opt, callback)
   ---@type FileEntry[]
   local files = {}
   ---@type FileEntry[]
@@ -1067,15 +1089,15 @@ HgAdapter.tracked_files = async.wrap(function (self, left, right, args, kind, op
     end
   end
 
-  local mergestate = vim.json.decode(table.concat(mergestate_out, ''))
+  local mergestate = vim.json.decode(table.concat(mergestate_out, ""))
   for _, file in ipairs(mergestate[1].files) do
     local base = nil
     for _, extra in ipairs(file.extras) do
-      if extra.key == 'ancestorlinknode' then
+      if extra.key == "ancestorlinknode" then
         base = extra.value
       end
     end
-    if file.state == 'u' then
+    if file.state == "u" then
       -- Ensure file_info entry exists before accessing it
       if not file_info[file.path] then
         file_info[file.path] = {
@@ -1084,7 +1106,7 @@ HgAdapter.tracked_files = async.wrap(function (self, left, right, args, kind, op
           stats = {},
         }
       end
-      file_info[file.path].status = 'U'
+      file_info[file.path].status = "U"
       file_info[file.path].base = base
       if file.other_path ~= file.path then
         file_info[file.path].oldname = file.other_path
@@ -1106,35 +1128,41 @@ HgAdapter.tracked_files = async.wrap(function (self, left, right, args, kind, op
 
   if kind == "working" and next(conflict_map) then
     for _, v in pairs(conflict_map) do
-      table.insert(conflicts, FileEntry.with_layout(opt.merge_layout, {
-        adapter = self,
-        path = v.name,
-        oldpath = v.oldname,
-        status = "U",
-        kind = "conflicting",
-        revs = {
-          a = self.Rev(RevType.COMMIT, nodes['local']),
-          b = self.Rev(RevType.LOCAL),
-          c = self.Rev(RevType.COMMIT, nodes.other),
-          d = self.Rev(RevType.COMMIT, v.base),
-        }
-      }))
+      table.insert(
+        conflicts,
+        FileEntry.with_layout(opt.merge_layout, {
+          adapter = self,
+          path = v.name,
+          oldpath = v.oldname,
+          status = "U",
+          kind = "conflicting",
+          revs = {
+            a = self.Rev(RevType.COMMIT, nodes["local"]),
+            b = self.Rev(RevType.LOCAL),
+            c = self.Rev(RevType.COMMIT, nodes.other),
+            d = self.Rev(RevType.COMMIT, v.base),
+          },
+        })
+      )
     end
   end
 
   for _, v in ipairs(data) do
-    table.insert(files, FileEntry.with_layout(opt.default_layout, {
-      adapter = self,
-      path = v.name,
-      oldpath = v.oldname,
-      status = v.status,
-      stats = v.stats,
-      kind = kind,
-      revs = {
-        a = left,
-        b = right,
-      }
-    }))
+    table.insert(
+      files,
+      FileEntry.with_layout(opt.default_layout, {
+        adapter = self,
+        path = v.name,
+        oldpath = v.oldname,
+        status = v.status,
+        stats = v.stats,
+        kind = kind,
+        revs = {
+          a = left,
+          b = right,
+        },
+      })
+    )
   end
 
   callback(nil, files, conflicts)
@@ -1152,7 +1180,7 @@ HgAdapter.untracked_files = async.wrap(function(self, left, right, opt, callback
       "--template={path}\\n"
     ),
     cwd = self.ctx.toplevel,
-    log_opt = { label = "HgAdapter:untracked_files()" }
+    log_opt = { label = "HgAdapter:untracked_files()" },
   })
 
   await(job)
@@ -1174,7 +1202,7 @@ HgAdapter.untracked_files = async.wrap(function(self, left, right, opt, callback
         revs = {
           a = left,
           b = right,
-        }
+        },
       })
     )
   end
@@ -1188,7 +1216,7 @@ end)
 ---@param callback fun(stderr: string[]?, stdout: string[]?)
 HgAdapter.show = async.wrap(function(self, path, rev, callback)
   -- File did not exist, need to return an empty buffer
-  if not(rev) or (rev:object_name() == self.Rev.NULL_TREE_SHA) then
+  if not rev or (rev:object_name() == self.Rev.NULL_TREE_SHA) then
     callback(nil, {})
     return
   end
@@ -1204,8 +1232,8 @@ HgAdapter.show = async.wrap(function(self, path, rev, callback)
     on_exit = async.void(function(_, ok, err)
       if not ok or job.code ~= 0 then
         -- Non zero exit code might mean the file was removed
-        local out = job.stderr and job.stderr[1] or ''
-        if out:match('no such file in rev') then
+        local out = job.stderr and job.stderr[1] or ""
+        if out:match("no such file in rev") then
           callback(nil, {})
         else
           callback(utils.vec_join(err, job.stderr), nil)
@@ -1225,19 +1253,19 @@ end)
 HgAdapter.flags = {
   ---@type FlagOption[]
   switches = {
-    FlagOption('-f', '--follow', 'Follow renames'),
-    FlagOption('-M', '--no-merges', 'List no merge changesets'),
+    FlagOption("-f", "--follow", "Follow renames"),
+    FlagOption("-M", "--no-merges", "List no merge changesets"),
   },
   ---@type FlagOption[]
   options = {
-    FlagOption('=r', '--rev=', 'Revspec', {prompt_label = "(Revspec)"}),
-    FlagOption('=l', '--limit=', 'Limit the number of changesets'),
-    FlagOption('=u', '--user=', 'Filter on user'),
-    FlagOption('=k', '--keyword=', 'Filter by keyword'),
-    FlagOption('=b', '--branch=', 'Filter by branch'),
-    FlagOption('=B', '--bookmark=', 'Filter by bookmark'),
-    FlagOption('=I', '--include=', 'Include files'),
-    FlagOption('=E', '--exclude=', 'Exclude files'),
+    FlagOption("=r", "--rev=", "Revspec", { prompt_label = "(Revspec)" }),
+    FlagOption("=l", "--limit=", "Limit the number of changesets"),
+    FlagOption("=u", "--user=", "Filter on user"),
+    FlagOption("=k", "--keyword=", "Filter by keyword"),
+    FlagOption("=b", "--branch=", "Filter by branch"),
+    FlagOption("=B", "--bookmark=", "Filter by bookmark"),
+    FlagOption("=I", "--include=", "Include files"),
+    FlagOption("=E", "--exclude=", "Exclude files"),
   },
 }
 
@@ -1291,7 +1319,7 @@ function HgAdapter:rev_candidates(arg_lead, opt)
 end
 
 function HgAdapter:init_completion()
-  self.comp.file_history:put({"--rev", "-r"}, function(_, arg_lead)
+  self.comp.file_history:put({ "--rev", "-r" }, function(_, arg_lead)
     return self:rev_candidates(arg_lead, { accept_range = true })
   end)
 
@@ -1305,13 +1333,12 @@ function HgAdapter:init_completion()
   self.comp.file_history:put({ "--branch", "-b" }, {}) -- TODO: completion
   self.comp.file_history:put({ "--bookmark", "-B" }, {}) -- TODO: completion
 
-  self.comp.file_history:put({"--include", "-I"}, function (_, arg_lead)
+  self.comp.file_history:put({ "--include", "-I" }, function(_, arg_lead)
     return vim.fn.getcompletion(arg_lead, "dir")
   end)
-  self.comp.file_history:put({"--exclude", "-X"}, function (_, arg_lead)
+  self.comp.file_history:put({ "--exclude", "-X" }, function(_, arg_lead)
     return vim.fn.getcompletion(arg_lead, "dir")
   end)
-
 end
 
 M.HgAdapter = HgAdapter

--- a/lua/diffview/vcs/adapters/hg/rev.lua
+++ b/lua/diffview/vcs/adapters/hg/rev.lua
@@ -1,6 +1,6 @@
 local oop = require("diffview.oop")
-local Rev = require('diffview.vcs.rev').Rev
-local RevType = require('diffview.vcs.rev').RevType
+local Rev = require("diffview.vcs.rev").Rev
+local RevType = require("diffview.vcs.rev").RevType
 
 local M = {}
 

--- a/lua/diffview/vcs/adapters/jj/init.lua
+++ b/lua/diffview/vcs/adapters/jj/init.lua
@@ -34,7 +34,9 @@ function JjAdapter.run_bootstrap()
   local jj_cmd = config.get_config().jj_cmd
   local bs = JjAdapter.bootstrap
   local err = VCSAdapter.bootstrap_preamble(bs, jj_cmd, "JjAdapter", "jj_cmd")
-  if not err then return end
+  if not err then
+    return
+  end
 
   local out = utils.job(utils.flatten({ jj_cmd, "--version" }))
   bs.version_string = out[1] and out[1]:match("jj (%S+)") or nil
@@ -122,7 +124,15 @@ end
 ---@param rev Rev?
 ---@return string[]
 function JjAdapter:get_show_args(path, rev)
-  return utils.vec_join(self:args(), "file", "show", "-r", rev and rev:object_name() or "@", "--", path)
+  return utils.vec_join(
+    self:args(),
+    "file",
+    "show",
+    "-r",
+    rev and rev:object_name() or "@",
+    "--",
+    path
+  )
 end
 
 ---@param args string[]
@@ -194,22 +204,21 @@ end
 function JjAdapter:resolve_rev_arg(rev_arg)
   rev_arg = self:normalize_rev_arg(rev_arg)
 
-  local out, code, stderr = self:exec_sync(
-    { "show", "-T", "commit_id", rev_arg, "--no-patch" },
-    {
-      cwd = self.ctx.toplevel,
-      retry = 2,
-      fail_on_empty = true,
-      log_opt = { label = "JjAdapter:resolve_rev_arg()" },
-    }
-  )
+  local out, code, stderr = self:exec_sync({ "show", "-T", "commit_id", rev_arg, "--no-patch" }, {
+    cwd = self.ctx.toplevel,
+    retry = 2,
+    fail_on_empty = true,
+    log_opt = { label = "JjAdapter:resolve_rev_arg()" },
+  })
 
   if code ~= 0 or not out[1] then
-    utils.err(utils.vec_join(
-      fmt("Failed to parse rev %s!", utils.str_quote(rev_arg)),
-      "Jujutsu output: ",
-      stderr
-    ))
+    utils.err(
+      utils.vec_join(
+        fmt("Failed to parse rev %s!", utils.str_quote(rev_arg)),
+        "Jujutsu output: ",
+        stderr
+      )
+    )
     return
   end
 
@@ -246,18 +255,21 @@ function JjAdapter:symmetric_diff_revs(rev_arg)
   local out, code, stderr = self:exec_sync(
     { "log", "-r", revset, "-T", [[commit_id ++ "\n"]], "--no-graph" },
     {
-    cwd = self.ctx.toplevel,
-    retry = 2,
-    fail_on_empty = true,
-    log_opt = { label = "JjAdapter:symmetric_diff_revs()" },
-  })
+      cwd = self.ctx.toplevel,
+      retry = 2,
+      fail_on_empty = true,
+      log_opt = { label = "JjAdapter:symmetric_diff_revs()" },
+    }
+  )
 
   if code ~= 0 or not out[1] then
-    utils.err(utils.vec_join(
-      fmt("Failed to compute merge-base for rev range %s!", utils.str_quote(rev_arg)),
-      "Jujutsu output: ",
-      stderr
-    ))
+    utils.err(
+      utils.vec_join(
+        fmt("Failed to compute merge-base for rev range %s!", utils.str_quote(rev_arg)),
+        "Jujutsu output: ",
+        stderr
+      )
+    )
     return
   end
 
@@ -305,8 +317,12 @@ function JjAdapter:parse_revs(rev_arg, opt)
     local r1 = self:normalize_rev_arg(rev_arg:match("^(.-)%.%.") or "@")
     local r2 = self:normalize_rev_arg(rev_arg:match("%.%.(.-)$") or "@")
 
-    if r1 == "" then r1 = "@" end
-    if r2 == "" then r2 = "@" end
+    if r1 == "" then
+      r1 = "@"
+    end
+    if r2 == "" then
+      r2 = "@"
+    end
 
     local h1 = self:resolve_rev_arg(r1)
     local h2 = self:resolve_rev_arg(r2)
@@ -352,7 +368,8 @@ function JjAdapter:refresh_revs(rev_arg, left, right)
     return nil, nil
   end
 
-  if new_left.type == left.type
+  if
+    new_left.type == left.type
     and new_right.type == right.type
     and new_left:object_name() == left:object_name()
     and new_right:object_name() == right:object_name()
@@ -396,10 +413,8 @@ function JjAdapter:rev_to_args(left, right)
 
   if left.type == RevType.COMMIT and right.type == RevType.COMMIT then
     return { "--from", left.commit, "--to", right.commit }
-
   elseif right.type == RevType.LOCAL and left.type == RevType.COMMIT then
     return { "--from", left.commit }
-
   elseif left.type == RevType.LOCAL and right.type == RevType.COMMIT then
     return { "--to", right.commit }
   end
@@ -463,12 +478,7 @@ end
 JjAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, opt, callback)
   local job = Job({
     command = self:bin(),
-    args = utils.vec_join(
-      self:args(),
-      "diff",
-      "--summary",
-      args
-    ),
+    args = utils.vec_join(self:args(), "diff", "--summary", args),
     cwd = self.ctx.toplevel,
     retry = 2,
     log_opt = { label = "JjAdapter:tracked_files()" },

--- a/lua/diffview/vcs/adapters/null/init.lua
+++ b/lua/diffview/vcs/adapters/null/init.lua
@@ -19,7 +19,9 @@ NullAdapter.Rev = NullRev
 
 ---@param opt NullAdapter.create.Opt
 ---@return NullAdapter
-function NullAdapter.create(opt) return NullAdapter(opt) end
+function NullAdapter.create(opt)
+  return NullAdapter(opt)
+end
 
 ---@param opt NullAdapter.create.Opt
 function NullAdapter:init(opt)
@@ -46,22 +48,30 @@ end
 ---@param path string
 ---@param rev Rev
 ---@return boolean
-function NullAdapter:is_binary(path, rev) return false end
+function NullAdapter:is_binary(path, rev)
+  return false
+end
 
 function NullAdapter:init_completion() end
 
 ---@param arg_lead string
 ---@param opt? RevCompletionSpec
 ---@return string[]
-function NullAdapter:rev_candidates(arg_lead, opt) return {} end
+function NullAdapter:rev_candidates(arg_lead, opt)
+  return {}
+end
 
 ---@return Rev?
-function NullAdapter:head_rev() return nil end
+function NullAdapter:head_rev()
+  return nil
+end
 
 ---@param path string
 ---@param rev_arg string?
 ---@return string?
-function NullAdapter:file_blob_hash(path, rev_arg) return nil end
+function NullAdapter:file_blob_hash(path, rev_arg)
+  return nil
+end
 
 ---@return string[]
 function NullAdapter:get_command()
@@ -74,20 +84,28 @@ end
 ---@param path string
 ---@param rev Rev
 ---@return string[]
-function NullAdapter:get_show_args(path, rev) return {} end
+function NullAdapter:get_show_args(path, rev)
+  return {}
+end
 
 ---@param args table
 ---@return string[]
-function NullAdapter:get_log_args(args) return {} end
+function NullAdapter:get_log_args(args)
+  return {}
+end
 
 ---@return vcs.MergeContext?
-function NullAdapter:get_merge_context() return nil end
+function NullAdapter:get_merge_context()
+  return nil
+end
 
 ---@param range? { [1]: integer, [2]: integer }
 ---@param paths string[]
 ---@param argo ArgObject
 ---@return nil
-function NullAdapter:file_history_options(range, paths, argo) return nil end
+function NullAdapter:file_history_options(range, paths, argo)
+  return nil
+end
 
 ---@param out_stream any
 ---@param opt any
@@ -96,20 +114,28 @@ NullAdapter.file_history_worker = async.void(function(self, out_stream, opt) end
 ---@param left Rev
 ---@param right Rev
 ---@return string[]
-function NullAdapter:rev_to_args(left, right) return {} end
+function NullAdapter:rev_to_args(left, right)
+  return {}
+end
 
 ---@param left Rev
 ---@param right Rev
 ---@return string|nil
-function NullAdapter:rev_to_pretty_string(left, right) return nil end
+function NullAdapter:rev_to_pretty_string(left, right)
+  return nil
+end
 
 ---@param argo ArgObject
 ---@return nil
-function NullAdapter:diffview_options(argo) return nil end
+function NullAdapter:diffview_options(argo)
+  return nil
+end
 
 ---@param opt? VCSAdapter.show_untracked.Opt
 ---@return boolean
-function NullAdapter:show_untracked(opt) return false end
+function NullAdapter:show_untracked(opt)
+  return false
+end
 
 ---@param path string
 ---@param kind string
@@ -118,15 +144,21 @@ function NullAdapter:restore_file(path, kind, commit) end
 
 ---@param paths string[]
 ---@return boolean
-function NullAdapter:add_files(paths) return false end
+function NullAdapter:add_files(paths)
+  return false
+end
 
 ---@param paths string[]?
 ---@return boolean
-function NullAdapter:reset_files(paths) return false end
+function NullAdapter:reset_files(paths)
+  return false
+end
 
 ---@param file vcs.File
 ---@return boolean
-function NullAdapter:stage_index_file(file) return false end
+function NullAdapter:stage_index_file(file)
+  return false
+end
 
 ---@param left Rev
 ---@param right Rev
@@ -134,33 +166,37 @@ function NullAdapter:stage_index_file(file) return false end
 ---@param kind vcs.FileKind
 ---@param opt table
 ---@param callback fun(err?: string[], files?: FileEntry[], conflicts?: FileEntry[])
-NullAdapter.tracked_files = async.wrap(
-  function(self, left, right, args, kind, opt, callback) callback(nil, {}, {}) end,
-  7
-)
+NullAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, opt, callback)
+  callback(nil, {}, {})
+end, 7)
 
 ---@param left Rev
 ---@param right Rev
 ---@param opt table
 ---@param callback? fun(err?: string[], files?: FileEntry[])
-NullAdapter.untracked_files = async.wrap(
-  function(self, left, right, opt, callback) callback(nil, {}) end,
-  5
-)
+NullAdapter.untracked_files = async.wrap(function(self, left, right, opt, callback)
+  callback(nil, {})
+end, 5)
 
 ---@param path_args string[]
 ---@param cpath? string
 ---@return string[], string[]
-function NullAdapter.get_repo_paths(path_args, cpath) return {}, {} end
+function NullAdapter.get_repo_paths(path_args, cpath)
+  return {}, {}
+end
 
 ---@param top_indicators string[]
 ---@return string?, string
-function NullAdapter.find_toplevel(top_indicators) return nil, "" end
+function NullAdapter.find_toplevel(top_indicators)
+  return nil, ""
+end
 
 ---@param left Rev
 ---@param right Rev
 ---@return boolean
-function NullAdapter:force_entry_refresh_on_noop(left, right) return false end
+function NullAdapter:force_entry_refresh_on_noop(left, right)
+  return false
+end
 
 M.NullAdapter = NullAdapter
 return M

--- a/lua/diffview/vcs/adapters/null/rev.lua
+++ b/lua/diffview/vcs/adapters/null/rev.lua
@@ -11,33 +11,47 @@ local NullRev = oop.create_class("NullRev", Rev)
 ---@param rev_type RevType
 ---@param revision? string|number
 ---@param track_head? boolean
-function NullRev:init(rev_type, revision, track_head) self:super(rev_type, revision, track_head) end
+function NullRev:init(rev_type, revision, track_head)
+  self:super(rev_type, revision, track_head)
+end
 
 ---@param rev_from NullRev|string
 ---@param rev_to? NullRev|string
 ---@return string?
-function NullRev.to_range(rev_from, rev_to) return nil end
+function NullRev.to_range(rev_from, rev_to)
+  return nil
+end
 
 ---@param name string
 ---@param adapter? VCSAdapter
 ---@return Rev?
-function NullRev.from_name(name, adapter) return nil end
+function NullRev.from_name(name, adapter)
+  return nil
+end
 
 ---@param adapter VCSAdapter
 ---@return Rev?
-function NullRev.earliest_commit(adapter) return nil end
+function NullRev.earliest_commit(adapter)
+  return nil
+end
 
 ---@return Rev
-function NullRev.new_null_tree() return NullRev(RevType.LOCAL) end
+function NullRev.new_null_tree()
+  return NullRev(RevType.LOCAL)
+end
 
 ---@param adapter VCSAdapter
 ---@return boolean?
-function NullRev:is_head(adapter) return false end
+function NullRev:is_head(adapter)
+  return false
+end
 
 ---@param abbrev_len? integer
 ---@return string
 function NullRev:object_name(abbrev_len)
-  if self.type == RevType.LOCAL then return "LOCAL" end
+  if self.type == RevType.LOCAL then
+    return "LOCAL"
+  end
   return "NULL"
 end
 

--- a/lua/diffview/vcs/adapters/p4/commit.lua
+++ b/lua/diffview/vcs/adapters/p4/commit.lua
@@ -1,13 +1,13 @@
 local lazy = require("diffview.lazy")
-local oop = require('diffview.oop')
-local Commit = require('diffview.vcs.commit').Commit
-local RevType = require('diffview.vcs.rev').RevType
-local utils = require('diffview.utils')
+local oop = require("diffview.oop")
+local Commit = require("diffview.vcs.commit").Commit
+local RevType = require("diffview.vcs.rev").RevType
+local utils = require("diffview.utils")
 
 local M = {}
 
 ---@class P4Commit : Commit
-local P4Commit = oop.create_class('P4Commit', Commit)
+local P4Commit = oop.create_class("P4Commit", Commit)
 
 ---P4Commit constructor
 ---@param opt table
@@ -18,77 +18,81 @@ function P4Commit:init(opt)
   -- Timezone handling might require parsing the date string or relying on system locale.
   -- Let's use the raw timestamp and format it simply for now.
   if self.time then
-      self.iso_date = os.date("%Y-%m-%d %H:%M:%S", self.time) -- Simple local time formatting
-      self.rel_date = utils.relative_time(self.time) -- Use existing utility if possible
+    self.iso_date = os.date("%Y-%m-%d %H:%M:%S", self.time) -- Simple local time formatting
+    self.rel_date = utils.relative_time(self.time) -- Use existing utility if possible
   end
   self.hash = opt.changelist -- Store CL number as 'hash' for consistency
 end
 
 -- Helper to parse p4 describe output
 local function parse_describe_output(output_lines)
-    local data = { files = {} }
-    local reading_files = false
-    local reading_diff = false
-    local current_file_diff = {}
+  local data = { files = {} }
+  local reading_files = false
+  local reading_diff = false
+  local current_file_diff = {}
 
-    for i, line in ipairs(output_lines) do
-        if not reading_files and not reading_diff then
-            local cl, date_str, user_at_client, desc_start = line:match("^Change (%d+) on ([^%s]+) by ([^@]+@[^%s]+) (.*)")
-            if cl then
-                data.changelist = cl
-                -- Attempt to parse date - p4 dates can be yyyy/mm/dd:hh:mm:ss
-                -- Let's stick to the Unix timestamp provided later for accuracy
-                data.user = user_at_client:match("^(.*)@")
-                data.client = user_at_client:match("@(.*)$")
-                data.description = desc_start .. "\n"
-            elseif line:match("^Description:") then
-                 -- Ignore, handled above or description continues
-            elseif line:match("^Affected files ...") or line:match("^Differences ...") then
-                reading_files = true
-            else -- Continue capturing multi-line description
-                if data.description and line:match("^ ") then -- Indented lines are part of desc
-                   data.description = data.description .. line:sub(2) .. "\n"
-                end
-            end
-        elseif reading_files then
-            local path, rev, action = line:match("^... (%S+)#(%d+) (%S+)")
-            if path then
-                table.insert(data.files, { path = path, rev = rev, action = action })
-            elseif line:match("^Differences ...$") then
-                reading_files = false
-                reading_diff = true
-            elseif line ~= "" then
-                -- A non-empty, non-matching line ends the file section.
-                reading_files = false
-            end
-            -- Blank lines inside the file section are expected (p4 describe
-            -- inserts one between "Affected files ..." and the first entry)
-            -- and should be skipped rather than ending the section.
-        -- elseif reading_diff then
-            -- Diff parsing is handled separately if needed, `p4 describe -du` gives unified diff
+  for i, line in ipairs(output_lines) do
+    if not reading_files and not reading_diff then
+      local cl, date_str, user_at_client, desc_start =
+        line:match("^Change (%d+) on ([^%s]+) by ([^@]+@[^%s]+) (.*)")
+      if cl then
+        data.changelist = cl
+        -- Attempt to parse date - p4 dates can be yyyy/mm/dd:hh:mm:ss
+        -- Let's stick to the Unix timestamp provided later for accuracy
+        data.user = user_at_client:match("^(.*)@")
+        data.client = user_at_client:match("@(.*)$")
+        data.description = desc_start .. "\n"
+      elseif line:match("^Description:") then
+        -- Ignore, handled above or description continues
+      elseif line:match("^Affected files ...") or line:match("^Differences ...") then
+        reading_files = true
+      else -- Continue capturing multi-line description
+        if data.description and line:match("^ ") then -- Indented lines are part of desc
+          data.description = data.description .. line:sub(2) .. "\n"
         end
-        -- Look for the timestamp which is usually near the end
-        local time_unix = line:match("^%*edit @ (%d+)") or line:match("^%*add @ (%d+)") or line:match("^%*delete @ (%d+)") or line:match("^%*branch @ (%d+)") or line:match("^%*integrate @ (%d+)")
-         if time_unix then
-            data.time = tonumber(time_unix)
-         end
+      end
+    elseif reading_files then
+      local path, rev, action = line:match("^... (%S+)#(%d+) (%S+)")
+      if path then
+        table.insert(data.files, { path = path, rev = rev, action = action })
+      elseif line:match("^Differences ...$") then
+        reading_files = false
+        reading_diff = true
+      elseif line ~= "" then
+        -- A non-empty, non-matching line ends the file section.
+        reading_files = false
+      end
+      -- Blank lines inside the file section are expected (p4 describe
+      -- inserts one between "Affected files ..." and the first entry)
+      -- and should be skipped rather than ending the section.
+      -- elseif reading_diff then
+      -- Diff parsing is handled separately if needed, `p4 describe -du` gives unified diff
     end
-    -- Clean up description whitespace
-    if data.description then
-        data.description = vim.trim(data.description)
+    -- Look for the timestamp which is usually near the end
+    local time_unix = line:match("^%*edit @ (%d+)")
+      or line:match("^%*add @ (%d+)")
+      or line:match("^%*delete @ (%d+)")
+      or line:match("^%*branch @ (%d+)")
+      or line:match("^%*integrate @ (%d+)")
+    if time_unix then
+      data.time = tonumber(time_unix)
     end
+  end
+  -- Clean up description whitespace
+  if data.description then
+    data.description = vim.trim(data.description)
+  end
 
-    -- Simple relative date calculation based on timestamp
-    if data.time then
-       data.rel_date = utils.relative_time(data.time)
-    else
-       -- Fallback if timestamp wasn't found (unlikely for submitted CLs)
-       data.rel_date = "unknown"
-    end
+  -- Simple relative date calculation based on timestamp
+  if data.time then
+    data.rel_date = utils.relative_time(data.time)
+  else
+    -- Fallback if timestamp wasn't found (unlikely for submitted CLs)
+    data.rel_date = "unknown"
+  end
 
-    return data
+  return data
 end
-
 
 ---@param rev_arg string # Changelist number or specifier like @CL
 ---@param adapter P4Adapter
@@ -99,10 +103,15 @@ function P4Commit.from_rev_arg(rev_arg, adapter)
     -- Handle other revspecs? For now, only support CL numbers for commit details.
     -- Could potentially support labels or #head, but describe works best with CLs.
     -- Maybe run 'p4 changes -m1 rev_arg' first to resolve to a CL number.
-    local resolve_out, resolve_code = adapter:exec_sync({ "changes", "-m1", rev_arg }, adapter.ctx.toplevel)
-    if resolve_code ~= 0 or #resolve_out == 0 then return nil end
+    local resolve_out, resolve_code =
+      adapter:exec_sync({ "changes", "-m1", rev_arg }, adapter.ctx.toplevel)
+    if resolve_code ~= 0 or #resolve_out == 0 then
+      return nil
+    end
     cl_num = resolve_out[1]:match("^Change (%d+)")
-    if not cl_num then return nil end
+    if not cl_num then
+      return nil
+    end
   end
 
   -- Fetch changelist details using p4 describe
@@ -113,16 +122,18 @@ function P4Commit.from_rev_arg(rev_arg, adapter)
   end
 
   local data = parse_describe_output(out)
-  if not data.changelist then return nil end
+  if not data.changelist then
+    return nil
+  end
 
   return P4Commit({
     changelist = data.changelist, -- Store the actual CL number
-    hash = data.changelist,       -- Use CL number as 'hash' for internal consistency
+    hash = data.changelist, -- Use CL number as 'hash' for internal consistency
     author = data.user,
-    time = data.time,             -- Unix timestamp
+    time = data.time, -- Unix timestamp
     subject = data.description:match("^[^\n]*") or ("Changelist " .. data.changelist), -- First line of description
     body = data.description,
-    rel_date = data.rel_date,     -- Calculated relative date
+    rel_date = data.rel_date, -- Calculated relative date
     -- Perforce doesn't have direct ref names like git branches/tags in describe output
   })
 end

--- a/lua/diffview/vcs/adapters/p4/init.lua
+++ b/lua/diffview/vcs/adapters/p4/init.lua
@@ -46,16 +46,18 @@ function P4Adapter.run_bootstrap()
   local p4_cmd = config.get_config().p4_cmd
   local bs = P4Adapter.bootstrap
   local err = VCSAdapter.bootstrap_preamble(bs, p4_cmd, "P4Adapter", "p4_cmd")
-  if not err then return end
+  if not err then
+    return
+  end
 
   -- Check if we can connect to the server using p4 info.
   local _, code, stderr = utils.job(utils.flatten({ p4_cmd, "info" }))
   if code ~= 0 then
-      local err_msg = "Could not connect to Perforce server. Check P4PORT, P4USER, P4CLIENT settings."
-      if stderr and #stderr > 0 then
-          err_msg = err_msg .. "\nError: " .. table.concat(stderr, " ")
-      end
-      return err(err_msg)
+    local err_msg = "Could not connect to Perforce server. Check P4PORT, P4USER, P4CLIENT settings."
+    if stderr and #stderr > 0 then
+      err_msg = err_msg .. "\nError: " .. table.concat(stderr, " ")
+    end
+    return err(err_msg)
   end
 
   -- Basic version check (optional, p4 versions are usually compatible)
@@ -72,21 +74,24 @@ function P4Adapter.get_repo_paths(path_args, cpath)
   local top_indicators = {}
 
   -- Use `p4 info` to find the client root, which serves as the 'toplevel'
-  local info_out, info_code = utils.job(utils.flatten({config.get_config().p4_cmd, "info"}))
+  local info_out, info_code = utils.job(utils.flatten({ config.get_config().p4_cmd, "info" }))
   local client_root
   if info_code == 0 then
-      for _, line in ipairs(info_out) do
-          client_root = line:match("^Client root: (.*)")
-          if client_root then client_root = vim.trim(client_root) break end
+    for _, line in ipairs(info_out) do
+      client_root = line:match("^Client root: (.*)")
+      if client_root then
+        client_root = vim.trim(client_root)
+        break
       end
+    end
   end
 
   if not client_root then
-      logger:error("[P4Adapter] Could not determine Perforce client root via 'p4 info'.")
-      -- Cannot reliably determine indicators without client root.
-      -- Maybe fallback to cpath or cwd?
-      table.insert(top_indicators, cpath or vim.loop.cwd())
-      return path_args or {}, top_indicators -- Return original args and best guess
+    logger:error("[P4Adapter] Could not determine Perforce client root via 'p4 info'.")
+    -- Cannot reliably determine indicators without client root.
+    -- Maybe fallback to cpath or cwd?
+    table.insert(top_indicators, cpath or vim.loop.cwd())
+    return path_args or {}, top_indicators -- Return original args and best guess
   end
 
   table.insert(top_indicators, client_root) -- The client root is the main indicator
@@ -94,23 +99,25 @@ function P4Adapter.get_repo_paths(path_args, cpath)
   -- Try to resolve paths relative to client root if they aren't depot paths
   for _, path_arg in ipairs(path_args or {}) do
     local expanded_paths = pl:vim_expand(path_arg, false, true) or { path_arg } -- Expand wildcards etc.
-    for _, path in ipairs(expanded_paths --[[@as string[] ]]) do
-        if path:match("^//") then -- Already a depot path
-            table.insert(paths, path)
+    for _, path in
+      ipairs(expanded_paths --[[@as string[] ]])
+    do
+      if path:match("^//") then -- Already a depot path
+        table.insert(paths, path)
+      else
+        local abs_path = pl:absolute(path, cpath)
+        -- Check if the path is within the client root
+        if abs_path:find(client_root, 1, true) == 1 then
+          -- Attempt to map local path to depot path (might be complex due to view mapping)
+          -- For simplicity, let's pass the local path relative to client root for now
+          -- or maybe just the absolute path, and let p4 commands handle it.
+          -- Using absolute local paths might be safer for commands like `p4 diff`.
+          table.insert(paths, abs_path)
         else
-            local abs_path = pl:absolute(path, cpath)
-            -- Check if the path is within the client root
-            if abs_path:find(client_root, 1, true) == 1 then
-                -- Attempt to map local path to depot path (might be complex due to view mapping)
-                -- For simplicity, let's pass the local path relative to client root for now
-                -- or maybe just the absolute path, and let p4 commands handle it.
-                -- Using absolute local paths might be safer for commands like `p4 diff`.
-                table.insert(paths, abs_path)
-            else
-                 -- Path is outside client root, pass it as is, p4 might handle it or error
-                 table.insert(paths, path)
-            end
+          -- Path is outside client root, pass it as is, p4 might handle it or error
+          table.insert(paths, path)
         end
+      end
     end
   end
 
@@ -118,42 +125,45 @@ function P4Adapter.get_repo_paths(path_args, cpath)
 end
 
 function P4Adapter.find_toplevel(top_indicators)
-    -- In Perforce, the "toplevel" is the client root.
-    -- We try to get it from `p4 info` executed potentially within one of the indicator paths.
-    local client_root
+  -- In Perforce, the "toplevel" is the client root.
+  -- We try to get it from `p4 info` executed potentially within one of the indicator paths.
+  local client_root
 
-    for _, p in ipairs(top_indicators) do
-        local target_dir = p
-        if not pl:is_dir(p) then
-            target_dir = pl:parent(p)
-        end
+  for _, p in ipairs(top_indicators) do
+    local target_dir = p
+    if not pl:is_dir(p) then
+      target_dir = pl:parent(p)
+    end
 
-        if target_dir and pl:readable(target_dir) then
-            local info_out, info_code = utils.job(utils.flatten({config.get_config().p4_cmd, "info"}), target_dir)
-            if info_code == 0 then
-                 for _, line in ipairs(info_out) do
-                    local root = line:match("^Client root: (.*)")
-                    if root then
-                       client_root = vim.trim(root)
-                       -- Make sure it's a valid directory before returning
-                       if pl:is_dir(client_root) then
-                           return nil, client_root -- Found valid client root
-                       else
-                           client_root = nil -- Found path, but not a directory
-                       end
-                    end
-                 end
+    if target_dir and pl:readable(target_dir) then
+      local info_out, info_code =
+        utils.job(utils.flatten({ config.get_config().p4_cmd, "info" }), target_dir)
+      if info_code == 0 then
+        for _, line in ipairs(info_out) do
+          local root = line:match("^Client root: (.*)")
+          if root then
+            client_root = vim.trim(root)
+            -- Make sure it's a valid directory before returning
+            if pl:is_dir(client_root) then
+              return nil, client_root -- Found valid client root
+            else
+              client_root = nil -- Found path, but not a directory
             end
+          end
         end
-        -- If we found a client root (even if not a dir yet), stop searching
-        if client_root ~= nil then break end
+      end
     end
-
-    if client_root then
-        return nil, client_root -- Return whatever we found, validation happens later
+    -- If we found a client root (even if not a dir yet), stop searching
+    if client_root ~= nil then
+      break
     end
+  end
 
-    return "Could not determine Perforce client root from provided paths.", ""
+  if client_root then
+    return nil, client_root -- Return whatever we found, validation happens later
+  end
+
+  return "Could not determine Perforce client root from provided paths.", ""
 end
 
 ---@param toplevel string -- This will be the Client Root path
@@ -188,7 +198,7 @@ function P4Adapter:init(opt)
 
   self.ctx = {
     toplevel = opt.toplevel, -- Client root
-    dir = opt.toplevel,      -- Use client root as dir
+    dir = opt.toplevel, -- Use client root as dir
     path_args = opt.path_args or {}, -- Use resolved paths
   }
 
@@ -232,7 +242,7 @@ function P4Adapter:verify_rev_arg(rev_arg)
   -- Use `p4 changes -m1` to check if a revision specifier resolves to at least one CL.
   -- Handle special cases like #head, #none, @
   if rev_arg == "#head" or rev_arg == "#none" or rev_arg == "@" then
-      return true, { rev_arg } -- Assume these are valid
+    return true, { rev_arg } -- Assume these are valid
   end
 
   local out, code = self:exec_sync({ "changes", "-m1", rev_arg }, {
@@ -248,15 +258,17 @@ end
 ---Let's return nil for now, as merge tool support requires significant work.
 ---@return vcs.MergeContext?
 function P4Adapter:get_merge_context()
-    -- Basic check if resolves are pending
-    local out, code = self:exec_sync({"resolve", "-n", "//..."}, self.ctx.toplevel)
-    if code == 0 and #out > 0 then
-        -- Files need resolving, but getting base/theirs/ours info reliably is hard.
-        logger:warn("[P4Adapter] Merge/resolve context detection is limited. Files may require resolve.")
-        -- Return a placeholder structure or nil? Returning nil disables merge features.
-        return nil
-    end
+  -- Basic check if resolves are pending
+  local out, code = self:exec_sync({ "resolve", "-n", "//..." }, self.ctx.toplevel)
+  if code == 0 and #out > 0 then
+    -- Files need resolving, but getting base/theirs/ours info reliably is hard.
+    logger:warn(
+      "[P4Adapter] Merge/resolve context detection is limited. Files may require resolve."
+    )
+    -- Return a placeholder structure or nil? Returning nil disables merge features.
     return nil
+  end
+  return nil
 end
 
 -- File History Implementation
@@ -275,14 +287,16 @@ function P4Adapter:prepare_fh_options(log_options, single_file)
 
   -- Perforce range syntax is typically path@rev1,rev2 or just path for all history
   if o.rev then
-      rev_range = o.rev -- Assuming o.rev contains the P4 range spec like @CL1,@CL2
+    rev_range = o.rev -- Assuming o.rev contains the P4 range spec like @CL1,@CL2
   end
 
   -- Note: Perforce flags differ significantly from Git/Hg. Adapt as needed.
   -- `-l` for long output (includes description) in `p4 changes`
   -- `-t` for timestamps in `p4 filelog`
   local flags = {}
-  if o.limit then table.insert(flags, "-m" .. o.limit) end
+  if o.limit then
+    table.insert(flags, "-m" .. o.limit)
+  end
   -- Add other relevant flags based on HgLogOptions mapping if desired
   -- if o.user then table.insert(flags, "-u" .. o.user) end -- `p4 changes -u user`
 
@@ -305,19 +319,29 @@ function P4Adapter:file_history_dry_run(log_opt)
     fmt("Client Root: '%s'", pl:vim_fnamemodify(self.ctx.toplevel, ":~")),
   }
   if prepared_opts.rev_range then
-      table.insert(description_parts, fmt("Revision Range: '%s'", prepared_opts.rev_range))
+    table.insert(description_parts, fmt("Revision Range: '%s'", prepared_opts.rev_range))
   end
   if #prepared_opts.flags > 0 then
-      table.insert(description_parts, fmt("Flags: %s", table.concat(prepared_opts.flags, " ")))
+    table.insert(description_parts, fmt("Flags: %s", table.concat(prepared_opts.flags, " ")))
   end
   local description = table.concat(description_parts, ", ")
 
   -- Command to check: Use 'p4 changes' or 'p4 filelog' with -m1 limit
   local cmd
   if single_file then
-      cmd = utils.vec_join("filelog", "-m1", prepared_opts.flags, prepared_opts.path_args[1] .. (prepared_opts.rev_range or ""))
+    cmd = utils.vec_join(
+      "filelog",
+      "-m1",
+      prepared_opts.flags,
+      prepared_opts.path_args[1] .. (prepared_opts.rev_range or "")
+    )
   else
-      cmd = utils.vec_join("changes", "-m1", prepared_opts.flags, (prepared_opts.path_args[1] or "//...") .. (prepared_opts.rev_range or ""))
+    cmd = utils.vec_join(
+      "changes",
+      "-m1",
+      prepared_opts.flags,
+      (prepared_opts.path_args[1] or "//...") .. (prepared_opts.rev_range or "")
+    )
   end
 
   local out, code = self:exec_sync(cmd, {
@@ -327,7 +351,7 @@ function P4Adapter:file_history_dry_run(log_opt)
 
   local ok = code == 0 and #out > 0
   if not ok then
-      logger:fmt_debug("[P4Adapter] Dry run failed for file history.")
+    logger:fmt_debug("[P4Adapter] Dry run failed for file history.")
   end
   return ok, description
 end
@@ -343,9 +367,9 @@ function P4Adapter:file_history_options(range, paths, argo)
 
   -- Use mapped options similar to Hg, adjust keys/flags as needed
   local log_flag_names = {
-    { "rev" },         -- Map to P4 revision range/specifier
-    { "limit", "m" },  -- Map to -m max
-    { "user", "u" },   -- Map to -u user
+    { "rev" }, -- Map to P4 revision range/specifier
+    { "limit", "m" }, -- Map to -m max
+    { "user", "u" }, -- Map to -u user
     -- Add more mappings if needed (e.g., -l for long desc in changes)
     -- { "long", "l" },
   }
@@ -354,7 +378,7 @@ function P4Adapter:file_history_options(range, paths, argo)
   for _, names in ipairs(log_flag_names) do
     local key = names[1]
     local v = argo:get_flag(names, {
-        expect_string = key ~= 'long', -- Adjust based on flag type
+      expect_string = key ~= "long", -- Adjust based on flag type
     })
     -- Use the Perforce flag name as the key if different (e.g., limit vs m)
     log_options[key] = v
@@ -366,16 +390,18 @@ function P4Adapter:file_history_options(range, paths, argo)
   local ok, opt_description = self:file_history_dry_run(log_options)
   if not ok then
     local target_desc = #paths > 0 and table.concat(paths, ", ") or "client view"
-    utils.info(fmt(
+    utils.info(
+      fmt(
         "No Perforce history found for target(s) with current options.\nTargets: %s\nOptions: [ %s ]",
-        target_desc, opt_description
-    ))
+        target_desc,
+        opt_description
+      )
+    )
     return nil -- Indicate failure
   end
 
   return log_options -- Return the parsed options
 end
-
 
 ---@class P4Adapter.FHState
 ---@field path_args string[]
@@ -389,172 +415,187 @@ end
 ---@param out_stream AsyncListStream
 ---@param opt vcs.adapter.FileHistoryWorkerSpec -- Contains log_opt etc.
 P4Adapter.file_history_worker = async.void(function(self, out_stream, opt)
-    local single_file_opt = opt.log_opt and opt.log_opt.single_file
-    local single_file = single_file_opt and #single_file_opt.path_args == 1 or false
+  local single_file_opt = opt.log_opt and opt.log_opt.single_file
+  local single_file = single_file_opt and #single_file_opt.path_args == 1 or false
 
-    ---@type table
-    local log_options = config.get_log_options(
-        single_file,
-        single_file and single_file_opt or opt.log_opt.multi_file,
-        "p4"
-    )
+  ---@type table
+  local log_options = config.get_log_options(
+    single_file,
+    single_file and single_file_opt or opt.log_opt.multi_file,
+    "p4"
+  )
 
-    ---@type P4Adapter.FHState
-    local state = {
-        path_args = log_options.path_args or {}, -- Ensure path_args exists
-        log_options = log_options,
-        prepared_log_opts = self:prepare_fh_options(log_options, single_file),
-        layout_opt = opt.layout_opt,
-        single_file = single_file,
-    }
+  ---@type P4Adapter.FHState
+  local state = {
+    path_args = log_options.path_args or {}, -- Ensure path_args exists
+    log_options = log_options,
+    prepared_log_opts = self:prepare_fh_options(log_options, single_file),
+    layout_opt = opt.layout_opt,
+    single_file = single_file,
+  }
 
-    logger:info("[P4 FileHistory] Updating with options:", vim.inspect(state.prepared_log_opts))
+  logger:info("[P4 FileHistory] Updating with options:", vim.inspect(state.prepared_log_opts))
 
-    local path_spec = #state.path_args > 0 and state.path_args[1] or "//..." -- Default to full depot if no path
-    local rev_spec = state.prepared_log_opts.rev_range or "" -- e.g., @CL1,@CL2
+  local path_spec = #state.path_args > 0 and state.path_args[1] or "//..." -- Default to full depot if no path
+  local rev_spec = state.prepared_log_opts.rev_range or "" -- e.g., @CL1,@CL2
 
-    -- Command to get relevant changelists
-    local changes_cmd = utils.vec_join(
-        "changes", "-l", -- Use -l for description
-        state.prepared_log_opts.flags, -- Contains -m limit, -u user etc.
-        path_spec .. rev_spec
-    )
+  -- Command to get relevant changelists
+  local changes_cmd = utils.vec_join(
+    "changes",
+    "-l", -- Use -l for description
+    state.prepared_log_opts.flags, -- Contains -m limit, -u user etc.
+    path_spec .. rev_spec
+  )
 
-    local changes_job = Job({
-        command = self:bin(),
-        args = changes_cmd,
-        cwd = self.ctx.toplevel,
-        log_opt = { label = "P4Adapter:file_history_worker(changes)" },
+  local changes_job = Job({
+    command = self:bin(),
+    args = changes_cmd,
+    cwd = self.ctx.toplevel,
+    log_opt = { label = "P4Adapter:file_history_worker(changes)" },
+  })
+
+  local ok, err = await(changes_job)
+  if not ok or changes_job.code ~= 0 then
+    local err_msg = "Failed to fetch Perforce changes."
+    if err then
+      table.insert(err, err_msg)
+    end
+    out_stream:push({
+      JobStatus.ERROR,
+      nil,
+      table.concat(utils.vec_join(err, changes_job.stderr), "\n"),
+    })
+    out_stream:close()
+    return
+  end
+
+  -- Process changes output line by line or parse structured output if available
+  local changelists = {}
+  for _, line in ipairs(changes_job.stdout) do
+    local cl = line:match("^Change (%d+)")
+    if cl then
+      table.insert(changelists, cl)
+    end
+  end
+
+  if #changelists == 0 then
+    out_stream:push({ JobStatus.SUCCESS }) -- No history found
+    out_stream:close()
+    return
+  end
+
+  -- Fetch details for each changelist using p4 describe
+  local interval = (1000 / 10) * 1E6 -- Limit rate slightly
+  local last_wait = uv.hrtime()
+
+  for _, cl in ipairs(changelists) do
+    -- Yield periodically
+    local now = uv.hrtime()
+    if now - last_wait > interval then
+      last_wait = now
+      await(async.schedule_now())
+    end
+
+    if out_stream:is_closed() then
+      return
+    end -- Check if consumer closed
+
+    local describe_job = Job({
+      command = self:bin(),
+      args = { "describe", cl },
+      cwd = self.ctx.toplevel,
+      log_opt = { label = fmt("P4Adapter:file_history_worker(describe %s)", cl) },
     })
 
-    local ok, err = await(changes_job)
-    if not ok or changes_job.code ~= 0 then
-        local err_msg = "Failed to fetch Perforce changes."
-        if err then table.insert(err, err_msg) end
-        out_stream:push({ JobStatus.ERROR, nil, table.concat(utils.vec_join(err, changes_job.stderr), "\n") })
-        out_stream:close()
-        return
+    ok, err = await(describe_job)
+    if not ok or describe_job.code ~= 0 then
+      logger:fmt_error(
+        "Failed to describe changelist %s: %s",
+        cl,
+        table.concat(utils.vec_join(err, describe_job.stderr), "\n")
+      )
+      -- Decide whether to error out or just skip this CL
+      goto continue -- Skip this problematic CL
     end
 
-    -- Process changes output line by line or parse structured output if available
-    local changelists = {}
-    for _, line in ipairs(changes_job.stdout) do
-        local cl = line:match("^Change (%d+)")
-        if cl then table.insert(changelists, cl) end
+    -- Parse describe output to create Commit and FileEntry objects
+    local commit_data = Commit.from_rev_arg("@" .. cl, self) -- Use commit class parser
+    if not commit_data then
+      logger:fmt_warn("Could not parse commit data for CL %s", cl)
+      goto continue -- Skip if parsing failed
     end
 
-    if #changelists == 0 then
-        out_stream:push({ JobStatus.SUCCESS }) -- No history found
-        out_stream:close()
-        return
+    local parsed_describe = parse_describe_output(describe_job.stdout) -- Re-use helper if needed
+    local files_in_cl = parsed_describe.files or {}
+
+    local file_entries = {}
+    for _, file_info in ipairs(files_in_cl) do
+      -- Check if this file matches the requested path_args if any
+      local path_matches = true
+      if #state.path_args > 0 then
+        -- Basic check: does the file path start with one of the arg paths?
+        -- Needs improvement for complex view mappings / wildcards.
+        path_matches = false
+        for _, arg_path in ipairs(state.path_args) do
+          -- Strip the Perforce recursive wildcard ("...") so we can
+          -- do a plain prefix match against the depot path.  E.g.
+          -- "//depot/main/..." becomes "//depot/main/" and will
+          -- match "//depot/main/foo.c".  This is intentionally
+          -- simplistic and won't handle all view-mapping edge cases.
+          if file_info.path:find(arg_path:gsub("%.%.%.", ""), 1, true) then
+            path_matches = true
+            break
+          end
+        end
+      end
+
+      if path_matches then
+        -- Determine previous revision for diffing (usually CL-1, but complex for integrations)
+        -- `p4 filelog -m1 file@CL` gives previous action.
+        -- For simplicity, let's assume diff against CL-1.
+        local prev_cl_num = tonumber(cl) - 1
+        local prev_rev_spec = "@" .. tostring(prev_cl_num)
+
+        -- Convert P4 action to Git status symbol (approximate mapping)
+        local status_map = { add = "A", edit = "M", delete = "D", branch = "A", integrate = "M" }
+        local status = status_map[file_info.action] or "M"
+
+        table.insert(
+          file_entries,
+          FileEntry.with_layout(state.layout_opt.default_layout or Diff2Hor, {
+            adapter = self,
+            path = file_info.path, -- Use depot path
+            status = status,
+            stats = nil, -- `p4 describe` doesn't give diff stats easily
+            kind = "working", -- Treat as 'working' kind for simplicity
+            commit = commit_data,
+            revs = {
+              a = P4Rev(RevType.COMMIT, prev_rev_spec), -- Previous revision
+              b = P4Rev(RevType.COMMIT, "@" .. cl), -- This revision
+            },
+          })
+        )
+      end
     end
 
-    -- Fetch details for each changelist using p4 describe
-    local interval = (1000 / 10) * 1E6 -- Limit rate slightly
-    local last_wait = uv.hrtime()
-
-    for _, cl in ipairs(changelists) do
-         -- Yield periodically
-        local now = uv.hrtime()
-        if (now - last_wait > interval) then
-            last_wait = now
-            await(async.schedule_now())
-        end
-
-        if out_stream:is_closed() then return end -- Check if consumer closed
-
-        local describe_job = Job({
-            command = self:bin(),
-            args = { "describe", cl },
-            cwd = self.ctx.toplevel,
-            log_opt = { label = fmt("P4Adapter:file_history_worker(describe %s)", cl) },
-        })
-
-        ok, err = await(describe_job)
-        if not ok or describe_job.code ~= 0 then
-             logger:fmt_error("Failed to describe changelist %s: %s", cl, table.concat(utils.vec_join(err, describe_job.stderr), "\n"))
-             -- Decide whether to error out or just skip this CL
-             goto continue -- Skip this problematic CL
-        end
-
-        -- Parse describe output to create Commit and FileEntry objects
-        local commit_data = Commit.from_rev_arg("@"..cl, self) -- Use commit class parser
-        if not commit_data then
-             logger:fmt_warn("Could not parse commit data for CL %s", cl)
-             goto continue -- Skip if parsing failed
-        end
-
-        local parsed_describe = parse_describe_output(describe_job.stdout) -- Re-use helper if needed
-        local files_in_cl = parsed_describe.files or {}
-
-        local file_entries = {}
-        for _, file_info in ipairs(files_in_cl) do
-            -- Check if this file matches the requested path_args if any
-            local path_matches = true
-            if #state.path_args > 0 then
-                 -- Basic check: does the file path start with one of the arg paths?
-                 -- Needs improvement for complex view mappings / wildcards.
-                 path_matches = false
-                 for _, arg_path in ipairs(state.path_args) do
-                     -- Strip the Perforce recursive wildcard ("...") so we can
-                     -- do a plain prefix match against the depot path.  E.g.
-                     -- "//depot/main/..." becomes "//depot/main/" and will
-                     -- match "//depot/main/foo.c".  This is intentionally
-                     -- simplistic and won't handle all view-mapping edge cases.
-                     if file_info.path:find(arg_path:gsub("%.%.%.", ""), 1, true) then
-                         path_matches = true
-                         break
-                     end
-                 end
-            end
-
-            if path_matches then
-                -- Determine previous revision for diffing (usually CL-1, but complex for integrations)
-                -- `p4 filelog -m1 file@CL` gives previous action.
-                -- For simplicity, let's assume diff against CL-1.
-                local prev_cl_num = tonumber(cl) - 1
-                local prev_rev_spec = "@" .. tostring(prev_cl_num)
-
-                -- Convert P4 action to Git status symbol (approximate mapping)
-                local status_map = { add = "A", edit = "M", delete = "D", branch = "A", integrate = "M" }
-                local status = status_map[file_info.action] or "M"
-
-                table.insert(file_entries, FileEntry.with_layout(
-                    state.layout_opt.default_layout or Diff2Hor,
-                    {
-                        adapter = self,
-                        path = file_info.path, -- Use depot path
-                        status = status,
-                        stats = nil, -- `p4 describe` doesn't give diff stats easily
-                        kind = "working", -- Treat as 'working' kind for simplicity
-                        commit = commit_data,
-                        revs = {
-                            a = P4Rev(RevType.COMMIT, prev_rev_spec), -- Previous revision
-                            b = P4Rev(RevType.COMMIT, "@"..cl),      -- This revision
-                        },
-                    }
-                ))
-            end
-        end
-
-        if #file_entries > 0 then
-             local entry = LogEntry({
-                path_args = state.path_args,
-                commit = commit_data,
-                files = file_entries,
-                single_file = state.single_file,
-            })
-            out_stream:push({ JobStatus.PROGRESS, entry })
-        else
-            -- Log entry might be empty if the CL didn't affect the filtered path
-            -- logger:fmt_debug("Changelist %s did not affect requested paths.", cl)
-        end
-
-        ::continue::
+    if #file_entries > 0 then
+      local entry = LogEntry({
+        path_args = state.path_args,
+        commit = commit_data,
+        files = file_entries,
+        single_file = state.single_file,
+      })
+      out_stream:push({ JobStatus.PROGRESS, entry })
+    else
+      -- Log entry might be empty if the CL didn't affect the filtered path
+      -- logger:fmt_debug("Changelist %s did not affect requested paths.", cl)
     end
 
-    out_stream:push({ JobStatus.SUCCESS })
-    out_stream:close()
+    ::continue::
+  end
+
+  out_stream:push({ JobStatus.SUCCESS })
+  out_stream:close()
 end)
 
 -- Diff View Implementation
@@ -570,17 +611,17 @@ function P4Adapter:diffview_options(argo)
     left = P4Rev(RevType.COMMIT, "#head")
     right = P4Rev(RevType.LOCAL) -- Represents workspace
   elseif rev_arg:match("^(@?%d+)%.%.(@?%d+)$") or rev_arg:match("^(@?%d+),(@?%d+)$") then
-      -- Range specified CL1..CL2 or @CL1,@CL2
-      local r1, r2 = rev_arg:match("^(@?%d+)[%.%.,](@?%d+)$")
-      local ok1, _ = self:verify_rev_arg(r1)
-      local ok2, _ = self:verify_rev_arg(r2)
-      if ok1 and ok2 then
-          left = P4Rev(RevType.COMMIT, r1)
-          right = P4Rev(RevType.COMMIT, r2)
-      else
-          utils.err("Invalid revision range specified: " .. rev_arg)
-          return nil
-      end
+    -- Range specified CL1..CL2 or @CL1,@CL2
+    local r1, r2 = rev_arg:match("^(@?%d+)[%.%.,](@?%d+)$")
+    local ok1, _ = self:verify_rev_arg(r1)
+    local ok2, _ = self:verify_rev_arg(r2)
+    if ok1 and ok2 then
+      left = P4Rev(RevType.COMMIT, r1)
+      right = P4Rev(RevType.COMMIT, r2)
+    else
+      utils.err("Invalid revision range specified: " .. rev_arg)
+      return nil
+    end
   else
     -- Single revision specified, e.g., @CL, CL, #head
     -- Compare this revision against the workspace? Or show diff *within* the CL?
@@ -588,22 +629,22 @@ function P4Adapter:diffview_options(argo)
     -- This requires comparing CL vs CL-1.
     local ok, resolved = self:verify_rev_arg(rev_arg)
     if not ok then
-        utils.err("Invalid revision specified: " .. rev_arg)
-        return nil
+      utils.err("Invalid revision specified: " .. rev_arg)
+      return nil
     end
     local current_rev_spec = resolved[1] -- Use resolved spec if possible
     local cl_num = current_rev_spec:match("@(%d+)")
     if cl_num then
-        local prev_cl_num = tonumber(cl_num) - 1
-        left = P4Rev(RevType.COMMIT, "@" .. prev_cl_num) -- CL-1
-        right = P4Rev(RevType.COMMIT, current_rev_spec) -- CL
+      local prev_cl_num = tonumber(cl_num) - 1
+      left = P4Rev(RevType.COMMIT, "@" .. prev_cl_num) -- CL-1
+      right = P4Rev(RevType.COMMIT, current_rev_spec) -- CL
     else
-        -- Cannot easily determine previous rev for non-CL specs like #head or labels
-        -- Fallback to comparing spec against workspace?
-        -- Or maybe error out? Let's compare against workspace for now.
-        left = P4Rev(RevType.COMMIT, current_rev_spec)
-        right = P4Rev(RevType.LOCAL)
-        -- utils.warn("Comparing single non-CL revision against workspace. To see diff *within* a CL, specify the changelist number.")
+      -- Cannot easily determine previous rev for non-CL specs like #head or labels
+      -- Fallback to comparing spec against workspace?
+      -- Or maybe error out? Let's compare against workspace for now.
+      left = P4Rev(RevType.COMMIT, current_rev_spec)
+      right = P4Rev(RevType.LOCAL)
+      -- utils.warn("Comparing single non-CL revision against workspace. To see diff *within* a CL, specify the changelist number.")
     end
   end
 
@@ -629,14 +670,14 @@ function P4Adapter:rev_to_args(left, right)
   if right.type == RevType.LOCAL then
     -- Diffing against workspace: `p4 diff //path/...#rev` or just `p4 diff //path/...`
     if left_spec == "#head" then
-        return {} -- `p4 diff` defaults to workspace vs head
+      return {} -- `p4 diff` defaults to workspace vs head
     else
-        -- Need to specify the revision for the depot side. Path args are added later.
-        -- Returning just the rev spec might work if paths are appended correctly.
-        -- `p4 diff` doesn't take two revisions like diff2.
-        -- This case might need handling in the calling function (`tracked_files`).
-        -- Let's return an empty array and handle it there.
-        return {}
+      -- Need to specify the revision for the depot side. Path args are added later.
+      -- Returning just the rev spec might work if paths are appended correctly.
+      -- `p4 diff` doesn't take two revisions like diff2.
+      -- This case might need handling in the calling function (`tracked_files`).
+      -- Let's return an empty array and handle it there.
+      return {}
     end
   elseif left.type == RevType.COMMIT and right.type == RevType.COMMIT then
     -- Diffing between two depot revisions: `p4 diff2 //path/...@rev1 //path/...@rev2`
@@ -658,204 +699,228 @@ end
 ---@param opt vcs.adapter.LayoutOpt
 ---@param callback fun(err?:any, files?:FileEntry[], conflicts?:FileEntry[])
 P4Adapter.tracked_files = async.wrap(function(self, left, right, args, kind, opt, callback)
-    local files = {}
-    local conflicts = {} -- Perforce conflicts detected via 'p4 resolve -n'
-    local log_opt = { label = "P4Adapter:tracked_files()" }
-    local path_args = self.ctx.path_args -- Use paths stored in adapter context
+  local files = {}
+  local conflicts = {} -- Perforce conflicts detected via 'p4 resolve -n'
+  local log_opt = { label = "P4Adapter:tracked_files()" }
+  local path_args = self.ctx.path_args -- Use paths stored in adapter context
 
-    -- Default pathspec if none provided in context
-    local path_spec = #path_args > 0 and path_args or { "//..." }
+  -- Default pathspec if none provided in context
+  local path_spec = #path_args > 0 and path_args or { "//..." }
 
-    if right.type == RevType.LOCAL then
-        -- Compare workspace (local) against a depot revision (left)
-        local depot_rev = left:object_name()
+  if right.type == RevType.LOCAL then
+    -- Compare workspace (local) against a depot revision (left)
+    local depot_rev = left:object_name()
 
-        -- Use `p4 diff -f -sl //...@depot_rev` to list files differing from depot rev
-        -- Use `p4 opened //...` to list files opened for edit/add/delete etc.
-        -- Combine results for a complete view.
+    -- Use `p4 diff -f -sl //...@depot_rev` to list files differing from depot rev
+    -- Use `p4 opened //...` to list files opened for edit/add/delete etc.
+    -- Combine results for a complete view.
 
-        local diff_job = Job({
-            command = self:bin(),
-            -- -sl lists files differing, -f forces diff even if identical (for adds/deletes)
-            args = utils.vec_join("diff", "-sl", vim.tbl_map(function(p) return p .. depot_rev end, path_spec)),
-            cwd = self.ctx.toplevel,
-            log_opt = { label = log_opt.label .. "(diff)" },
-        })
-        local opened_job = Job({
-            command = self:bin(),
-            args = utils.vec_join("opened", path_spec),
-            cwd = self.ctx.toplevel,
-            log_opt = { label = log_opt.label .. "(opened)" },
-        })
+    local diff_job = Job({
+      command = self:bin(),
+      -- -sl lists files differing, -f forces diff even if identical (for adds/deletes)
+      args = utils.vec_join(
+        "diff",
+        "-sl",
+        vim.tbl_map(function(p)
+          return p .. depot_rev
+        end, path_spec)
+      ),
+      cwd = self.ctx.toplevel,
+      log_opt = { label = log_opt.label .. "(diff)" },
+    })
+    local opened_job = Job({
+      command = self:bin(),
+      args = utils.vec_join("opened", path_spec),
+      cwd = self.ctx.toplevel,
+      log_opt = { label = log_opt.label .. "(opened)" },
+    })
 
-        local ok, err = await(Job.join({ diff_job, opened_job }))
-        if not ok then
-            callback(utils.vec_join(err, diff_job.stderr, opened_job.stderr), nil)
-            return
-        end
-
-        local file_status = {} -- local_path -> { status, path }
-
-        -- Process opened files first to get status (add, edit, delete).
-        -- p4 opened output format: //depot/path#rev - action change (type)
-        -- Strip the #rev suffix to get just the depot path.
-        local depot_paths = {}
-        local depot_status = {} -- depot_path -> status letter
-        for _, line in ipairs(opened_job.stdout) do
-            local depot_path, change_type = line:match("^(.-)#%d+%s*-%s*([^%s]+)%s+")
-            if depot_path then
-                local status_map = { add = "A", edit = "M", delete = "D", branch = "A", integrate = "M" }
-                depot_status[depot_path] = status_map[change_type] or "M"
-                table.insert(depot_paths, depot_path)
-            end
-        end
-
-        -- Map depot paths to local (workspace) paths via `p4 -ztag where`
-        -- so that all entries use paths relative to the client root.  Tagged
-        -- output gives us "... path /local/path" lines which are safe to
-        -- parse even when paths contain spaces.
-        local depot_to_local = {}
-        if #depot_paths > 0 then
-            local where_job = Job({
-                command = self:bin(),
-                args = utils.vec_join("-ztag", "where", depot_paths),
-                cwd = self.ctx.toplevel,
-                log_opt = { label = log_opt.label .. "(where)" },
-            })
-            await(Job.join({ where_job }))
-
-            local cur_depot = nil
-            for _, line in ipairs(where_job.stdout) do
-                local key, value = line:match("^%.%.%. (%S+) (.+)$")
-                if key == "depotFile" then
-                    cur_depot = value
-                elseif key == "path" and cur_depot then
-                    depot_to_local[cur_depot] = value
-                    cur_depot = nil
-                end
-            end
-        end
-
-        -- Build file_status from opened files, keyed by workspace-relative path.
-        local toplevel = self.ctx.toplevel
-        for dp, status in pairs(depot_status) do
-            local lp = depot_to_local[dp]
-            if lp then
-                local rel = pl:relative(lp, toplevel)
-                file_status[rel] = { status = status, path = rel }
-            else
-                -- Fallback: use depot path if `p4 where` did not resolve it
-                -- (e.g. the file only exists in the depot and has no local mapping).
-                file_status[dp] = { status = status, path = dp }
-            end
-        end
-
-        -- Process diff output, update status if needed, add files not in
-        -- 'opened'.  p4 diff -sl output format: "diff /local/path" or
-        -- "same /local/path".  We only care about files that differ.
-        for _, line in ipairs(diff_job.stdout) do
-             local diff_status, local_path = line:match("^(%S+) (.+)$")
-             if diff_status == "diff" and local_path then
-                 local rel = pl:relative(local_path, toplevel)
-                 if not file_status[rel] then
-                     file_status[rel] = { status = "M", path = rel }
-                 end
-             end
-        end
-
-        -- Convert file_status map to FileEntry array
-        for _, data in pairs(file_status) do
-            table.insert(files, FileEntry.with_layout(opt.default_layout, {
-                adapter = self,
-                path = data.path,
-                status = data.status,
-                stats = data.stats, -- nil for now
-                kind = "working",
-                revs = { a = left, b = right },
-            }))
-        end
-
-    elseif left.type == RevType.COMMIT and right.type == RevType.COMMIT then
-        -- Compare two depot revisions
-        local left_spec = left:object_name()
-        local right_spec = right:object_name()
-
-        -- Use `p4 diff2 -q //path/...@rev1 //path/...@rev2` to get diff summary
-        -- Or `p4 files //path/...@rev1,@rev2` then `p4 diff2`?
-        -- Or `p4 describe -du CL` if it represents a single CL change.
-        -- Let's use diff2 -ds for summary between two arbitrary revisions.
-        local diff_cmd = utils.vec_join(
-            "diff2", "-ds", -- -ds provides summary status line per file
-            vim.tbl_map(function(p) return p .. left_spec end, path_spec),
-            vim.tbl_map(function(p) return p .. right_spec end, path_spec)
-        )
-
-        local diff_job = Job({
-            command = self:bin(),
-            args = diff_cmd,
-            cwd = self.ctx.toplevel,
-            log_opt = { label = log_opt.label .. "(diff2)" },
-        })
-
-        local ok, err = await(diff_job)
-        if not ok then
-            callback(utils.vec_join(err, diff_job.stderr), nil)
-            return
-        end
-
-        -- Parse `diff2 -ds` output.  The format varies:
-        --   ==== //path#rev (type) - //path#rev (type) ==== content
-        --   ==== //path#rev (type) - //path#rev (type) ==== identical
-        --   ==== <none> - //path#rev ====               (added file)
-        --   ==== //path#rev - <none> ===                (deleted file, note 3 '=')
-        -- Stats lines like "add 0 chunks 0 lines" follow and are ignored.
-        for _, line in ipairs(diff_job.stdout) do
-          if line:match("^====") then
-            local left_file, right_file, diff_type =
-              line:match("^==== (%S+).-%-(.-)===+%s*(%S*)")
-
-            if left_file then
-              right_file = right_file:match("(%S+)") or right_file
-
-              local status
-              if diff_type == "content" then status = "M"
-              elseif diff_type == "types" then status = "T"
-              elseif diff_type == "branch" then status = "A"
-              elseif left_file == "<none>" then status = "A"
-              elseif right_file == "<none>" then status = "D"
-              elseif diff_type == "identical" then status = nil
-              else status = "M"
-              end
-
-              if status then
-                -- Strip #rev suffix from depot paths.
-                local path = left_file ~= "<none>" and left_file or right_file
-                path = path:match("^(.-)#%d+") or path
-
-                table.insert(files, FileEntry.with_layout(opt.default_layout, {
-                    adapter = self,
-                    path = path,
-                    status = status,
-                    stats = nil,
-                    kind = "working",
-                    revs = { a = left, b = right },
-                }))
-              end
-            end
-          end
-        end
-    else
-        logger:fmt_warn("Unsupported revision combination for tracked_files: %s vs %s", left, right)
+    local ok, err = await(Job.join({ diff_job, opened_job }))
+    if not ok then
+      callback(utils.vec_join(err, diff_job.stderr, opened_job.stderr), nil)
+      return
     end
 
-    -- Check for conflicts separately if needed (complex)
-    -- local conflict_check_job = ... `p4 resolve -n` ...
-    -- if conflicts_found then populate `conflicts` array
+    local file_status = {} -- local_path -> { status, path }
 
-    -- Sort files alphabetically by path
-    table.sort(files, function(a, b) return a.path < b.path end)
+    -- Process opened files first to get status (add, edit, delete).
+    -- p4 opened output format: //depot/path#rev - action change (type)
+    -- Strip the #rev suffix to get just the depot path.
+    local depot_paths = {}
+    local depot_status = {} -- depot_path -> status letter
+    for _, line in ipairs(opened_job.stdout) do
+      local depot_path, change_type = line:match("^(.-)#%d+%s*-%s*([^%s]+)%s+")
+      if depot_path then
+        local status_map = { add = "A", edit = "M", delete = "D", branch = "A", integrate = "M" }
+        depot_status[depot_path] = status_map[change_type] or "M"
+        table.insert(depot_paths, depot_path)
+      end
+    end
 
-    callback(nil, files, conflicts)
+    -- Map depot paths to local (workspace) paths via `p4 -ztag where`
+    -- so that all entries use paths relative to the client root.  Tagged
+    -- output gives us "... path /local/path" lines which are safe to
+    -- parse even when paths contain spaces.
+    local depot_to_local = {}
+    if #depot_paths > 0 then
+      local where_job = Job({
+        command = self:bin(),
+        args = utils.vec_join("-ztag", "where", depot_paths),
+        cwd = self.ctx.toplevel,
+        log_opt = { label = log_opt.label .. "(where)" },
+      })
+      await(Job.join({ where_job }))
+
+      local cur_depot = nil
+      for _, line in ipairs(where_job.stdout) do
+        local key, value = line:match("^%.%.%. (%S+) (.+)$")
+        if key == "depotFile" then
+          cur_depot = value
+        elseif key == "path" and cur_depot then
+          depot_to_local[cur_depot] = value
+          cur_depot = nil
+        end
+      end
+    end
+
+    -- Build file_status from opened files, keyed by workspace-relative path.
+    local toplevel = self.ctx.toplevel
+    for dp, status in pairs(depot_status) do
+      local lp = depot_to_local[dp]
+      if lp then
+        local rel = pl:relative(lp, toplevel)
+        file_status[rel] = { status = status, path = rel }
+      else
+        -- Fallback: use depot path if `p4 where` did not resolve it
+        -- (e.g. the file only exists in the depot and has no local mapping).
+        file_status[dp] = { status = status, path = dp }
+      end
+    end
+
+    -- Process diff output, update status if needed, add files not in
+    -- 'opened'.  p4 diff -sl output format: "diff /local/path" or
+    -- "same /local/path".  We only care about files that differ.
+    for _, line in ipairs(diff_job.stdout) do
+      local diff_status, local_path = line:match("^(%S+) (.+)$")
+      if diff_status == "diff" and local_path then
+        local rel = pl:relative(local_path, toplevel)
+        if not file_status[rel] then
+          file_status[rel] = { status = "M", path = rel }
+        end
+      end
+    end
+
+    -- Convert file_status map to FileEntry array
+    for _, data in pairs(file_status) do
+      table.insert(
+        files,
+        FileEntry.with_layout(opt.default_layout, {
+          adapter = self,
+          path = data.path,
+          status = data.status,
+          stats = data.stats, -- nil for now
+          kind = "working",
+          revs = { a = left, b = right },
+        })
+      )
+    end
+  elseif left.type == RevType.COMMIT and right.type == RevType.COMMIT then
+    -- Compare two depot revisions
+    local left_spec = left:object_name()
+    local right_spec = right:object_name()
+
+    -- Use `p4 diff2 -q //path/...@rev1 //path/...@rev2` to get diff summary
+    -- Or `p4 files //path/...@rev1,@rev2` then `p4 diff2`?
+    -- Or `p4 describe -du CL` if it represents a single CL change.
+    -- Let's use diff2 -ds for summary between two arbitrary revisions.
+    local diff_cmd = utils.vec_join(
+      "diff2",
+      "-ds", -- -ds provides summary status line per file
+      vim.tbl_map(function(p)
+        return p .. left_spec
+      end, path_spec),
+      vim.tbl_map(function(p)
+        return p .. right_spec
+      end, path_spec)
+    )
+
+    local diff_job = Job({
+      command = self:bin(),
+      args = diff_cmd,
+      cwd = self.ctx.toplevel,
+      log_opt = { label = log_opt.label .. "(diff2)" },
+    })
+
+    local ok, err = await(diff_job)
+    if not ok then
+      callback(utils.vec_join(err, diff_job.stderr), nil)
+      return
+    end
+
+    -- Parse `diff2 -ds` output.  The format varies:
+    --   ==== //path#rev (type) - //path#rev (type) ==== content
+    --   ==== //path#rev (type) - //path#rev (type) ==== identical
+    --   ==== <none> - //path#rev ====               (added file)
+    --   ==== //path#rev - <none> ===                (deleted file, note 3 '=')
+    -- Stats lines like "add 0 chunks 0 lines" follow and are ignored.
+    for _, line in ipairs(diff_job.stdout) do
+      if line:match("^====") then
+        local left_file, right_file, diff_type = line:match("^==== (%S+).-%-(.-)===+%s*(%S*)")
+
+        if left_file then
+          right_file = right_file:match("(%S+)") or right_file
+
+          local status
+          if diff_type == "content" then
+            status = "M"
+          elseif diff_type == "types" then
+            status = "T"
+          elseif diff_type == "branch" then
+            status = "A"
+          elseif left_file == "<none>" then
+            status = "A"
+          elseif right_file == "<none>" then
+            status = "D"
+          elseif diff_type == "identical" then
+            status = nil
+          else
+            status = "M"
+          end
+
+          if status then
+            -- Strip #rev suffix from depot paths.
+            local path = left_file ~= "<none>" and left_file or right_file
+            path = path:match("^(.-)#%d+") or path
+
+            table.insert(
+              files,
+              FileEntry.with_layout(opt.default_layout, {
+                adapter = self,
+                path = path,
+                status = status,
+                stats = nil,
+                kind = "working",
+                revs = { a = left, b = right },
+              })
+            )
+          end
+        end
+      end
+    end
+  else
+    logger:fmt_warn("Unsupported revision combination for tracked_files: %s vs %s", left, right)
+  end
+
+  -- Check for conflicts separately if needed (complex)
+  -- local conflict_check_job = ... `p4 resolve -n` ...
+  -- if conflicts_found then populate `conflicts` array
+
+  -- Sort files alphabetically by path
+  table.sort(files, function(a, b)
+    return a.path < b.path
+  end)
+
+  callback(nil, files, conflicts)
 end)
 
 ---Get untracked files (files in workspace not known to Perforce).
@@ -866,49 +931,55 @@ end)
 ---@param opt vcs.adapter.LayoutOpt
 ---@param callback fun(err?:any, files?:FileEntry[])
 P4Adapter.untracked_files = async.wrap(function(self, left, right, opt, callback)
-    -- Only show untracked if comparing against workspace AND configured to do so
-    if right.type ~= RevType.LOCAL or not self:show_untracked({ revs = { left=left, right=right }}) then
-        callback(nil, {})
-        return
+  -- Only show untracked if comparing against workspace AND configured to do so
+  if
+    right.type ~= RevType.LOCAL
+    or not self:show_untracked({ revs = { left = left, right = right } })
+  then
+    callback(nil, {})
+    return
+  end
+
+  local path_args = self.ctx.path_args
+  local path_spec = #path_args > 0 and path_args or { "//..." }
+
+  -- `p4 status` or `p4 reconcile -nlad` lists local files not in depot or opened.
+  local status_job = Job({
+    command = self:bin(),
+    args = utils.vec_join("reconcile", "-nl", path_spec), -- -n: preview, -l: local files not in depot
+    cwd = self.ctx.toplevel,
+    log_opt = { label = "P4Adapter:untracked_files()" },
+  })
+
+  local ok, err = await(status_job)
+  if not ok then
+    callback(utils.vec_join(err, status_job.stderr), nil)
+    return
+  end
+
+  local files = {}
+  for _, line in ipairs(status_job.stdout) do
+    -- Output format: //depot/path#none - add default changelist (local) /path/on/disk
+    local local_path = line:match("%(local%)%s*(.*)")
+    if local_path then
+      local_path = vim.trim(local_path)
+      -- We need the path relative to client root or the depot path if possible
+      -- Sticking with the local path for now.
+      table.insert(
+        files,
+        FileEntry.with_layout(opt.default_layout, {
+          adapter = self,
+          path = local_path, -- Use local path for untracked
+          status = "?",
+          stats = nil,
+          kind = "working",
+          revs = { a = P4Rev.new_null_tree(), b = right }, -- Diff from nothing to local
+        })
+      )
     end
+  end
 
-    local path_args = self.ctx.path_args
-    local path_spec = #path_args > 0 and path_args or { "//..." }
-
-    -- `p4 status` or `p4 reconcile -nlad` lists local files not in depot or opened.
-    local status_job = Job({
-        command = self:bin(),
-        args = utils.vec_join("reconcile", "-nl", path_spec), -- -n: preview, -l: local files not in depot
-        cwd = self.ctx.toplevel,
-        log_opt = { label = "P4Adapter:untracked_files()" },
-    })
-
-    local ok, err = await(status_job)
-    if not ok then
-        callback(utils.vec_join(err, status_job.stderr), nil)
-        return
-    end
-
-    local files = {}
-    for _, line in ipairs(status_job.stdout) do
-        -- Output format: //depot/path#none - add default changelist (local) /path/on/disk
-        local local_path = line:match("%(local%)%s*(.*)")
-        if local_path then
-             local_path = vim.trim(local_path)
-            -- We need the path relative to client root or the depot path if possible
-            -- Sticking with the local path for now.
-            table.insert(files, FileEntry.with_layout(opt.default_layout, {
-                adapter = self,
-                path = local_path, -- Use local path for untracked
-                status = "?",
-                stats = nil,
-                kind = "working",
-                revs = { a = P4Rev.new_null_tree(), b = right }, -- Diff from nothing to local
-            }))
-        end
-    end
-
-    callback(nil, files)
+  callback(nil, files)
 end)
 
 ---Check configuration/defaults if untracked files should be shown.
@@ -935,30 +1006,30 @@ end
 ---@param commit string? -- Ignored for p4 revert (reverts to depot head or unopened state)
 ---@param callback fun(ok: boolean, undo?: string)
 P4Adapter.file_restore = async.wrap(function(self, path, kind, commit, callback)
-    -- `p4 revert` reverts opened files to their state before being opened,
-    -- or removes added files. It doesn't restore to a specific historical commit.
-    -- If the goal is to revert changes made in the workspace:
-    local revert_job = Job({
-        command = self:bin(),
-        args = { "revert", path },
-        cwd = self.ctx.toplevel,
-        log_opt = { label = "P4Adapter:file_restore(revert)" },
-    })
+  -- `p4 revert` reverts opened files to their state before being opened,
+  -- or removes added files. It doesn't restore to a specific historical commit.
+  -- If the goal is to revert changes made in the workspace:
+  local revert_job = Job({
+    command = self:bin(),
+    args = { "revert", path },
+    cwd = self.ctx.toplevel,
+    log_opt = { label = "P4Adapter:file_restore(revert)" },
+  })
 
-    local ok, err = await(revert_job)
-    if not ok then
-        callback(false, nil) -- Revert failed
-        return
-    end
+  local ok, err = await(revert_job)
+  if not ok then
+    callback(false, nil) -- Revert failed
+    return
+  end
 
-    -- Check if the file still exists after revert (it might if it was edited, not if added)
-    local exists_local = pl:readable(path) -- Assumes path is local absolute
+  -- Check if the file still exists after revert (it might if it was edited, not if added)
+  local exists_local = pl:readable(path) -- Assumes path is local absolute
 
-    -- Constructing an "undo" command for p4 revert is difficult.
-    -- Maybe sync to the previous revision?
-    local undo_cmd -- = nil (Hard to provide a reliable undo for p4 revert)
+  -- Constructing an "undo" command for p4 revert is difficult.
+  -- Maybe sync to the previous revision?
+  local undo_cmd -- = nil (Hard to provide a reliable undo for p4 revert)
 
-    callback(true, undo_cmd)
+  callback(true, undo_cmd)
 end)
 
 --- Staging is implicit via `p4 add/edit/delete`. This doesn't map well.
@@ -985,42 +1056,40 @@ end
 ---@param rev P4Rev -- Revision to check
 ---@return boolean -- True if binary or non-existent
 function P4Adapter:is_binary(path, rev)
-    -- File type check works best on depot paths and revisions.
-    local path_spec = path
-    if rev and rev.type == RevType.COMMIT then
-        path_spec = path .. rev:object_name()
-    elseif rev and rev.type == RevType.LOCAL then
-        path_spec = path
-    else
-        path_spec = path .. "#head"
+  -- File type check works best on depot paths and revisions.
+  local path_spec = path
+  if rev and rev.type == RevType.COMMIT then
+    path_spec = path .. rev:object_name()
+  elseif rev and rev.type == RevType.LOCAL then
+    path_spec = path
+  else
+    path_spec = path .. "#head"
+  end
+
+  local out, code = self:exec_sync({ "fstat", "-T", "headType", path_spec }, self.ctx.toplevel)
+
+  if code ~= 0 then
+    return true -- Assume binary or non-existent on error
+  end
+
+  for _, line in ipairs(out) do
+    local file_type = line:match("headType (%S+)")
+    if file_type then
+      if
+        file_type:find("binary")
+        or file_type:find("apple")
+        or file_type:find("resource")
+        or file_type:find("unicode")
+        or file_type:find("utf16")
+      then
+        return true
+      else
+        return false
+      end
     end
+  end
 
-    local out, code = self:exec_sync(
-      { "fstat", "-T", "headType", path_spec },
-      self.ctx.toplevel
-    )
-
-    if code ~= 0 then
-        return true -- Assume binary or non-existent on error
-    end
-
-    for _, line in ipairs(out) do
-        local file_type = line:match("headType (%S+)")
-        if file_type then
-            if file_type:find("binary")
-              or file_type:find("apple")
-              or file_type:find("resource")
-              or file_type:find("unicode")
-              or file_type:find("utf16")
-            then
-                return true
-            else
-                return false
-            end
-        end
-    end
-
-    return true -- Not found or no type info, assume binary/non-existent
+  return true -- Not found or no type info, assume binary/non-existent
 end
 
 ---Convert revs to pretty string for display.
@@ -1032,13 +1101,13 @@ function P4Adapter:rev_to_pretty_string(left, right)
   local r_str = right:object_name()
 
   if right.type == RevType.LOCAL then
-      return l_str -- Show only the depot revision being compared to workspace
+    return l_str -- Show only the depot revision being compared to workspace
   else
-      if l_str ~= P4Rev.NULL_TREE_SHA and r_str ~= P4Rev.NULL_TREE_SHA and l_str ~= r_str then
-          return l_str .. ".." .. r_str
-      else
-           return r_str -- Show single revision if left is null or same
-      end
+    if l_str ~= P4Rev.NULL_TREE_SHA and r_str ~= P4Rev.NULL_TREE_SHA and l_str ~= r_str then
+      return l_str .. ".." .. r_str
+    else
+      return r_str -- Show single revision if left is null or same
+    end
   end
 end
 
@@ -1046,101 +1115,115 @@ end
 
 --- Placeholder for Perforce completion logic.
 function P4Adapter:init_completion()
-    -- Completion for :DiffviewOpen [rev]
-    self.comp.open:put({}, function(_, arg_lead) -- No specific flags yet
-        -- Provide CLs, #head, @, labels?
-        return self:rev_candidates(arg_lead, { accept_range = true })
-    end)
+  -- Completion for :DiffviewOpen [rev]
+  self.comp.open:put({}, function(_, arg_lead) -- No specific flags yet
+    -- Provide CLs, #head, @, labels?
+    return self:rev_candidates(arg_lead, { accept_range = true })
+  end)
 
-    -- Completion for :DiffviewFileHistory flags
-    self.comp.file_history:put({ "--rev", "-r" }, function(_, arg_lead)
-        -- Provide CLs, #head, @rev1,@rev2 ranges, labels
-        return self:rev_candidates(arg_lead, { accept_range = true })
-    end)
-    self.comp.file_history:put({ "--limit", "-m" }, {}) -- Expects number
-    self.comp.file_history:put({ "--user", "-u" }, function(_, arg_lead)
-        -- Provide list of users? `p4 users`
-        -- local users_out, _ = self:exec_sync({"users", "-a"}, self.ctx.toplevel)
-        -- return vim.tbl_map(function(l) return l:match("^(%S+)") end, users_out or {})
-        return {} -- Placeholder
-    end)
-     self.comp.file_history:put({ "--" }, function(_, arg_lead) -- Path completion
-        return self:path_candidates(arg_lead)
-    end)
+  -- Completion for :DiffviewFileHistory flags
+  self.comp.file_history:put({ "--rev", "-r" }, function(_, arg_lead)
+    -- Provide CLs, #head, @rev1,@rev2 ranges, labels
+    return self:rev_candidates(arg_lead, { accept_range = true })
+  end)
+  self.comp.file_history:put({ "--limit", "-m" }, {}) -- Expects number
+  self.comp.file_history:put({ "--user", "-u" }, function(_, arg_lead)
+    -- Provide list of users? `p4 users`
+    -- local users_out, _ = self:exec_sync({"users", "-a"}, self.ctx.toplevel)
+    -- return vim.tbl_map(function(l) return l:match("^(%S+)") end, users_out or {})
+    return {} -- Placeholder
+  end)
+  self.comp.file_history:put({ "--" }, function(_, arg_lead) -- Path completion
+    return self:path_candidates(arg_lead)
+  end)
 
-    -- Add other completions as needed
+  -- Add other completions as needed
 end
 
 --- Provide revision candidates for completion.
 ---@param arg_lead string
 ---@param opt? RevCompletionSpec
 function P4Adapter:rev_candidates(arg_lead, opt)
-    opt = vim.tbl_extend("keep", opt or {}, { accept_range = false }) --[[@as RevCompletionSpec ]]
-    local candidates = { "#head", "#none", "@" } -- Basic specs
+  opt = vim.tbl_extend("keep", opt or {}, { accept_range = false }) --[[@as RevCompletionSpec ]]
+  local candidates = { "#head", "#none", "@" } -- Basic specs
 
-    -- Fetch recent changes
-    local changes_out, _ = self:exec_sync({"changes", "-m", "20", "-s", "submitted", "//..."}, self.ctx.toplevel)
-    for _, line in ipairs(changes_out or {}) do
-        local cl = line:match("^Change (%d+)")
-        if cl then table.insert(candidates, "@" .. cl) end
+  -- Fetch recent changes
+  local changes_out, _ =
+    self:exec_sync({ "changes", "-m", "20", "-s", "submitted", "//..." }, self.ctx.toplevel)
+  for _, line in ipairs(changes_out or {}) do
+    local cl = line:match("^Change (%d+)")
+    if cl then
+      table.insert(candidates, "@" .. cl)
     end
+  end
 
-    -- Fetch labels (can be slow)
-    -- local labels_out, _ = self:exec_sync({"labels"}, self.ctx.toplevel)
-    -- for _, line in ipairs(labels_out or {}) do
-    --    local label = line:match("^Label (%S+)")
-    --    if label then table.insert(candidates, "@" .. label) end
-    -- end
+  -- Fetch labels (can be slow)
+  -- local labels_out, _ = self:exec_sync({"labels"}, self.ctx.toplevel)
+  -- for _, line in ipairs(labels_out or {}) do
+  --    local label = line:match("^Label (%S+)")
+  --    if label then table.insert(candidates, "@" .. label) end
+  -- end
 
-    -- Handle range completion if needed
-    if opt.accept_range then
-       -- Logic similar to Git/Hg to prepend range prefix to candidates
-       local range_prefix = arg_lead:match("^(.-[,%.%.])")
-       if range_prefix then
-           local remaining_lead = arg_lead:sub(#range_prefix + 1)
-           local filtered_candidates = vim.tbl_filter(function(c) return c:find(remaining_lead, 1, true) == 1 end, candidates)
-           return vim.tbl_map(function(c) return range_prefix .. c end, filtered_candidates)
-       end
+  -- Handle range completion if needed
+  if opt.accept_range then
+    -- Logic similar to Git/Hg to prepend range prefix to candidates
+    local range_prefix = arg_lead:match("^(.-[,%.%.])")
+    if range_prefix then
+      local remaining_lead = arg_lead:sub(#range_prefix + 1)
+      local filtered_candidates = vim.tbl_filter(function(c)
+        return c:find(remaining_lead, 1, true) == 1
+      end, candidates)
+      return vim.tbl_map(function(c)
+        return range_prefix .. c
+      end, filtered_candidates)
     end
+  end
 
-    -- Filter candidates based on arg_lead
-    return vim.tbl_filter(function(c) return c:find(arg_lead, 1, true) == 1 end, candidates)
+  -- Filter candidates based on arg_lead
+  return vim.tbl_filter(function(c)
+    return c:find(arg_lead, 1, true) == 1
+  end, candidates)
 end
 
 --- Provide path candidates for completion (depot paths).
 ---@param arg_lead string
 function P4Adapter:path_candidates(arg_lead)
-    -- Use `p4 files` or `p4 dirs` for completion.
-    -- Needs careful handling of depot vs local paths and view mapping.
-    local cmd
-    local pattern = arg_lead
-    if not pattern:match("^//") then
-       -- Assume it's a local path relative to CWD or client root? Map it?
-       -- For simplicity, default to completing from depot root if not a depot path.
-       pattern = "//..."
-       if arg_lead ~= "" then pattern = arg_lead .. "*" end -- Basic wildcard
-    else
-       pattern = arg_lead .. "*" -- Add wildcard for directory listing effect
+  -- Use `p4 files` or `p4 dirs` for completion.
+  -- Needs careful handling of depot vs local paths and view mapping.
+  local cmd
+  local pattern = arg_lead
+  if not pattern:match("^//") then
+    -- Assume it's a local path relative to CWD or client root? Map it?
+    -- For simplicity, default to completing from depot root if not a depot path.
+    pattern = "//..."
+    if arg_lead ~= "" then
+      pattern = arg_lead .. "*"
+    end -- Basic wildcard
+  else
+    pattern = arg_lead .. "*" -- Add wildcard for directory listing effect
+  end
+
+  -- Use 'p4 dirs' for directory completion
+  cmd = { "dirs", pattern }
+  local dirs_out, _ = self:exec_sync(cmd, self.ctx.toplevel)
+
+  -- Use 'p4 files' for file completion (limit results?)
+  cmd = { "files", "-m", "20", pattern:gsub("%*$", "") .. "..." } -- Limit files shown
+  local files_out, _ = self:exec_sync(cmd, self.ctx.toplevel)
+
+  local candidates = {}
+  for _, line in ipairs(dirs_out or {}) do
+    table.insert(candidates, line)
+  end
+  for _, line in ipairs(files_out or {}) do
+    local file_path = line:match("^(%S+)#")
+    if file_path then
+      table.insert(candidates, file_path)
     end
+  end
 
-    -- Use 'p4 dirs' for directory completion
-    cmd = { "dirs", pattern }
-    local dirs_out, _ = self:exec_sync(cmd, self.ctx.toplevel)
-
-    -- Use 'p4 files' for file completion (limit results?)
-    cmd = { "files", "-m", "20", pattern:gsub("%*$", "") .. "..." } -- Limit files shown
-    local files_out, _ = self:exec_sync(cmd, self.ctx.toplevel)
-
-    local candidates = {}
-    for _, line in ipairs(dirs_out or {}) do table.insert(candidates, line) end
-    for _, line in ipairs(files_out or {}) do
-        local file_path = line:match("^(%S+)#")
-        if file_path then table.insert(candidates, file_path) end
-    end
-
-    return candidates
+  return candidates
 end
-
 
 M.P4Adapter = P4Adapter
 return M

--- a/lua/diffview/vcs/adapters/p4/rev.lua
+++ b/lua/diffview/vcs/adapters/p4/rev.lua
@@ -1,6 +1,6 @@
 local oop = require("diffview.oop")
-local Rev = require('diffview.vcs.rev').Rev
-local RevType = require('diffview.vcs.rev').RevType
+local Rev = require("diffview.vcs.rev").Rev
+local RevType = require("diffview.vcs.rev").RevType
 
 local M = {}
 
@@ -52,14 +52,14 @@ function P4Rev.from_name(name, adapter)
   -- Attempt to resolve the revision specifier using p4 changes
   local rev_spec = name
   if tonumber(name) then
-      rev_spec = "@" .. name -- Ensure it's in @CL format if just a number
+    rev_spec = "@" .. name -- Ensure it's in @CL format if just a number
   end
 
   -- Use 'p4 changes -m1' to verify the revision exists.
   -- #head, #none, @client are usually implicitly valid if p4 client is set up.
   if rev_spec == "#head" or rev_spec == "#none" or rev_spec == "@" then
-      -- Assume these are valid in a working client context
-      return P4Rev(RevType.COMMIT, rev_spec) -- Treat #head etc. as COMMIT type for simplicity
+    -- Assume these are valid in a working client context
+    return P4Rev(RevType.COMMIT, rev_spec) -- Treat #head etc. as COMMIT type for simplicity
   end
 
   local out, code = adapter:exec_sync({ "changes", "-m1", rev_spec }, adapter.ctx.toplevel)
@@ -105,9 +105,9 @@ end
 ---@return string
 function P4Rev:object_name(abbrev_len)
   if self.type == RevType.COMMIT then
-      return self.commit -- e.g., @12345, #head, @labelname
+    return self.commit -- e.g., @12345, #head, @labelname
   elseif self.type == RevType.LOCAL then
-      return "@" -- Perforce often uses '@' to denote workspace files implicitly in diffs
+    return "@" -- Perforce often uses '@' to denote workspace files implicitly in diffs
   end
   return "UNKNOWN"
 end

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -15,7 +15,6 @@ local pl = lazy.access(utils, "path") ---@type PathLib
 local api = vim.api
 local M = {}
 
-
 ---@alias git.FileDataProducer fun(kind: vcs.FileKind, path: string, pos: "left"|"right"): string[]
 
 ---@class vcs.File : diffview.Object
@@ -81,26 +80,27 @@ function File:init(opt)
   self.active = true
   self.ready = false
 
-  self.winopts = opt.winopts or {
-    diff = true,
-    scrollbind = true,
-    cursorbind = true,
-    foldmethod = "diff",
-    scrollopt = { "ver", "hor", "jump" },
-    foldcolumn = "1",
-    -- Resolved from `view.foldlevel` at window open (see `Window:open_file`).
-    foldlevel = 0,
-    foldenable = true,
-    -- Use prepend method so diffview's highlights take precedence but don't
-    -- clobber user's additional winhl customizations (#515).
-    winhl = {
-      "DiffAdd:DiffviewDiffAdd",
-      "DiffDelete:DiffviewDiffDelete",
-      "DiffChange:DiffviewDiffChange",
-      "DiffText:DiffviewDiffText",
-      opt = { method = "prepend" },
-    },
-  }
+  self.winopts = opt.winopts
+    or {
+      diff = true,
+      scrollbind = true,
+      cursorbind = true,
+      foldmethod = "diff",
+      scrollopt = { "ver", "hor", "jump" },
+      foldcolumn = "1",
+      -- Resolved from `view.foldlevel` at window open (see `Window:open_file`).
+      foldlevel = 0,
+      foldenable = true,
+      -- Use prepend method so diffview's highlights take precedence but don't
+      -- clobber user's additional winhl customizations (#515).
+      winhl = {
+        "DiffAdd:DiffviewDiffAdd",
+        "DiffDelete:DiffviewDiffDelete",
+        "DiffChange:DiffviewDiffChange",
+        "DiffText:DiffviewDiffText",
+        opt = { method = "prepend" },
+      },
+    }
 
   -- Set winbar info
   if self.rev then
@@ -289,7 +289,9 @@ File.create_buffer = async.wrap(function(self, callback)
   end
 
   local err, lines = await(self:produce_data())
-  if err then error(table.concat(err, "\n")) end
+  if err then
+    error(table.concat(err, "\n"))
+  end
 
   await(async.scheduler())
 
@@ -341,7 +343,9 @@ File.create_buffer = async.wrap(function(self, callback)
     buffer = self.bufnr,
     callback = function(ev)
       local client_id = ev.data and ev.data.client_id
-      if not client_id then return end
+      if not client_id then
+        return
+      end
       vim.schedule(function()
         if api.nvim_buf_is_valid(ev.buf) then
           pcall(vim.lsp.buf_detach_client, ev.buf, client_id)
@@ -443,7 +447,9 @@ end
 ---@param lhs string
 local function save_existing_keymap(bufnr, saved, mode_map_cache, mode, lhs)
   local key = mode .. " " .. lhs
-  if saved[key] then return end
+  if saved[key] then
+    return
+  end
 
   local mode_cache = mode_map_cache[mode]
   if not mode_cache then
@@ -457,7 +463,9 @@ local function save_existing_keymap(bufnr, saved, mode_map_cache, mode, lhs)
   end
 
   local km = mode_cache[lhs]
-  if not km then return end
+  if not km then
+    return
+  end
 
   saved[key] = {
     mode = mode,
@@ -507,7 +515,8 @@ function File:attach_buffer(force, opt)
             mapping[2]
           )
         end
-        local map_opt = vim.tbl_extend("force", default_map_opt, mapping[4] or {}, { buffer = self.bufnr })
+        local map_opt =
+          vim.tbl_extend("force", default_map_opt, mapping[4] or {}, { buffer = self.bufnr })
         vim.keymap.set(mapping[1], mapping[2], mapping[3], map_opt)
       end
 

--- a/lua/diffview/vcs/file_dict.lua
+++ b/lua/diffview/vcs/file_dict.lua
@@ -42,7 +42,8 @@ end
 
 function FileDict:update_file_trees()
   -- Save collapsed state from existing trees before recreating them.
-  local conflicting_state = self.conflicting_tree and self.conflicting_tree:get_collapsed_state() or {}
+  local conflicting_state = self.conflicting_tree and self.conflicting_tree:get_collapsed_state()
+    or {}
   local working_state = self.working_tree and self.working_tree:get_collapsed_state() or {}
   local staged_state = self.staged_tree and self.staged_tree:get_collapsed_state() or {}
 
@@ -58,7 +59,9 @@ end
 
 function FileDict:len()
   local l = 0
-  for _, set in ipairs(self.sets) do l = l + #set end
+  for _, set in ipairs(self.sets) do
+    l = l + #set
+  end
 
   return l
 end

--- a/lua/diffview/vcs/flag_option.lua
+++ b/lua/diffview/vcs/flag_option.lua
@@ -50,10 +50,13 @@ function FlagOption:init(keymap, flag_name, desc, opt)
   self.keymap = keymap
   self.flag_name = flag_name
   self.desc = desc
-  self.key = opt.key or utils.str_match(flag_name, {
-    "^%-%-?([^=]+)=?",
-    "^%+%+?([^=]+)=?",
-  }):gsub("%-", "_")
+  self.key = opt.key
+    or utils
+      .str_match(flag_name, {
+        "^%-%-?([^=]+)=?",
+        "^%+%+?([^=]+)=?",
+      })
+      :gsub("%-", "_")
   self.select = opt.select
   self.completion = opt.completion
   self.expect_list = utils.sate(opt.expect_list, false)
@@ -85,16 +88,20 @@ end
 function FlagOption:transform(values)
   return utils.tbl_fmap(self:prepare_values(values), function(v)
     v = utils.str_match(v, { "^" .. vim.pesc(self.flag_name) .. "(.*)", ".*" })
-    if v == "" then return nil end
+    if v == "" then
+      return nil
+    end
     return v
   end)
 end
 
 function FlagOption:render_prompt()
-  return utils.str_template(self.prompt_fmt, {
-    label = self.prompt_label and self.prompt_label .. " " or "",
-    flag_name = self.flag_name .. " ",
-  }):sub(1, -2)
+  return utils
+    .str_template(self.prompt_fmt, {
+      label = self.prompt_label and self.prompt_label .. " " or "",
+      flag_name = self.flag_name .. " ",
+    })
+    :sub(1, -2)
 end
 
 ---Render a single option value
@@ -117,14 +124,18 @@ function FlagOption:render_display(values)
     return true, self.flag_name
   end
 
-  local quoted = table.concat(vim.tbl_map(function(v)
-    return self:render_value(v)
-  end, values), " ")
+  local quoted = table.concat(
+    vim.tbl_map(function(v)
+      return self:render_value(v)
+    end, values),
+    " "
+  )
 
-  return false, utils.str_template(self.display_fmt, {
-    flag_name = self.flag_name,
-    values = quoted,
-  })
+  return false,
+    utils.str_template(self.display_fmt, {
+      flag_name = self.flag_name,
+      values = quoted,
+    })
 end
 
 ---Render the default text for |input()|.

--- a/lua/diffview/vcs/init.lua
+++ b/lua/diffview/vcs/init.lua
@@ -1,8 +1,8 @@
 local config = require("diffview.config")
-local GitAdapter = require('diffview.vcs.adapters.git').GitAdapter
-local HgAdapter = require('diffview.vcs.adapters.hg').HgAdapter
-local JjAdapter = require('diffview.vcs.adapters.jj').JjAdapter
-local P4Adapter = require('diffview.vcs.adapters.p4').P4Adapter
+local GitAdapter = require("diffview.vcs.adapters.git").GitAdapter
+local HgAdapter = require("diffview.vcs.adapters.hg").HgAdapter
+local JjAdapter = require("diffview.vcs.adapters.jj").JjAdapter
+local P4Adapter = require("diffview.vcs.adapters.p4").P4Adapter
 
 local M = {}
 
@@ -40,8 +40,12 @@ function M.get_adapter(opt)
     local path_args
     local top_indicators = opt.top_indicators
 
-    if not kind.bootstrap.done then kind.run_bootstrap() end
-    if not kind.bootstrap.ok then goto continue end
+    if not kind.bootstrap.done then
+      kind.run_bootstrap()
+    end
+    if not kind.bootstrap.ok then
+      goto continue
+    end
 
     if not top_indicators then
       path_args, top_indicators = kind.get_repo_paths(opt.cmd_ctx.path_args, opt.cmd_ctx.cpath)

--- a/lua/diffview/vcs/log_entry.lua
+++ b/lua/diffview/vcs/log_entry.lua
@@ -28,11 +28,13 @@ function LogEntry:init(opt)
   self.nulled = utils.sate(opt.nulled, false)
   -- NOTE: This only detects commits at remote branch/tag tips via %D
   -- decorations, not full reachability from upstream.
-  self.has_remote_ref = opt.commit and opt.commit.ref_names
-    and (opt.commit.ref_names:find("origin/")
-      or opt.commit.ref_names:find("upstream/")
-      or opt.commit.ref_names:find("remotes/"))
-    and true or false
+  self.has_remote_ref = opt.commit
+      and opt.commit.ref_names
+      and (opt.commit.ref_names:find("origin/") or opt.commit.ref_names:find("upstream/") or opt.commit.ref_names:find(
+        "remotes/"
+      ))
+      and true
+    or false
   self:update_status()
   self:update_stats()
 end
@@ -86,7 +88,9 @@ end
 ---@param path string
 ---@return diff.FileEntry?
 function LogEntry:get_diff(path)
-  if not self.commit.diff then return nil end
+  if not self.commit.diff then
+    return nil
+  end
 
   for _, diff_entry in ipairs(self.commit.diff) do
     if path == (diff_entry.path_new or diff_entry.path_old) then
@@ -101,12 +105,10 @@ end
 function LogEntry.new_null_entry(adapter, opt)
   opt = opt or {}
 
-  return LogEntry(
-    vim.tbl_extend("force", opt, {
-      nulled = true,
-      files = { FileEntry.new_null_entry(adapter) },
-    })
-  )
+  return LogEntry(vim.tbl_extend("force", opt, {
+    nulled = true,
+    files = { FileEntry.new_null_entry(adapter) },
+  }))
 end
 
 M.LogEntry = LogEntry

--- a/lua/diffview/vcs/rev.lua
+++ b/lua/diffview/vcs/rev.lua
@@ -4,10 +4,10 @@ local M = {}
 
 ---@enum RevType
 local RevType = oop.enum({
-  LOCAL   = 1,
-  COMMIT  = 2,
-  STAGE   = 3,
-  CUSTOM  = 4,
+  LOCAL = 1,
+  COMMIT = 2,
+  STAGE = 3,
+  CUSTOM = 4,
 })
 
 ---@alias RevRange { first: Rev, last: Rev }
@@ -33,10 +33,7 @@ function Rev:init(rev_type, revision, track_head)
   if t == "string" then
     assert(revision ~= "", "'revision' cannot be an empty string!")
   elseif t == "number" then
-    assert(
-      revision >= 0 and revision <= 3,
-      "'revision' must be a valid stage number ([0-3])!"
-    )
+    assert(revision >= 0 and revision <= 3, "'revision' must be a valid stage number ([0-3])!")
   end
 
   t = type(track_head)
@@ -73,7 +70,9 @@ end
 ---@param rev_from Rev|string
 ---@param rev_to? Rev|string
 ---@return string?
-function Rev.to_range(rev_from, rev_to) oop.abstract_stub() end
+function Rev.to_range(rev_from, rev_to)
+  oop.abstract_stub()
+end
 
 ---@param name string
 ---@param adapter? VCSAdapter
@@ -124,8 +123,12 @@ end
 ---@param b Rev?
 ---@return boolean
 function M.same_rev(a, b)
-  if a == nil and b == nil then return true end
-  if a == nil or b == nil then return false end
+  if a == nil and b == nil then
+    return true
+  end
+  if a == nil or b == nil then
+    return false
+  end
   return a.type == b.type
     and a.commit == b.commit
     and a.stage == b.stage

--- a/lua/diffview/vcs/utils.lua
+++ b/lua/diffview/vcs/utils.lua
@@ -54,11 +54,11 @@ end
 
 ---@enum JobStatus
 local JobStatus = oop.enum({
-  SUCCESS  = 1,
+  SUCCESS = 1,
   PROGRESS = 2,
-  ERROR    = 3,
-  KILLED   = 4,
-  FATAL    = 5,
+  ERROR = 3,
+  KILLED = 4,
+  FATAL = 5,
 })
 
 ---@type diffview.Job[]
@@ -77,12 +77,16 @@ local job_watchdogs = {}
 ---@param job diffview.Job
 local function start_job_watchdog(job)
   local timer = uv.new_timer()
-  if not timer then return end
+  if not timer then
+    return
+  end
 
   job_watchdogs[job] = timer
 
   timer:start(SYNC_JOB_TIMEOUT, 0, function()
-    if not timer:is_closing() then timer:close() end
+    if not timer:is_closing() then
+      timer:close()
+    end
     job_watchdogs[job] = nil
 
     if not job:is_done() then
@@ -97,7 +101,9 @@ end
 local function cancel_job_watchdog(job)
   local timer = job_watchdogs[job]
   if timer then
-    if not timer:is_closing() then timer:close() end
+    if not timer:is_closing() then
+      timer:close()
+    end
     job_watchdogs[job] = nil
   end
 end
@@ -150,20 +156,13 @@ M.diff_file_list = async.wrap(function(adapter, left, right, path_args, dv_opt, 
   local files = FileDict()
   local rev_args = adapter:rev_to_args(left, right)
   local errors = {}
-
-  ;(function()
+  (function()
     local err, tfiles, tconflicts = await(
-      adapter:tracked_files(
-        left,
-        right,
-        utils.vec_join(rev_args, "--", path_args),
-        "working",
-        opt
-      )
+      adapter:tracked_files(left, right, utils.vec_join(rev_args, "--", path_args), "working", opt)
     )
 
     if err then
-      errors[#errors+1] = err
+      errors[#errors + 1] = err
       utils.err("Failed to get git status for tracked files!", true)
       return
     end
@@ -171,17 +170,20 @@ M.diff_file_list = async.wrap(function(adapter, left, right, path_args, dv_opt, 
     files:set_working(tfiles)
     files:set_conflicting(tconflicts)
 
-    if not adapter:show_untracked({
+    if
+      not adapter:show_untracked({
         dv_opt = dv_opt,
         revs = { left = left, right = right },
       })
-    then return end
+    then
+      return
+    end
 
     ---@diagnostic disable-next-line: redefined-local
     local err, ufiles = await(adapter:untracked_files(left, right, opt))
 
     if err then
-      errors[#errors+1] = err
+      errors[#errors + 1] = err
       utils.err("Failed to get git status for untracked files!", true)
     else
       files:set_working(utils.vec_join(files.working, ufiles))
@@ -207,7 +209,7 @@ M.diff_file_list = async.wrap(function(adapter, left, right, path_args, dv_opt, 
     )
 
     if err then
-      errors[#errors+1] = err
+      errors[#errors + 1] = err
       utils.err("Failed to get git status for staged files!", true)
     else
       files:set_staged(tfiles)
@@ -326,7 +328,6 @@ local function parse_diff_hunk(scanner, old_row, old_size, new_row, new_size)
     if cur_start == " " then
       ret.common_content[#ret.common_content + 1] = line:sub(2) or ""
       common_idx = common_idx + 1
-
     elseif cur_start == "-" then
       local content = { line:sub(2) or "" }
 
@@ -336,7 +337,6 @@ local function parse_diff_hunk(scanner, old_row, old_size, new_row, new_size)
 
       ret.old_content[#ret.old_content + 1] = { common_idx + old_offset, content }
       old_offset = old_offset + #content
-
     elseif cur_start == "+" then
       local content = { line:sub(2) or "" }
 
@@ -378,8 +378,9 @@ local function parse_file_diff(scanner)
   -- The current line will here be the diff header
 
   -- Extended git diff headers
-  while scanner:peek_line() and
-    not is_diff_header(scanner:peek_line() or "")
+  while
+    scanner:peek_line()
+    and not is_diff_header(scanner:peek_line() or "")
     and not (scanner:peek_line() or ""):match(DIFF_HUNK_HEADER)
   do
     -- Extended header lines:
@@ -498,13 +499,16 @@ local function parse_file_diff(scanner)
     scanner:next_line() -- Current line is now the hunk header
 
     if old_row then
-      table.insert(ret.hunks, parse_diff_hunk(
-        scanner,
-        tonumber(old_row) or -1,
-        tonumber(old_size) or -1,
-        tonumber(new_row) or -1,
-        tonumber(new_size) or -1
-      ))
+      table.insert(
+        ret.hunks,
+        parse_diff_hunk(
+          scanner,
+          tonumber(old_row) or -1,
+          tonumber(old_size) or -1,
+          tonumber(new_row) or -1,
+          tonumber(new_size) or -1
+        )
+      )
     end
 
     line = scanner:peek_line()
@@ -592,20 +596,20 @@ function M.parse_conflicts(lines, winid)
 
   local function handle(data)
     local first = math.min(
-     data.ours.first or math.huge,
-     data.base.first or math.huge,
-     data.theirs.first or math.huge
+      data.ours.first or math.huge,
+      data.base.first or math.huge,
+      data.theirs.first or math.huge
     )
 
-    if first == math.huge then return end
+    if first == math.huge then
+      return
+    end
 
-    local last = math.max(
-      data.ours.last or -1,
-      data.base.last or -1,
-      data.theirs.last or -1
-    )
+    local last = math.max(data.ours.last or -1, data.base.last or -1, data.theirs.last or -1)
 
-    if last == -1 then return end
+    if last == -1 then
+      return
+    end
 
     if data.ours.first and data.ours.last and data.ours.first < data.ours.last then
       data.ours.content = utils.vec_slice(lines, data.ours.first + 1, data.ours.last)
@@ -717,7 +721,6 @@ function M.check_semver(version, required)
   end
   return true
 end
-
 
 M.JobStatus = JobStatus
 return M

--- a/stylua.toml
+++ b/stylua.toml
@@ -4,4 +4,5 @@ indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
 call_parentheses = "Always"
-collapse_simple_statement = "Always"
+collapse_simple_statement = "Never"
+syntax = "LuaJIT"


### PR DESCRIPTION
The `stylua.toml` is inconsistent with the code base as it hasn't been enforced. This brings it back into sync and enforces the style in the CI.