### PR TITLE
feat(inline): layer tree-sitter highlights over deleted virt_lines

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -893,6 +893,15 @@ view.inline                                     *diffview-config-view.inline*
                   highlight; the rest of the row carries
                   |hl-DiffDelete|.
 
+            {deletion_treesitter} (boolean)
+                Layer tree-sitter syntax highlights over the deleted
+                virtual lines so they read like the rest of the buffer.
+                Default: `true`. No-op when no parser is attached for
+                the buffer's filetype. Composes orthogonally with
+                {deletion_highlight}: the background extent is
+                unchanged, only the foreground colouring of the deleted
+                text is affected.
+
 file_panel                                      *diffview-config-file_panel*
         Type: `table`, Default: (see defaults)
 

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -351,10 +351,12 @@ M.defaults = {
     ---@class DiffviewInlineConfig
     ---@field style DiffviewInlineStyle
     ---@field deletion_highlight DiffviewInlineDeletionHighlight
+    ---@field deletion_treesitter boolean
 
     ---@class DiffviewInlineConfig.user
     ---@field style? DiffviewInlineStyle Rendering style for `diff1_inline`. "unified" shows old lines as virt_lines above; "overleaf" renders deletions as inline strikethrough virt_text.
     ---@field deletion_highlight? DiffviewInlineDeletionHighlight Extent of the `DiffDelete` background on deleted virt_lines: `"text"` covers only the deleted chars, `"full_width"` pads to the row, `"hanging"` covers everything except the leading indent.
+    ---@field deletion_treesitter? boolean Layer tree-sitter syntax highlights over the deleted virt_lines so they read like the rest of the buffer. Falls back transparently when no parser is attached.
     -- Options specific to the `diff1_inline` layout.
     inline = {
       -- Rendering style. "unified": proper unified diff — old lines shown
@@ -369,6 +371,10 @@ M.defaults = {
       --   "hanging":    skip the leading indent, then highlight the rest of
       --                 the row.
       deletion_highlight = "text",
+      -- Layer tree-sitter syntax highlights over the deleted virt_lines so
+      -- they read like the rest of the buffer. No-op when no parser is
+      -- attached for the buffer's filetype.
+      deletion_treesitter = true,
     },
   },
 
@@ -1204,6 +1210,16 @@ function M.setup(user_config)
         )
       )
       view.inline.deletion_highlight = M.defaults.view.inline.deletion_highlight
