### PR TITLE
fix(inline): scope `diff1_inline` highlights to the diffview window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim: [stable, nightly]
+        # Pin the lowest patch on each supported minor so the inline-diff
+        # window-scoping fallbacks (Neovim < 0.11 → no-op + warning;
+        # 0.11 → experimental `nvim__ns_set`; 0.12+ → stable
+        # `nvim_win_add_ns`) all have an explicit gate. `stable` /
+        # `nightly` give forward-compat coverage on top.
+        neovim: [v0.10.4, v0.11.6, stable, nightly]
     # Keep nightly as an early-warning signal but don't let it block PRs.
     continue-on-error: ${{ matrix.neovim == 'nightly' }}
     name: Test (Neovim ${{ matrix.neovim }})

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -24,6 +24,25 @@ local M = {}
 
 M.ns = api.nvim_create_namespace("diffview_inline_diff")
 
+-- Confine inline-diff extmarks to the diffview window so they don't
+-- leak into other windows displaying the same buffer (issue #156).
+-- Two APIs:
+--   * stable `nvim_win_add_ns`/`nvim_win_remove_ns` (0.12+)
+--   * experimental `nvim__ns_set` (0.11; the `{wins = {...}}` shape
+--     has been steady).
+-- Use the stable pair only when *both* halves ship; otherwise fall
+-- back to `nvim__ns_set` if present. With neither available,
+-- `WIN_SCOPE_SUPPORTED` is false and `attach_to_window` degrades to a
+-- one-shot warning.
+-- TODO: drop the experimental fallback when the plugin's minimum
+-- Neovim version is raised to 0.12.
+local has_stable_pair = api.nvim_win_add_ns ~= nil and api.nvim_win_remove_ns ~= nil
+local win_add_ns = has_stable_pair and api.nvim_win_add_ns or nil ---@type (fun(win: integer, ns: integer): boolean?)?
+local win_remove_ns = has_stable_pair and api.nvim_win_remove_ns or nil ---@type (fun(win: integer, ns: integer): boolean?)?
+---@diagnostic disable-next-line: undefined-field -- experimental 0.11 API.
+local ns_set = api.nvim__ns_set ---@type fun(ns: integer, opts: table): table?
+local WIN_SCOPE_SUPPORTED = has_stable_pair or ns_set ~= nil
+
 -- Upper bound on `string.rep(" ", pad)` per virt_line. Real terminal widths
 -- are well under this; the cap exists to bound memory on unusually wide
 -- setups (multi-monitor tiles, font-scaled ultrawides) where the windowed
@@ -907,6 +926,28 @@ M._hunks_by_buf = {}
 ---@type table<integer, { ft: string, old: string, captures: table<integer, InlineDiff.LineCapture[]> }>
 M._captures_by_buf = {}
 
+-- Per-buffer set of winids where `M.ns` is currently scoped. Maintained
+-- via the stable `nvim_win_add_ns`/`nvim_win_remove_ns` pair, or via
+-- `nvim__ns_set` (which `detach_from_all_windows` rebuilds from the
+-- remaining buffers' winids). Lets `M.detach` and the buffer-lifecycle
+-- autocmd drop this buffer's contributions before clearing extmarks.
+-- Empty when neither scope API is available.
+---@type table<integer, table<integer, true>>
+M._scoped_wins_by_buf = {}
+
+-- One-shot per-session flag: the first time `attach_to_window` runs on
+-- Neovim < 0.11 against a buffer that's also displayed outside the
+-- diffview window, emit the leak warning once. Avoids re-warning on
+-- every repaint or on every file inside a long file-history walk.
+local leak_warned = false
+
+-- Forward declaration so the BufWipeout/BufDelete autocmd installed by
+-- `register_cache_cleanup` (defined below) can call into this helper,
+-- which itself isn't declared until further down the file. The body is
+-- assigned at the actual definition site.
+---@type fun(bufnr: integer)
+local detach_from_all_windows
+
 -- Track which buffers already have a cleanup autocmd so we don't register
 -- duplicates across repeated render passes on the same buffer.
 ---@type table<integer, true>
@@ -936,6 +977,15 @@ local function register_cache_cleanup(bufnr)
     callback = function(args)
       M._hunks_by_buf[args.buf] = nil
       M._captures_by_buf[args.buf] = nil
+      -- The hosting windows may still be valid (e.g. `:bdelete`
+      -- switches them to an alternate buffer rather than closing
+      -- them), and on the experimental `nvim__ns_set` path the
+      -- namespace's window list is global across all attached
+      -- buffers, so leaving stale winids in it would leak this
+      -- buffer's old slots into rendering for *other* still-attached
+      -- buffers. `detach_from_all_windows` rebuilds the list
+      -- correctly under both APIs.
+      detach_from_all_windows(args.buf)
       cache_cleanup_registered[args.buf] = nil
       -- Buffer-scoped autocmds on the scroll-adjuster group are dropped by
       -- Neovim when the buffer is wiped, so only the registration flag needs
@@ -1068,6 +1118,132 @@ local function register_scroll_adjuster(bufnr)
   })
 end
 
