### PR TITLE
feat(inline): add `view.inline.deletion_highlight` option

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -873,6 +873,19 @@ view.inline                                     *diffview-config-view.inline*
                       deletions (default: `DiffDelete` colours +
                       `strikethrough`; override with |:hi| to customise).
 
+            {deletion_highlight} ("text"|"full_width"|"hanging")
+                How far the |hl-DiffDelete| background extends on the
+                virtual lines used to render deletions. Default:
+                `"text"`.
+
+                • `"text"`: the highlight covers exactly the deleted
+                  characters.
+                • `"full_width"`: the background spans the row (matching
+                  `diff2_horizontal`'s native |hl-DiffDelete| look).
+                • `"hanging"`: leading whitespace is emitted without a
+                  highlight; the rest of the row carries
+                  |hl-DiffDelete|.
+
 file_panel                                      *diffview-config-file_panel*
         Type: `table`, Default: (see defaults)
 

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -347,11 +347,14 @@ M.defaults = {
     },
 
     ---@alias DiffviewInlineStyle "unified"|"overleaf"
+    ---@alias DiffviewInlineDeletionHighlight "text"|"full_width"|"hanging"
     ---@class DiffviewInlineConfig
     ---@field style DiffviewInlineStyle
+    ---@field deletion_highlight DiffviewInlineDeletionHighlight
 
     ---@class DiffviewInlineConfig.user
     ---@field style? DiffviewInlineStyle Rendering style for `diff1_inline`. "unified" shows old lines as virt_lines above; "overleaf" renders deletions as inline strikethrough virt_text.
+    ---@field deletion_highlight? DiffviewInlineDeletionHighlight Extent of the `DiffDelete` background on deleted virt_lines: `"text"` covers only the deleted chars, `"full_width"` pads to the row, `"hanging"` covers everything except the leading indent.
     -- Options specific to the `diff1_inline` layout.
     inline = {
       -- Rendering style. "unified": proper unified diff — old lines shown
@@ -359,6 +362,13 @@ M.defaults = {
       -- "overleaf": deleted chars on modified lines rendered inline as
       -- strikethrough virtual text (Overleaf-editor style); no block echo.
       style = "unified",
+      -- How far the `DiffDelete` background extends on deleted virt_lines:
+      --   "text":       just the deleted characters.
+      --   "full_width": highlight the row, which matches `diff2_horizontal`'s
+      --                 native look.
+      --   "hanging":    skip the leading indent, then highlight the rest of
+      --                 the row.
+      deletion_highlight = "text",
     },
   },
 
@@ -1182,6 +1192,18 @@ function M.setup(user_config)
         )
       )
       view.inline.style = M.defaults.view.inline.style
+    end
+    local valid_deletion_hl = { "text", "full_width", "hanging" }
+    if view.inline.deletion_highlight == nil then
+      view.inline.deletion_highlight = M.defaults.view.inline.deletion_highlight
+    elseif not vim.tbl_contains(valid_deletion_hl, view.inline.deletion_highlight) then
+      utils.err(
+        ("Invalid value '%s' for 'view.inline.deletion_highlight'! Must be one of (%s)."):format(
+          view.inline.deletion_highlight,
+          fmt_enum(valid_deletion_hl)
+        )
+      )
+      view.inline.deletion_highlight = M.defaults.view.inline.deletion_highlight
     end
   end
 

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -24,6 +24,15 @@ local M = {}
 
 M.ns = api.nvim_create_namespace("diffview_inline_diff")
 
+-- Upper bound on the padded width used by `deletion_highlight = "full_width"`.
+-- The actual pad target is `min(vim.o.columns, DELETION_HL_WIDTH_CAP)`. The
+-- editor-wide `vim.o.columns` is an upper bound on any window's text area,
+-- and this cap guards against pathological `:set columns=…` values that
+-- would allocate huge space strings per virt_line. Virt_lines past a
+-- window's edge are clipped, so over-padding within reasonable bounds is
+-- free.
+local DELETION_HL_WIDTH_CAP = 250
+
 -- Iterate over UTF-8 characters in `s`. Each step yields the character
 -- substring, its 0-indexed byte offset, and its byte length. Pure-Lua O(n)
 -- traversal: avoids the quadratic cost of `vim.fn.strcharpart(s, i, 1)` in