+    end
+    if view.inline.deletion_treesitter == nil then
+      view.inline.deletion_treesitter = M.defaults.view.inline.deletion_treesitter
+    elseif type(view.inline.deletion_treesitter) ~= "boolean" then
+      utils.err(
+        ("Invalid value '%s' for 'view.inline.deletion_treesitter'! Must be a boolean."):format(
+          tostring(view.inline.deletion_treesitter)
+        )
+      )
+      view.inline.deletion_treesitter = M.defaults.view.inline.deletion_treesitter
     end
   end
 

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -592,6 +592,179 @@ local function render_char_highlights(bufnr, new_row, old_line, new_line, inline
   return "ok"
 end
 
+-- A single tree-sitter capture span on one line: `{col_start, col_end,
+-- hl_group}`, with byte-0-indexed columns and `hl_group` in `@<capture>`
+-- form.
+---@alias InlineDiff.LineCapture { [1]: integer, [2]: integer, [3]: string }
+
+-- Cap on the total source length (`#source`) above which
+-- `compute_old_line_captures` short-circuits to `{}` rather than parsing.
+-- A full TS parse + highlights-query iteration is synchronous and runs
+-- on every render that touches a deletion-bearing call site (modulo the
+-- `M._captures_by_buf` cache hit), so a large source — e.g. a deletion
+-- spanning a generated/minified file — would block the UI. The per-line
+-- `CAPTURED_CHUNKS_MAX_LEN` cap protects the chunk builder but does
+-- nothing about the parse cost, which is what this cap is for. Sized
+-- around the upper bound of a hand-written deletion block: a
+-- thousand-line file averaging 100 chars/line is ~100 KB, and anything
+-- larger is almost certainly generated content the user didn't expect
+-- to syntax-highlight.
+local CAPTURE_SOURCE_MAX_LEN = 100000
+
+-- Compute per-line tree-sitter captures for `old_lines` using the buffer's
+-- filetype to pick the parser. Returns a table mapping 1-based line index to
+-- a list of `InlineDiff.LineCapture` entries. Multi-line captures (e.g.
+-- multi-line strings or comments) are split into one entry per spanned line
+-- so the per-line chunk builder can apply them without crossing line
+-- boundaries. Returns an empty table whenever any required piece is missing
+-- — no filetype, no language mapping, parser not installed, parse failure,
+-- no highlights query, or source larger than `CAPTURE_SOURCE_MAX_LEN` — so
+-- callers can unconditionally treat the result as "captures or nothing."
+-- `source` is optional; when supplied (e.g. by `M.render`, which already
+-- joined `old_lines` for `vim.diff`), it's reused as the parser input,
+-- avoiding a second O(N) `table.concat`. A trailing newline is harmless.
+---@param old_lines string[]
+---@param bufnr integer
+---@param source? string Pre-joined `old_lines` (`"\n"`-separated). Computed if omitted.
+---@return table<integer, InlineDiff.LineCapture[]>
+local function compute_old_line_captures(old_lines, bufnr, source)
+  if #old_lines == 0 or not api.nvim_buf_is_valid(bufnr) then
+    return {}
+  end
+
+  local ft = vim.bo[bufnr].filetype
+  if not ft or ft == "" then
+    return {}
+  end
+
+  local lang = vim.treesitter.language.get_lang(ft)
+  if not lang then
+    return {}
+  end
+
+  source = source or table.concat(old_lines, "\n")
+  if #source > CAPTURE_SOURCE_MAX_LEN then
+    return {}
+  end
+  -- `get_string_parser` loads the parser shared library on first use; pcall
+  -- catches the "parser not installed" path so we degrade silently rather
+  -- than surfacing a stack trace through every render.
+  local ok_parser, parser = pcall(vim.treesitter.get_string_parser, source, lang)
+  if not ok_parser or not parser then
+    return {}
+  end
+
+  -- Wrap parse + capture iteration in pcall: injection-language failures,
+  -- malformed queries, or runtime errors inside predicates can throw, and
+  -- a render-time exception would be more disruptive than missing colour.
+  local ok, result = pcall(function()
+    local trees = parser:parse(true)
+    if not trees or not trees[1] then
+      return nil
+    end
+    local root = trees[1]:root()
+
+    local query = vim.treesitter.query.get(lang, "highlights")
+    if not query then
+      return nil
+    end
+
+    local out = {}
+    local function add(line_idx, col_start, col_end, hl)
+      out[line_idx] = out[line_idx] or {}
+      out[line_idx][#out[line_idx] + 1] = { col_start, col_end, hl }
+    end
+
+    for id, node in query:iter_captures(root, source) do
+      local capture = query.captures[id]
+      -- Underscore-prefixed captures are TS-internal scratch names used by
+      -- predicates; they don't map to highlight groups.
+      if not capture:match("^_") then
+        local sr, sc, er, ec = node:range()
+        local hl = "@" .. capture
+        if sr == er then
+          add(sr + 1, sc, ec, hl)
+        else
+          -- Multi-line capture: emit one entry per spanned line. Line `sr`
+          -- runs from `sc` to end-of-line; intermediate lines span the full
+          -- line; line `er` runs from 0 to `ec`.
+          add(sr + 1, sc, #(old_lines[sr + 1] or ""), hl)
+          for k = sr + 1, er - 1 do
+            add(k + 1, 0, #(old_lines[k + 1] or ""), hl)
+          end
+          add(er + 1, 0, ec, hl)
+        end
+      end
+    end
+
+    return out
+  end)
+
+  if not ok or not result then
+    return {}
+  end
+  return result
+end
+
+-- Cap on `text` length above which `captured_chunks` skips per-byte capture
+-- resolution and emits the plain `{ {text, del_hl} }` chunk. The per-byte
+-- pass is O(text_len) in time and memory, which gets pathological on
+-- minified-bundle lines (10s of KB). Mirrors the spirit of `'synmaxcol'`
+-- (Neovim's syntax-highlighting cutoff) with a higher bound, since this
+-- runs once per render rather than per redraw.
+local CAPTURED_CHUNKS_MAX_LEN = 5000
+
+-- Build virt_line chunks for `text`, layering tree-sitter captures on top of
+-- `del_hl` so deletions keep their background while showing TS colours on
+-- top. `caps` is a list of `{col_start, col_end, hl}` whose columns reference
+-- `text` directly — slice callers (e.g. the "hanging" extent) must offset
+-- before calling. Each output chunk uses `{del_hl, ts_hl}` so Neovim's
+-- left-to-right hl-group merging stacks the foreground over the background.
+-- With no captures (or `text` over `CAPTURED_CHUNKS_MAX_LEN`), returns the
+-- same `{ {text, del_hl} }` the pre-TS code produced. Empty `text` returns
+-- `{ { "", del_hl } }` rather than `{}` so a deleted blank line still
+-- renders as a virt_line row instead of being elided to nothing.
+---@param text string
+---@param caps InlineDiff.LineCapture[]?
+---@param del_hl string
+---@return table[]
+local function captured_chunks(text, caps, del_hl)
+  if text == "" or not caps or #caps == 0 or #text > CAPTURED_CHUNKS_MAX_LEN then
+    return { { text, del_hl } }
+  end
+
+  local len = #text
+  -- Resolve the most-specific (latest-applied) capture per byte. TS emits
+  -- captures in document order with later overriding earlier; mirroring
+  -- that here keeps the inline rendering consistent with how the same
+  -- buffer would highlight under `vim.treesitter.start`.
+  local hl_at = {}
+  for _, c in ipairs(caps) do
+    local sc, ec, hl = c[1], c[2], c[3]
+    -- Clamp to `len` so a stale or off-by-one capture can't write past
+    -- the string end and create a phantom chunk on the next iteration.
+    local stop = math.min(ec, len)
+    for i = sc + 1, stop do
+      hl_at[i] = hl
+    end
+  end
+
+  local chunks = {}
+  local segment_start = 1
+  local current = hl_at[1]
+  for i = 2, len do
+    if hl_at[i] ~= current then
+      local groups = current and { del_hl, current } or del_hl
+      chunks[#chunks + 1] = { text:sub(segment_start, i - 1), groups }
+      segment_start = i
+      current = hl_at[i]
+    end
+  end
+  local groups = current and { del_hl, current } or del_hl
+  chunks[#chunks + 1] = { text:sub(segment_start, len), groups }
+  return chunks
+end
+
 -- Attach a block of deleted lines as virtual lines near `new_start`. The
 -- `extent` argument controls how far the `del_hl` background reaches:
 --   • `"text"`:       only the deleted characters carry `del_hl`.
@@ -601,6 +774,10 @@ end
 --                     target is `full_width_target(bufnr)`.
 --   • `"hanging"`:    leading whitespace is emitted unhighlighted; the
 --                     remainder of the line carries `del_hl`.
+-- When `line_captures` is supplied, foreground tree-sitter highlights are
+-- layered on each line's chunks so the deleted text reads with syntax
+-- colour even though the lines themselves are virtual (and so unparsable
+-- by the buffer's own TS attachment).
 ---@param bufnr integer
 ---@param old_lines string[]
 ---@param old_from integer 1-based start index into `old_lines`.
@@ -611,6 +788,7 @@ end
 ---@param del_hl? string Highlight group for the deleted text. Default: `DiffviewDiffDelete`.
 ---@param extent? "text"|"full_width"|"hanging" Default: `"text"`.
 ---@param fw_target? integer Pad target for `extent == "full_width"`. Default: 0 (no padding).
+---@param line_captures? table<integer, InlineDiff.LineCapture[]> Per-`old_lines` index TS captures from `compute_old_line_captures`.
 local function render_deleted_block(
   bufnr,
   old_lines,
@@ -621,7 +799,8 @@ local function render_deleted_block(
   above,
   del_hl,
   extent,
-  fw_target
+  fw_target,
+  line_captures
 )
   del_hl = del_hl or "DiffviewDiffDelete"
   extent = extent or "text"
@@ -633,9 +812,10 @@ local function render_deleted_block(
   api.nvim_buf_call(bufnr, function()
     for k = old_from, old_to do
       local text = old_lines[k] or ""
+      local caps = line_captures and line_captures[k] or nil
       local chunks
       if extent == "full_width" then
-        chunks = { { text, del_hl } }
+        chunks = captured_chunks(text, caps, del_hl)
         local pad = fw_target - vim.fn.strdisplaywidth(text)
         if pad > 0 then
           chunks[#chunks + 1] = { string.rep(" ", pad), del_hl }
@@ -647,7 +827,26 @@ local function render_deleted_block(
           if indent ~= "" then
             chunks[#chunks + 1] = { indent }
           end
-          chunks[#chunks + 1] = { rest, del_hl }
+          -- Captures reference offsets in `text`; shift them to `rest`'s
+          -- coordinate space and drop entries that fell entirely inside
+          -- the unhighlighted indent.
+          local rest_caps
+          if caps then
+            local indent_len = #indent
+            rest_caps = {}
+            for _, c in ipairs(caps) do
+              if c[2] > indent_len then
+                rest_caps[#rest_caps + 1] = {
+                  math.max(0, c[1] - indent_len),
+                  c[2] - indent_len,
+                  c[3],
+                }
+              end
+            end
+          end
+          for _, rc in ipairs(captured_chunks(rest, rest_caps, del_hl)) do
+            chunks[#chunks + 1] = rc
+          end
         else
           -- Empty or all-whitespace line: no "rest" to highlight without
           -- making the row invisible. Fall back to highlighting the whole
@@ -655,7 +854,7 @@ local function render_deleted_block(
           chunks = { { text, del_hl } }
         end
       else
-        chunks = { { text, del_hl } }
+        chunks = captured_chunks(text, caps, del_hl)
       end
       virt_lines[#virt_lines + 1] = chunks
     end
@@ -696,6 +895,18 @@ end
 ---@type table<integer, integer[][]>
 M._hunks_by_buf = {}
 
+-- Per-buffer cache of tree-sitter captures for the old side. Survives
+-- `M.clear`/`M.render` so `_repaint`-style flows (where `old_lines` is held
+-- by the caller and reused unchanged) skip the parse on every redraw. The
+-- entry is matched by filetype + content equality on the joined old-side
+-- string `old`, so an in-place mutation of `old_lines` still invalidates
+-- (the next render rebuilds `old` and the comparison fails). String
+-- equality on `old` is O(N) but always cheaper than re-parsing + running
+-- the highlights query. Cleared by `M.detach` and by the same
+-- buffer-lifecycle autocmd as `_hunks_by_buf`.
+---@type table<integer, { ft: string, old: string, captures: table<integer, InlineDiff.LineCapture[]> }>
+M._captures_by_buf = {}
+
 -- Track which buffers already have a cleanup autocmd so we don't register
 -- duplicates across repeated render passes on the same buffer.
 ---@type table<integer, true>
@@ -724,6 +935,7 @@ local function register_cache_cleanup(bufnr)
     once = true,
     callback = function(args)
       M._hunks_by_buf[args.buf] = nil
+      M._captures_by_buf[args.buf] = nil
       cache_cleanup_registered[args.buf] = nil
       -- Buffer-scoped autocmds on the scroll-adjuster group are dropped by
       -- Neovim when the buffer is wiped, so only the registration flag needs
@@ -884,6 +1096,7 @@ function M.detach(bufnr)
   if not bufnr then
     return
   end
+  M._captures_by_buf[bufnr] = nil
   if scroll_adjuster_registered[bufnr] then
     scroll_adjuster_registered[bufnr] = nil
     if api.nvim_buf_is_valid(bufnr) then
@@ -995,6 +1208,7 @@ end
 ---@field ignore_blank_lines? boolean
 ---@field style? "unified"|"overleaf" Default: `"unified"`.
 ---@field deletion_highlight? "text"|"full_width"|"hanging" Extent of the `del_hl` background on virt_line deletions. Default: `"text"`.
+---@field deletion_treesitter? boolean Layer TS captures over deleted virt_lines. Default: `true`.
 
 ---@class InlineDiffStyle
 ---@field del_hl string Highlight group for virt_line deletions.
@@ -1095,6 +1309,49 @@ function M.render(bufnr, old_lines, new_lines, opts)
   -- traversal per block.
   local fw_target = extent == "full_width" and full_width_target(bufnr) or 0
 
+  -- TS captures for the entire old side, computed lazily and memoized:
+  -- the data is shared across every `render_deleted_block` call below
+  -- (each pure deletion or unified-style echo of an old line indexes
+  -- into it), so a single parse covers the render. Hunks with no
+  -- deletion-bearing call sites (e.g. pure-addition diffs, or overleaf
+  -- runs that take only the inline-strikethrough path) skip the parse
+  -- entirely. `compute_old_line_captures` returns an empty table when
+  -- TS is unavailable, which the chunk builder handles transparently.
+  --
+  -- The result is also cached across renders in `M._captures_by_buf`
+  -- so `_repaint`-style flows (re-render on `TextChanged` while
+  -- `old_lines` is held by the caller and reused) skip the parse on
+  -- every redraw. The cache is keyed by filetype + content equality
+  -- on the joined `old` string, so an in-place mutation of `old_lines`
+  -- still invalidates correctly on the next lookup.
+  --
+  -- Disabled when `opts.deletion_treesitter == false`: skip the parse
+  -- altogether and pass `nil` to `render_deleted_block`, which then
+  -- emits a single `del_hl` chunk per line.
+  local ts_enabled = opts.deletion_treesitter ~= false
+  local line_captures
+  local function get_line_captures()
+    if not ts_enabled then
+      return nil
+    end
+    if line_captures then
+      return line_captures
+    end
+    local ft = api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].filetype or ""
+    local entry = M._captures_by_buf[bufnr]
+    if entry and entry.ft == ft and entry.old == old then
+      line_captures = entry.captures
+    else
+      line_captures = compute_old_line_captures(old_lines, bufnr, old)
+      M._captures_by_buf[bufnr] = {
+        ft = ft,
+        old = old,
+        captures = line_captures,
+      }
+    end
+    return line_captures
+  end
+
   for _, h in ipairs(hunks) do
     local old_start, old_count, new_start, new_count = h[1], h[2], h[3], h[4]
 
@@ -1119,7 +1376,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
         nil,
         style.del_hl,
         extent,
-        fw_target
+        fw_target,
+        get_line_captures()
       )
     elseif old_count > 0 and new_count > 0 then
       -- Modification: unified and overleaf diverge on how deletions are
@@ -1140,7 +1398,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
           true,
           style.del_hl,
           extent,
-          fw_target
+          fw_target,
+          get_line_captures()
         )
       elseif old_count > paired then
         -- Overleaf: overflow old lines still get a virt_line above.
@@ -1155,7 +1414,8 @@ function M.render(bufnr, old_lines, new_lines, opts)
           false,
           style.del_hl,
           extent,
-          fw_target
+          fw_target,
+          get_line_captures()
         )
       end
 
@@ -1181,7 +1441,10 @@ function M.render(bufnr, old_lines, new_lines, opts)
 
         -- Overleaf fallback: when char-level was skipped and we're not
         -- already echoing old lines, show this paired old line above the
-        -- new one so the reader can see what changed.
+        -- new one so the reader can see what changed. Use the style's
+        -- own `del_hl` so the echoed line keeps the overleaf look (e.g.
+        -- the strikethrough on `DiffviewDiffDeleteInline`) rather than
+        -- silently downgrading to the unified `DiffviewDiffDelete`.
         if not style.echo_paired_old and char_result == "skipped" and ol ~= nl then
           render_deleted_block(
             bufnr,
@@ -1191,9 +1454,10 @@ function M.render(bufnr, old_lines, new_lines, opts)
             new_start + k,
             row,
             true,
-            "DiffviewDiffDelete",
+            style.del_hl,
             extent,
-            fw_target
+            fw_target,
+            get_line_captures()
           )
         end
       end
@@ -1229,6 +1493,8 @@ M._test = {
   diff_units = diff_units,
   refinement_safe = refinement_safe,
   INTRALINE_MAX_HUNKS = INTRALINE_MAX_HUNKS,
+  compute_old_line_captures = compute_old_line_captures,
+  captured_chunks = captured_chunks,
 }
 
 return M

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -172,6 +172,7 @@ local function render_opts()
   local inline_opt = config.get_config().view.inline or {}
   opts.style = inline_opt.style
   opts.deletion_highlight = inline_opt.deletion_highlight
+  opts.deletion_treesitter = inline_opt.deletion_treesitter
   return opts
 end
 

--- a/lua/diffview/tests/functional/config_options_spec.lua
+++ b/lua/diffview/tests/functional/config_options_spec.lua
@@ -223,3 +223,35 @@ describe("view.inline.deletion_highlight", function()
     assert.equals("text", conf.view.inline.deletion_highlight)
   end)
 end)
+
+describe("view.inline.deletion_treesitter", function()
+  local original
+  local utils = require("diffview.utils")
+  local orig_err
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+    orig_err = utils.err
+    utils.err = function() end
+  end)
+
+  after_each(function()
+    config.setup(original)
+    utils.err = orig_err
+  end)
+
+  it("defaults to true", function()
+    local conf = setup_with({})
+    assert.equals(true, conf.view.inline.deletion_treesitter)
+  end)
+
+  it("accepts false", function()
+    local conf = setup_with({ view = { inline = { deletion_treesitter = false } } })
+    assert.equals(false, conf.view.inline.deletion_treesitter)
+  end)
+
+  it("rejects non-boolean values and falls back to the default", function()
+    local conf = setup_with({ view = { inline = { deletion_treesitter = "yes" } } })
+    assert.equals(true, conf.view.inline.deletion_treesitter)
+  end)
+end)

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -95,6 +95,18 @@ describe("diffview.scene.inline_diff", function()
 
   local initial_winid
 
+  local function virt_line_chunks(marks)
+    local out = {}
+    for _, m in ipairs(marks) do
+      if m[4] and m[4].virt_lines then
+        for _, line in ipairs(m[4].virt_lines) do
+          out[#out + 1] = line
+        end
+      end
+    end
+    return out
+  end
+
   before_each(function()
     created_bufs = {}
     initial_winid = api.nvim_get_current_win()
@@ -383,18 +395,6 @@ describe("diffview.scene.inline_diff", function()
   end)
 
   describe("deletion_highlight", function()
-    local function virt_line_chunks(marks)
-      local out = {}
-      for _, m in ipairs(marks) do
-        if m[4] and m[4].virt_lines then
-          for _, line in ipairs(m[4].virt_lines) do
-            out[#out + 1] = line
-          end
-        end
-      end
-      return out
-    end
-
     -- Mirrors `DELETION_HL_WIDTH_CAP` in `inline_diff.lua`. Kept as a literal
     -- so a drift in the source value is caught here.
     local FULL_WIDTH_CAP = 500
@@ -876,7 +876,10 @@ describe("diffview.scene.inline_diff", function()
     it("falls back to block echo + line_hl in overleaf when char-level skips", function()
       -- When overleaf's char-level rendering is gated off, the paired
       -- modification would otherwise be invisible. Verify the fallback
-      -- emits a DiffChange line_hl and a virt_line with the old content.
+      -- emits a DiffChange line_hl and a virt_line with the old content
+      -- under the overleaf `del_hl` (so the strikethrough on
+      -- DiffviewDiffDeleteInline is preserved on the echoed line, not
+      -- silently downgraded to the unified DiffviewDiffDelete).
       local old = "This is a plain, singular window. This is available in case"
       local new = "This is a plain, singular window with no diff rendering —"
       local bufnr = fresh_buf({ new })
@@ -886,7 +889,7 @@ describe("diffview.scene.inline_diff", function()
       assert.are.same({ { row = 0, hl = "DiffviewDiffChange" } }, hls)
 
       local vls = virt_line_hls(extmarks(bufnr))
-      assert.are.same({ "DiffviewDiffDelete" }, vls)
+      assert.are.same({ "DiffviewDiffDeleteInline" }, vls)
     end)
   end)
 
@@ -1194,5 +1197,277 @@ describe("diffview.scene.inline_diff", function()
         assert.are.same({ "new string", "param" }, texts)
       end
     )
+  end)
+
+  describe("treesitter captures", function()
+    local captured_chunks = inline_diff._test.captured_chunks
+    local compute_old_line_captures = inline_diff._test.compute_old_line_captures
+
+    -- Probe whether the test environment has the `lua` parser; the end-to-end
+    -- TS tests below need it. When unavailable, the parser-dependent
+    -- assertions degrade to a no-op rather than fail the suite, since the
+    -- production code path also degrades silently.
+    local lua_parser_available = (function()
+      local ok = pcall(vim.treesitter.get_string_parser, "local x = 1\n", "lua")
+      return ok
+    end)()
+
+    it("captured_chunks falls back to a single chunk when no captures supplied", function()
+      assert.are.same(
+        { { "hello", "DiffviewDiffDelete" } },
+        captured_chunks("hello", nil, "DiffviewDiffDelete")
+      )
+      assert.are.same(
+        { { "hello", "DiffviewDiffDelete" } },
+        captured_chunks("hello", {}, "DiffviewDiffDelete")
+      )
+    end)
+
+    it("captured_chunks emits a single empty del_hl chunk for empty text", function()
+      -- Preserve the pre-TS shape so a deleted blank line still produces a
+      -- visible virt_line row (a zero-chunk list could be elided by Neovim's
+      -- renderer). Captures past `#text` are simply ignored.
+      assert.are.same(
+        { { "", "DiffviewDiffDelete" } },
+        captured_chunks("", { { 0, 5, "@string" } }, "DiffviewDiffDelete")
+      )
+    end)
+
+    it("captured_chunks layers a single capture over del_hl as stacked hl groups", function()
+      local chunks = captured_chunks("hello", { { 0, 5, "@string" } }, "DiffviewDiffDelete")
+      assert.are.equal(1, #chunks)
+      assert.are.equal("hello", chunks[1][1])
+      assert.are.same({ "DiffviewDiffDelete", "@string" }, chunks[1][2])
+    end)
+
+    it("captured_chunks splits text into per-capture segments around uncovered runs", function()
+      -- Cover only the middle "ll" so the outer "he"/"o" segments fall back
+      -- to plain del_hl.
+      local chunks = captured_chunks("hello", { { 2, 4, "@keyword" } }, "DiffviewDiffDelete")
+      assert.are.equal(3, #chunks)
+      assert.are.equal("he", chunks[1][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[1][2])
+      assert.are.equal("ll", chunks[2][1])
+      assert.are.same({ "DiffviewDiffDelete", "@keyword" }, chunks[2][2])
+      assert.are.equal("o", chunks[3][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[3][2])
+    end)
+
+    it("captured_chunks resolves overlapping captures to the latest applied", function()
+      -- Mirrors TS document order: a later capture overrides an earlier one
+      -- on the bytes they share. Outer "@variable" applies to all 5 bytes,
+      -- inner "@string" overrides bytes 1..3.
+      local chunks = captured_chunks(
+        "hello",
+        { { 0, 5, "@variable" }, { 1, 3, "@string" } },
+        "DiffviewDiffDelete"
+      )
+      -- Expect: [h:variable][el:string][lo:variable]
+      assert.are.equal(3, #chunks)
+      assert.are.same({ "DiffviewDiffDelete", "@variable" }, chunks[1][2])
+      assert.are.equal("h", chunks[1][1])
+      assert.are.same({ "DiffviewDiffDelete", "@string" }, chunks[2][2])
+      assert.are.equal("el", chunks[2][1])
+      assert.are.same({ "DiffviewDiffDelete", "@variable" }, chunks[3][2])
+      assert.are.equal("lo", chunks[3][1])
+    end)
+
+    it("captured_chunks clamps captures that extend past text end", function()
+      -- Off-by-one or stale captures past `#text` must not generate a phantom
+      -- chunk on the next iteration.
+      local chunks = captured_chunks("hi", { { 0, 100, "@string" } }, "DiffviewDiffDelete")
+      assert.are.equal(1, #chunks)
+      assert.are.equal("hi", chunks[1][1])
+      assert.are.same({ "DiffviewDiffDelete", "@string" }, chunks[1][2])
+    end)
+
+    it("captured_chunks bypasses per-byte resolution past the long-line cap", function()
+      -- Pathologically long lines (e.g. minified bundles) skip the
+      -- O(text_len) per-byte capture pass and fall back to a single
+      -- plain del_hl chunk, regardless of any captures supplied.
+      local long = string.rep("a", 5001)
+      local chunks = captured_chunks(long, { { 0, 5001, "@string" } }, "DiffviewDiffDelete")
+      assert.are.equal(1, #chunks)
+      assert.are.equal(long, chunks[1][1])
+      assert.are.equal("DiffviewDiffDelete", chunks[1][2])
+    end)
+
+    it("compute_old_line_captures returns empty table when filetype is unset", function()
+      local bufnr = fresh_buf({ "local x = 1" })
+      vim.api.nvim_set_option_value("filetype", "", { buf = bufnr })
+      assert.are.same({}, compute_old_line_captures({ "local x = 1" }, bufnr))
+    end)
+
+    it("compute_old_line_captures returns empty table for empty old_lines", function()
+      -- Empty `old_lines` short-circuits before any filetype/TS lookup, so the
+      -- buffer's filetype is irrelevant. Leave it unset to avoid triggering
+      -- ftplugins that might error out when their TS parser isn't installed.
+      local bufnr = fresh_buf({ "" })
+      assert.are.same({}, compute_old_line_captures({}, bufnr))
+    end)
+
+    it("compute_old_line_captures bails out past the source-size cap", function()
+      -- Past the cap, the function returns `{}` before any parse work runs,
+      -- so callers fall back to plain del_hl chunks rather than blocking
+      -- the UI on a synchronous parse over a large generated/minified
+      -- source. `noautocmd` keeps the bundled lua ftplugin (which calls
+      -- `vim.treesitter.start`) out of this path so the test stays
+      -- portable when the lua parser isn't installed in the runtime.
+      local bufnr = fresh_buf({ "" })
+      vim.api.nvim_buf_call(bufnr, function()
+        vim.cmd("noautocmd set filetype=lua")
+      end)
+      local oversized = string.rep("x", 100001)
+      assert.are.same({}, compute_old_line_captures({ "x" }, bufnr, oversized))
+    end)
+
+    if lua_parser_available then
+      it("compute_old_line_captures yields per-line captures for a known filetype", function()
+        local bufnr = fresh_buf({ "" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        local result = compute_old_line_captures({ "local x = 1" }, bufnr)
+        -- Lua highlights query is rich: at minimum we expect captures on
+        -- line 1 (the only old line). Don't pin specific capture names —
+        -- the TS query catalog evolves between Nvim versions.
+        assert.is_table(result[1])
+        assert.is_true(#result[1] > 0)
+        for _, c in ipairs(result[1]) do
+          assert.is_number(c[1])
+          assert.is_number(c[2])
+          assert.is_string(c[3])
+          assert.is_truthy(c[3]:match("^@"))
+        end
+      end)
+
+      it("render layers TS captures over the deletion background", function()
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        inline_diff.render(bufnr, { "local x = 1", "tail" }, { "tail" })
+
+        local lines = virt_line_chunks(extmarks(bufnr))
+        assert.are.equal(1, #lines)
+        local chunks = lines[1]
+        -- At least one chunk must be a stacked-hl chunk (TS layered over
+        -- del_hl). The plain-text fallback would emit a single chunk with
+        -- a string hl_group; once captures kick in we get multiple chunks
+        -- and at least one with a list-shaped hl_group.
+        local saw_stacked = false
+        for _, ch in ipairs(chunks) do
+          if type(ch[2]) == "table" then
+            assert.are.equal("DiffviewDiffDelete", ch[2][1])
+            saw_stacked = true
+          end
+        end
+        assert.is_true(saw_stacked, "expected at least one stacked TS+del_hl chunk")
+      end)
+
+      it("deletion_treesitter=false skips the TS layer", function()
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        inline_diff.render(
+          bufnr,
+          { "local x = 1", "tail" },
+          { "tail" },
+          { deletion_treesitter = false }
+        )
+
+        local lines = virt_line_chunks(extmarks(bufnr))
+        assert.are.equal(1, #lines)
+        -- Without TS layering each line collapses to a single plain-text
+        -- chunk under `del_hl`, with no stacked hl_group.
+        for _, ch in ipairs(lines[1]) do
+          assert.are.equal("string", type(ch[2]))
+          assert.are.equal("DiffviewDiffDelete", ch[2])
+        end
+      end)
+
+      it("'hanging' offsets TS captures past the leading indent", function()
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        inline_diff.render(
+          bufnr,
+          { "  local x = 1", "tail" },
+          { "tail" },
+          { deletion_highlight = "hanging" }
+        )
+
+        local lines = virt_line_chunks(extmarks(bufnr))
+        assert.are.equal(1, #lines)
+        local chunks = lines[1]
+        -- First chunk is the unhighlighted indent (no hl_group).
+        assert.are.equal("  ", chunks[1][1])
+        assert.is_nil(chunks[1][2])
+        -- Subsequent chunks must concatenate to the rest of the line and
+        -- carry stacked-hl groups for at least one of them.
+        local rest_text = ""
+        local saw_stacked = false
+        for i = 2, #chunks do
+          rest_text = rest_text .. chunks[i][1]
+          if type(chunks[i][2]) == "table" then
+            assert.are.equal("DiffviewDiffDelete", chunks[i][2][1])
+            saw_stacked = true
+          end
+        end
+        assert.are.equal("local x = 1", rest_text)
+        assert.is_true(saw_stacked, "expected at least one stacked TS+del_hl chunk in the rest")
+      end)
+
+      it("reuses captures across renders when old_lines content is unchanged", function()
+        -- _repaint flows re-call render with the same old-side content on
+        -- every TextChanged; the captures cache lets the TS parse run once
+        -- instead of per redraw. Cache key is content-based, so a fresh
+        -- table with equal content also hits.
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        inline_diff.render(bufnr, { "local x = 1", "tail" }, { "tail" })
+        local first = inline_diff._captures_by_buf[bufnr]
+        assert.is_not_nil(first)
+
+        inline_diff.render(bufnr, { "local x = 1", "tail" }, { "tail" })
+        local second = inline_diff._captures_by_buf[bufnr]
+        assert.are.equal(first, second)
+      end)
+
+      it("recomputes captures when old_lines content changes", function()
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        inline_diff.render(bufnr, { "local x = 1", "tail" }, { "tail" })
+        local first = inline_diff._captures_by_buf[bufnr]
+        assert.is_not_nil(first)
+
+        inline_diff.render(bufnr, { "local y = 2", "tail" }, { "tail" })
+        local second = inline_diff._captures_by_buf[bufnr]
+        assert.is_not_nil(second)
+        assert.are_not.equal(first, second)
+      end)
+
+      it("recomputes captures when old_lines is mutated in place", function()
+        -- Reference-equality keying would incorrectly reuse stale captures
+        -- when a caller mutates the same table between renders; the
+        -- content-based key invalidates correctly.
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        local old_lines = { "local x = 1", "tail" }
+        inline_diff.render(bufnr, old_lines, { "tail" })
+        local first = inline_diff._captures_by_buf[bufnr]
+        assert.is_not_nil(first)
+
+        old_lines[1] = "local y = 2"
+        inline_diff.render(bufnr, old_lines, { "tail" })
+        local second = inline_diff._captures_by_buf[bufnr]
+        assert.is_not_nil(second)
+        assert.are_not.equal(first, second)
+      end)
+
+      it("detach() drops the cached captures entry", function()
+        local bufnr = fresh_buf({ "tail" })
+        vim.api.nvim_set_option_value("filetype", "lua", { buf = bufnr })
+        inline_diff.render(bufnr, { "local x = 1", "tail" }, { "tail" })
+        assert.is_not_nil(inline_diff._captures_by_buf[bufnr])
+
+        inline_diff.detach(bufnr)
+        assert.is_nil(inline_diff._captures_by_buf[bufnr])
+      end)
+    end
   end)
 end)


### PR DESCRIPTION
In response to https://github.com/dlyongemallo/diffview.nvim/pull/144#issuecomment-4368371297.