+-- Emit a one-shot WARN if the inline diff is being rendered against a
+-- buffer that's also displayed in a window other than `winid`, but the
+-- running Neovim is too old (< 0.11) to scope `M.ns` to a single
+-- window. The buffer-shared extmarks will leak into those other
+-- windows; the warning makes that visible without spamming on every
+-- repaint or on every file in a long file-history walk.
+---@param bufnr integer
+---@param winid integer
+local function maybe_warn_leak(bufnr, winid)
+  if leak_warned then
+    return
+  end
+  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then
+    return
+  end
+  for _, w in ipairs(vim.fn.win_findbuf(bufnr)) do
+    if w ~= winid then
+      leak_warned = true
+      vim.notify(
+        "diffview.nvim: `diff1_inline` highlights may leak into other windows showing this file. "
+          .. "Upgrade to Neovim 0.11+ to fix.",
+        vim.log.levels.WARN
+      )
+      return
+    end
+  end
+end
+
+-- Confine `M.ns` to `winid` so the inline-diff extmarks render only in
+-- the diffview window (issue #156). Without `WIN_SCOPE_SUPPORTED`,
+-- `maybe_warn_leak` emits a one-shot warning instead. Idempotent:
+-- re-attaching the same `winid` is a no-op.
+--
+-- A window hosts one buffer at a time, so `winid` already recorded
+-- under another `bufnr` means it's been reassigned (e.g. `diff1_inline`
+-- cycles entries through one window). Transfer ownership so a later
+-- detach of the previous buffer doesn't strip the namespace off a
+-- window the current buffer still relies on.
+---@param bufnr integer
+---@param winid integer
+function M.attach_to_window(bufnr, winid)
+  if not (api.nvim_buf_is_valid(bufnr) and api.nvim_win_is_valid(winid)) then
+    return
+  end
+  if not WIN_SCOPE_SUPPORTED then
+    maybe_warn_leak(bufnr, winid)
+    return
+  end
+  local set = M._scoped_wins_by_buf[bufnr] or {}
+  if set[winid] then
+    return
+  end
+  local ok
+  if win_add_ns then
+    ok = pcall(win_add_ns, winid, M.ns)
+  else
+    -- The experimental `nvim__ns_set` replaces the entire window list
+    -- in one call, so collect every previously-scoped winid (across
+    -- all buffers, since the list is per-namespace not per-buffer)
+    -- plus the new one and pass them together. Stale winids are
+    -- filtered out so a closed window doesn't carry forward.
+    local wins = { winid }
+    for _, other in pairs(M._scoped_wins_by_buf) do
+      for w in pairs(other) do
+        if w ~= winid and api.nvim_win_is_valid(w) then
+          wins[#wins + 1] = w
+        end
+      end
+    end
+    ok = pcall(ns_set, M.ns, { wins = wins })
+  end
+  if not ok then
+    return
+  end
+  for other_bufnr, other in pairs(M._scoped_wins_by_buf) do
+    if other_bufnr ~= bufnr and other[winid] then
+      other[winid] = nil
+      if next(other) == nil then
+        M._scoped_wins_by_buf[other_bufnr] = nil
+      end
+    end
+  end
+  set[winid] = true
+  M._scoped_wins_by_buf[bufnr] = set
+end
+
+-- Reverse of `attach_to_window`. Called by `M.detach` for each window
+-- the namespace was scoped to before clearing the buffer's extmarks,
+-- so a later non-diffview render pass on the same buffer in the same
+-- window slot doesn't silently inherit the scope. Forward-declared
+-- above so the BufWipeout/BufDelete autocmd in `register_cache_cleanup`
+-- can reach it.
+---@param bufnr integer
+detach_from_all_windows = function(bufnr)
+  if not WIN_SCOPE_SUPPORTED then
+    return
+  end
+  local set = M._scoped_wins_by_buf[bufnr]
+  if not set then
+    return
+  end
+  if win_remove_ns then
+    for winid in pairs(set) do
+      if api.nvim_win_is_valid(winid) then
+        pcall(win_remove_ns, winid, M.ns)
+      end
+    end
+  else
+    -- Experimental fallback: rebuild the namespace's window list from
+    -- the remaining buffers' scoped winids, dropping the ones tied to
+    -- `bufnr`.
+    local wins = {}
+    for other_bufnr, other in pairs(M._scoped_wins_by_buf) do
+      if other_bufnr ~= bufnr then
+        for w in pairs(other) do
+          if api.nvim_win_is_valid(w) then
+            wins[#wins + 1] = w
+          end
+        end
+      end
+    end
+    pcall(ns_set, M.ns, { wins = wins })
+  end
+  M._scoped_wins_by_buf[bufnr] = nil
+end
+
 -- Clear all inline-diff extmarks from the buffer.
 ---@param bufnr integer
 function M.clear(bufnr)
@@ -1092,6 +1268,9 @@ end
 -- teardown doesn't leave an empty filler band above line 1.
 ---@param bufnr integer
 function M.detach(bufnr)
+  if bufnr then
+    detach_from_all_windows(bufnr)
+  end
   M.clear(bufnr)
   if not bufnr then
     return

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -336,6 +336,13 @@ Diff1Inline._render_inline = async.void(function(self)
 
   local new_lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
   inline_diff.render(bufnr, old_lines, new_lines, render_opts())
+  -- Confine the inline-diff highlights to this window so they don't
+  -- leak into other windows that happen to display the same buffer
+  -- (e.g. a working-tree file the user already has open in a normal
+  -- tab — issue #156). Idempotent across repeated renders on the
+  -- same window, and a no-op on Neovim < 0.11 where window-scoped
+  -- namespaces aren't available.
+  inline_diff.attach_to_window(bufnr, winid)
   register_repaint_autocmds(self, bufnr)
 end)
 

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -114,6 +114,10 @@ describe("diffview.scene.inline_diff", function()
 
   after_each(function()
     for _, b in ipairs(created_bufs) do
+      -- Detach explicitly: tests that bypass `render` never register
+      -- the BufWipeout cleanup autocmd, so per-buffer module tables
+      -- would otherwise survive the buf delete. Idempotent.
+      pcall(inline_diff.detach, b)
       pcall(api.nvim_buf_delete, b, { force = true })
     end
     -- Close any windows the test opened so a leak (e.g. from a failing
@@ -1469,5 +1473,170 @@ describe("diffview.scene.inline_diff", function()
         assert.is_nil(inline_diff._captures_by_buf[bufnr])
       end)
     end
+  end)
+
+  describe("window scoping", function()
+    -- Mirror `WIN_SCOPE_SUPPORTED` exactly so the test gate doesn't
+    -- disagree with the implementation on edge builds that ship only
+    -- one half of the stable pair. The leak-warning path is covered
+    -- by a separate test. Bracket-index `nvim__ns_set` to keep
+    -- `type-check-tests` clean of `undefined-field`.
+    local supported = (api.nvim_win_add_ns ~= nil and api.nvim_win_remove_ns ~= nil)
+      or api["nvim__ns_set"] ~= nil
+
+    if supported then
+      it("attach_to_window records the scoped winid in _scoped_wins_by_buf", function()
+        local bufnr = fresh_buf({ "a", "b" })
+        inline_diff.attach_to_window(bufnr, initial_winid)
+        local set = inline_diff._scoped_wins_by_buf[bufnr]
+        assert.is_not_nil(set)
+        assert.is_true(set[initial_winid])
+      end)
+
+      it("attach_to_window is idempotent across repeated calls", function()
+        local bufnr = fresh_buf({ "a" })
+        inline_diff.attach_to_window(bufnr, initial_winid)
+        inline_diff.attach_to_window(bufnr, initial_winid)
+        local set = inline_diff._scoped_wins_by_buf[bufnr]
+        local count = 0
+        for _ in pairs(set) do
+          count = count + 1
+        end
+        assert.are.equal(1, count)
+      end)
+
+      it("detach() clears the scoped-windows entry", function()
+        local bufnr = fresh_buf({ "a" })
+        inline_diff.attach_to_window(bufnr, initial_winid)
+        assert.is_not_nil(inline_diff._scoped_wins_by_buf[bufnr])
+
+        inline_diff.detach(bufnr)
+        assert.is_nil(inline_diff._scoped_wins_by_buf[bufnr])
+      end)
+
+      it("BufWipeout drops the scoped-windows entry via the cleanup autocmd", function()
+        local bufnr = fresh_buf({ "a" })
+        -- `inline_diff.render` registers the BufWipeout/BufDelete
+        -- cleanup autocmd; the `attach_to_window` call seeds the
+        -- scoped-windows entry so the cleanup has something to drop.
+        inline_diff.render(bufnr, { "old" }, { "a" })
+        inline_diff.attach_to_window(bufnr, initial_winid)
+        assert.is_not_nil(inline_diff._scoped_wins_by_buf[bufnr])
+
+        api.nvim_buf_delete(bufnr, { force = true })
+        assert.is_nil(inline_diff._scoped_wins_by_buf[bufnr])
+      end)
+
+      it("a buffer shown in two windows only highlights the attached one", function()
+        local bufnr = fresh_buf({ "old line" })
+        api.nvim_win_set_buf(initial_winid, bufnr)
+        vim.cmd("split")
+        local other_winid = api.nvim_get_current_win()
+        api.nvim_win_set_buf(other_winid, bufnr)
+        api.nvim_set_current_win(initial_winid)
+
+        inline_diff.render(bufnr, { "old line" }, { "new line" })
+        inline_diff.attach_to_window(bufnr, initial_winid)
+
+        -- The namespace is now scoped: only `initial_winid` should
+        -- render the diff. We can't easily inspect rendered pixels, but
+        -- we can assert that only the attached window is recorded.
+        local set = inline_diff._scoped_wins_by_buf[bufnr]
+        assert.is_true(set[initial_winid])
+        assert.is_nil(set[other_winid])
+      end)
+
+      it("attach_to_window transfers winid ownership to the new bufnr", function()
+        -- `diff1_inline` cycles entries through one window, so the
+        -- latest attach must strip `winid` from the previous buffer's
+        -- set; otherwise detaching that buffer would `win_remove_ns`
+        -- a window the current one still relies on.
+        local first = fresh_buf({ "a" })
+        local second = fresh_buf({ "b" })
+        inline_diff.attach_to_window(first, initial_winid)
+        assert.is_true(inline_diff._scoped_wins_by_buf[first][initial_winid])
+
+        inline_diff.attach_to_window(second, initial_winid)
+        assert.is_nil(inline_diff._scoped_wins_by_buf[first])
+        assert.is_true(inline_diff._scoped_wins_by_buf[second][initial_winid])
+
+        -- Detaching the previous buffer must leave the current scope
+        -- intact: this is the regression the transfer guards against.
+        inline_diff.detach(first)
+        assert.is_true(inline_diff._scoped_wins_by_buf[second][initial_winid])
+      end)
+    else
+      it("attach_to_window is a no-op on Neovim < 0.11", function()
+        local bufnr = fresh_buf({ "a" })
+        inline_diff.attach_to_window(bufnr, initial_winid)
+        assert.is_nil(inline_diff._scoped_wins_by_buf[bufnr])
+      end)
+    end
+
+    -- Simulate Neovim < 0.11 by stripping the scope APIs from `vim.api`
+    -- and re-loading the module so `WIN_SCOPE_SUPPORTED` is captured as
+    -- false. Runs on every Neovim version so the fallback path is
+    -- exercised even on builds where the scope API exists.
+    it(
+      "emits a one-shot warning when no scope API is available and the buffer is shared",
+      function()
+        local real_add = api.nvim_win_add_ns
+        local real_remove = api.nvim_win_remove_ns
+        -- Bracket-indexed so LuaLS doesn't flag the experimental field.
+        local real_set = api["nvim__ns_set"]
+        local real_notify = vim.notify
+        local notifications = {}
+
+        api.nvim_win_add_ns = nil
+        api.nvim_win_remove_ns = nil
+        api["nvim__ns_set"] = nil
+        vim.notify = function(msg, level)
+          notifications[#notifications + 1] = { msg = msg, level = level }
+        end
+
+        -- `pcall` so a mid-test failure still restores the patched
+        -- globals; otherwise a leaked stub would cascade through the
+        -- rest of the suite. Re-raised below.
+        local ok, err = pcall(function()
+          package.loaded["diffview.scene.inline_diff"] = nil
+          local stripped = require("diffview.scene.inline_diff")
+
+          -- Surface the buffer in a second window so the leak-warning
+          -- guard (`win_findbuf` returns >1 entry) fires.
+          local bufnr = fresh_buf({ "a" })
+          api.nvim_win_set_buf(initial_winid, bufnr)
+          vim.cmd("split")
+          local other = api.nvim_get_current_win()
+          api.nvim_win_set_buf(other, bufnr)
+          api.nvim_set_current_win(initial_winid)
+
+          stripped.attach_to_window(bufnr, initial_winid)
+          assert.is_nil(stripped._scoped_wins_by_buf[bufnr])
+          assert.are.equal(1, #notifications)
+          assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+          assert.is_truthy(notifications[1].msg:find("diff1_inline", 1, true))
+
+          -- Second attach must not re-warn.
+          stripped.attach_to_window(bufnr, initial_winid)
+          assert.are.equal(1, #notifications)
+        end)
+
+        -- Restore the API and put the *original* module instance back
+        -- into `package.loaded` so subsequent tests' `inline_diff`
+        -- upvalue (captured at file load time) keeps matching what
+        -- `require` returns now. Without this, the stripped instance
+        -- would linger in `package.loaded` and the autocmds re-registered
+        -- against it would diverge from the upvalue's state tables.
+        api.nvim_win_add_ns = real_add
+        api.nvim_win_remove_ns = real_remove
+        api["nvim__ns_set"] = real_set
+        vim.notify = real_notify
+        package.loaded["diffview.scene.inline_diff"] = inline_diff
+
+        if not ok then
+          error(err)
+        end
+      end
+    )
   end)
 end)


### PR DESCRIPTION
When the new-side buffer is also displayed in a non-diffview window, the inline-diff extmarks leak into that window because extmarks are buffer-scoped. Confine the namespace to the diffview window via `nvim_win_add_ns` (0.12+, stable) or `nvim__ns_set` (0.11, experimental); on Neovim < 0.11 emit a one-shot warning instead.

Add explicit `v0.10.4` and `v0.11.6` entries to the test matrix so each fallback path has a CI gate.

Fixes #156.