@@ -455,7 +464,15 @@ local function render_char_highlights(bufnr, new_row, old_line, new_line, inline
   return "ok"
 end
 
--- Attach a block of deleted lines as virtual lines near `new_start`.
+-- Attach a block of deleted lines as virtual lines near `new_start`. The
+-- `extent` argument controls how far the `del_hl` background reaches:
+--   • `"text"`:       only the deleted characters carry `del_hl`.
+--   • `"full_width"`: append a space-padded chunk under `del_hl` so the
+--                     highlight spans the row (matching
+--                     `diff2_horizontal`'s native `DiffDelete` look). Pad
+--                     target is `min(vim.o.columns, DELETION_HL_WIDTH_CAP)`.
+--   • `"hanging"`:    leading whitespace is emitted unhighlighted; the
+--                     remainder of the line carries `del_hl`.
 ---@param bufnr integer
 ---@param old_lines string[]
 ---@param old_from integer 1-based start index into `old_lines`.
@@ -464,6 +481,7 @@ end
 ---@param anchor_row? integer 0-indexed row to attach to; default `new_start - 1`.
 ---@param above? boolean Default: `new_start == 0`.
 ---@param del_hl? string Highlight group for the deleted text. Default: `DiffviewDiffDelete`.
+---@param extent? "text"|"full_width"|"hanging" Default: `"text"`.
 local function render_deleted_block(
   bufnr,
   old_lines,
@@ -472,15 +490,45 @@ local function render_deleted_block(
   new_start,
   anchor_row,
   above,
-  del_hl
+  del_hl,
+  extent
 )
   del_hl = del_hl or "DiffviewDiffDelete"
+  extent = extent or "text"
   local virt_lines = {}
-  for k = old_from, old_to do
-    virt_lines[#virt_lines + 1] = {
-      { old_lines[k] or "", del_hl },
-    }
-  end
+  -- `strdisplaywidth` reads `tabstop` from the current buffer; evaluate
+  -- widths against `bufnr` so tab-bearing deletions pad correctly when
+  -- the caller's current buffer differs.
+  api.nvim_buf_call(bufnr, function()
+    for k = old_from, old_to do
+      local text = old_lines[k] or ""
+      local chunks
+      if extent == "full_width" then
+        chunks = { { text, del_hl } }
+        local pad = math.min(vim.o.columns, DELETION_HL_WIDTH_CAP) - vim.fn.strdisplaywidth(text)
+        if pad > 0 then
+          chunks[#chunks + 1] = { string.rep(" ", pad), del_hl }
+        end
+      elseif extent == "hanging" then
+        local indent, rest = text:match("^(%s*)(.*)$")
+        if rest ~= "" then
+          chunks = {}
+          if indent ~= "" then
+            chunks[#chunks + 1] = { indent }
+          end
+          chunks[#chunks + 1] = { rest, del_hl }
+        else
+          -- Empty or all-whitespace line: no "rest" to highlight without
+          -- making the row invisible. Fall back to highlighting the whole
+          -- line so the deletion stays visible.
+          chunks = { { text, del_hl } }
+        end
+      else
+        chunks = { { text, del_hl } }
+      end
+      virt_lines[#virt_lines + 1] = chunks
+    end
+  end)
 
   if #virt_lines == 0 then
     return
@@ -815,6 +863,7 @@ end
 ---@field ignore_whitespace_change_at_eol? boolean
 ---@field ignore_blank_lines? boolean
 ---@field style? "unified"|"overleaf" Default: `"unified"`.
+---@field deletion_highlight? "text"|"full_width"|"hanging" Extent of the `del_hl` background on virt_line deletions. Default: `"text"`.
 
 ---@class InlineDiffStyle
 ---@field del_hl string Highlight group for virt_line deletions.
@@ -852,6 +901,7 @@ local STYLES = {
 function M.render(bufnr, old_lines, new_lines, opts)
   opts = opts or {}
   local style = STYLES[opts.style] or STYLES.unified
+  local extent = opts.deletion_highlight or "text"
   M.clear(bufnr)
 
   if not api.nvim_buf_is_valid(bufnr) then
@@ -930,7 +980,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
         new_start,
         nil,
         nil,
-        style.del_hl
+        style.del_hl,
+        extent
       )
     elseif old_count > 0 and new_count > 0 then
       -- Modification: unified and overleaf diverge on how deletions are
@@ -949,7 +1000,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
           new_start,
           new_start - 1,
           true,
-          style.del_hl
+          style.del_hl,
+          extent
         )
       elseif old_count > paired then
         -- Overleaf: overflow old lines still get a virt_line above.
@@ -962,7 +1014,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
           new_start,
           anchor,
           false,
-          style.del_hl
+          style.del_hl,
+          extent
         )
       end
 
@@ -998,7 +1051,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
             new_start + k,
             row,
             true,
-            "DiffviewDiffDelete"
+            "DiffviewDiffDelete",
+            extent
           )
         end
       end

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -164,6 +164,7 @@ local function render_opts()
   local opts = effective_diffopt()
   local inline_opt = config.get_config().view.inline or {}
   opts.style = inline_opt.style
+  opts.deletion_highlight = inline_opt.deletion_highlight
   return opts
 end
 

--- a/lua/diffview/tests/functional/config_options_spec.lua
+++ b/lua/diffview/tests/functional/config_options_spec.lua
@@ -186,3 +186,40 @@ describe("view.inline.style", function()
     assert.equals("unified", conf.view.inline.style)
   end)
 end)
+
+describe("view.inline.deletion_highlight", function()
+  local original
+  local utils = require("diffview.utils")
+  local orig_err
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+    orig_err = utils.err
+    utils.err = function() end
+  end)
+
+  after_each(function()
+    config.setup(original)
+    utils.err = orig_err
+  end)
+
+  it("defaults to 'text'", function()
+    local conf = setup_with({})
+    assert.equals("text", conf.view.inline.deletion_highlight)
+  end)
+
+  it("accepts 'full_width'", function()
+    local conf = setup_with({ view = { inline = { deletion_highlight = "full_width" } } })
+    assert.equals("full_width", conf.view.inline.deletion_highlight)
+  end)
+
+  it("accepts 'hanging'", function()
+    local conf = setup_with({ view = { inline = { deletion_highlight = "hanging" } } })
+    assert.equals("hanging", conf.view.inline.deletion_highlight)
+  end)
+
+  it("rejects unknown values and falls back to the default", function()
+    local conf = setup_with({ view = { inline = { deletion_highlight = "bogus" } } })
+    assert.equals("text", conf.view.inline.deletion_highlight)
+  end)
+end)

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -366,6 +366,131 @@ describe("diffview.scene.inline_diff", function()
     end)
   end)
 
+  describe("deletion_highlight", function()
+    local function virt_line_chunks(marks)
+      local out = {}
+      for _, m in ipairs(marks) do
+        if m[4] and m[4].virt_lines then
+          for _, line in ipairs(m[4].virt_lines) do
+            out[#out + 1] = line
+          end
+        end
+      end
+      return out
+    end
+
+    -- The cap value mirrors `DELETION_HL_WIDTH_CAP` in `inline_diff.lua`.
+    -- Kept as a literal so a drift in the source value is caught here.
+    local FULL_WIDTH_CAP = 250
+
+    it("'full_width' appends a padding chunk under the same hl, sized by display width", function()
+      -- Tab + "hi" with tabstop=4 = 6 display cells; padding fills out
+      -- the rest of `vim.o.columns`. `nvim_buf_call` ensures
+      -- `strdisplaywidth` reads the target buffer's tabstop even when
+      -- the active buffer differs.
+      local target = fresh_buf({ "tail" })
+      vim.api.nvim_set_option_value("tabstop", 4, { buf = target })
+      local other = fresh_buf({ "" })
+      vim.api.nvim_set_option_value("tabstop", 8, { buf = other })
+      api.nvim_win_set_buf(api.nvim_get_current_win(), other)
+
+      inline_diff.render(
+        target,
+        { "\thi", "tail" },
+        { "tail" },
+        { deletion_highlight = "full_width" }
+      )
+
+      local lines = virt_line_chunks(extmarks(target))
+      assert.are.equal(1, #lines)
+      local chunks = lines[1]
+      assert.are.equal(2, #chunks)
+      assert.are.equal("DiffviewDiffDelete", chunks[1][2])
+      assert.are.equal("DiffviewDiffDelete", chunks[2][2])
+      assert.are.equal(math.min(vim.o.columns, FULL_WIDTH_CAP) - 6, #chunks[2][1])
+    end)
+
+    it("'full_width' pads in overleaf style under the overleaf del_hl", function()
+      local bufnr = fresh_buf({ "alpha" })
+      inline_diff.render(
+        bufnr,
+        { "xyz", "pqr" },
+        { "alpha" },
+        { style = "overleaf", deletion_highlight = "full_width" }
+      )
+
+      local lines = virt_line_chunks(extmarks(bufnr))
+      assert.is_true(#lines > 0)
+      for _, chunks in ipairs(lines) do
+        -- Every virt_line must carry both a text chunk and a padding chunk
+        -- under the overleaf del_hl so the background stays consistent.
+        assert.are.equal(2, #chunks)
+        for _, chunk in ipairs(chunks) do
+          assert.are.equal("DiffviewDiffDeleteInline", chunk[2])
+        end
+      end
+    end)
+
+    it("'text' emits a single chunk covering only the deleted characters", function()
+      local bufnr = fresh_buf({ "tail" })
+      inline_diff.render(bufnr, { "deleted", "tail" }, { "tail" }, { deletion_highlight = "text" })
+
+      local lines = virt_line_chunks(extmarks(bufnr))
+      assert.are.equal(1, #lines)
+      local chunks = lines[1]
+      assert.are.equal(1, #chunks)
+      assert.are.equal("deleted", chunks[1][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[1][2])
+    end)
+
+    it("'hanging' splits leading whitespace off the highlight", function()
+      local bufnr = fresh_buf({ "tail" })
+      inline_diff.render(
+        bufnr,
+        { "  indented", "tail" },
+        { "tail" },
+        { deletion_highlight = "hanging" }
+      )
+
+      local lines = virt_line_chunks(extmarks(bufnr))
+      assert.are.equal(1, #lines)
+      local chunks = lines[1]
+      assert.are.equal(2, #chunks)
+      -- Leading whitespace chunk: no hl_group set (single-element chunk).
+      assert.are.equal("  ", chunks[1][1])
+      assert.is_nil(chunks[1][2])
+      -- Remainder gets the deletion highlight.
+      assert.are.equal("indented", chunks[2][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[2][2])
+    end)
+
+    it("'hanging' on a non-indented line emits the whole text under del_hl", function()
+      local bufnr = fresh_buf({ "tail" })
+      inline_diff.render(bufnr, { "plain", "tail" }, { "tail" }, { deletion_highlight = "hanging" })
+
+      local lines = virt_line_chunks(extmarks(bufnr))
+      assert.are.equal(1, #lines)
+      local chunks = lines[1]
+      assert.are.equal(1, #chunks)
+      assert.are.equal("plain", chunks[1][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[1][2])
+    end)
+
+    it("'hanging' on an all-whitespace line still highlights the row", function()
+      -- Defensive fallback: a deleted blank/all-whitespace line must remain
+      -- visible as a deletion rather than collapsing to a zero-chunk virt_line.
+      local bufnr = fresh_buf({ "tail" })
+      inline_diff.render(bufnr, { "   ", "tail" }, { "tail" }, { deletion_highlight = "hanging" })
+
+      local lines = virt_line_chunks(extmarks(bufnr))
+      assert.are.equal(1, #lines)
+      local chunks = lines[1]
+      assert.are.equal(1, #chunks)
+      assert.are.equal("   ", chunks[1][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[1][2])
+    end)
+  end)
+
   describe("hunk navigation", function()
     -- Set up a buffer with three discontiguous hunks: pure add at top,
     -- change in the middle, and pure deletion at the end.


### PR DESCRIPTION
Configure the extent of the `DiffDelete` background on deleted virt_lines in the `diff1_inline` layout: `"text"` (default — just the deleted chars), `"full_width"` (pad to `min(&columns, 250)` so the highlight spans the row, matching `diff2_horizontal`'s native look), or `"hanging"` (skip the leading indent).

