### PR TITLE
feat(config)!: split panel visibility for diff and file history views

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1033,6 +1033,10 @@ file_history_panel                              *diffview-config-file_history_pa
             {win_config} (table|function)
                 See |diffview-config-win_config|.
 
+            {show} (boolean)
+                Show the file history panel when opening
+                |:DiffviewFileHistory|. Default: `true`
+
             {commit_subject_max_length} (integer)
                 Maximum length for commit subject display.
                 Default: `72`

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -151,6 +151,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
         height = 16,
         win_opts = {},
       },
+      show = true,                        -- Show the file history panel when opening DiffviewFileHistory.
       commit_subject_max_length = 72,     -- Max length for commit subject display.
       date_format = "auto",               -- Date format: "auto" | "relative" | "iso"
     },

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -472,6 +472,7 @@ M.defaults = {
   ---@field commit_format DiffviewCommitFormatField[]
   ---@field log_options DiffviewFileHistoryLogOptions
   ---@field win_config DiffviewFileHistoryPanelWinConfig
+  ---@field show boolean
   ---@field commit_subject_max_length integer
   ---@field date_format DiffviewDateFormat
 
@@ -481,6 +482,7 @@ M.defaults = {
   ---@field commit_format? DiffviewCommitFormatField[] Ordered components shown per commit entry.
   ---@field log_options? DiffviewFileHistoryLogOptions.user Log options per adapter. See `|diffview-config-log_options|`.
   ---@field win_config? DiffviewFileHistoryPanelWinConfig.user File history panel window config.
+  ---@field show? boolean Show the file history panel when opening DiffviewFileHistory.
   ---@field commit_subject_max_length? integer Max length for commit subject display.
   ---@field date_format? DiffviewDateFormat "auto", "relative", or "iso".
   file_history_panel = {
@@ -537,6 +539,7 @@ M.defaults = {
       height = 16,
       win_opts = {}
     },
+    show = true, -- Show the file history panel by default when opening DiffviewFileHistory.
     commit_subject_max_length = 72, -- Max length for commit subject display.
     date_format = "auto", -- Date format: "auto" (relative for recent, ISO for old), "relative", or "iso".
   },

--- a/lua/diffview/scene/views/file_history/file_history_view.lua
+++ b/lua/diffview/scene/views/file_history/file_history_view.lua
@@ -527,6 +527,11 @@ function FileHistoryView:get_default_layout_name()
   return config.get_config().view.file_history.layout
 end
 
+---@override
+function FileHistoryView:should_show_panel()
+  return config.get_config().file_history_panel.show
+end
+
 -- Map a non-pinned Diff2 layout name to its pinned counterpart. Pinned
 -- layouts share window orientation with their unpinned siblings; we just
 -- re-route the layout class so the b-window keeps its file across entry

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -62,9 +62,16 @@ function StandardView:init_layout()
     api.nvim_win_close(curwin, false)
   end
 
-  local show_panel = config.get_config().file_panel.show
-  self.panel:focus(not show_panel)
+  self.panel:focus(not self:should_show_panel())
   self.emitter:emit("post_layout")
+end
+
+---Whether the view's panel should be opened on view init. Subclasses bound
+---to a specific panel type (DiffView → file_panel, FileHistoryView →
+---file_history_panel) override this to read their own config block.
+---@return boolean
+function StandardView:should_show_panel()
+  return config.get_config().file_panel.show
 end
 
 function StandardView:post_layout()

--- a/lua/diffview/tests/functional/standard_view_spec.lua
+++ b/lua/diffview/tests/functional/standard_view_spec.lua
@@ -1,5 +1,8 @@
 local helpers = require("diffview.tests.helpers")
+local config = require("diffview.config")
 local StandardView = require("diffview.scene.views.standard.standard_view").StandardView
+local FileHistoryView =
+  require("diffview.scene.views.file_history.file_history_view").FileHistoryView
 
 local eq = helpers.eq
 
@@ -115,5 +118,49 @@ describe("diffview.standard_view panel cursor", function()
     view:save_panel_cursor()
     view:restore_panel_cursor()
     eq({ 7, 4 }, restored)
+  end)
+end)
+
+describe("diffview.standard_view should_show_panel", function()
+  local original_config
+
+  before_each(function()
+    original_config = vim.deepcopy(config.get_config())
+  end)
+
+  after_each(function()
+    config.setup(original_config)
+  end)
+
+  it("StandardView reads file_panel.show", function()
+    local view = setmetatable({}, { __index = StandardView })
+
+    config.get_config().file_panel.show = true
+    eq(true, view:should_show_panel())
+
+    config.get_config().file_panel.show = false
+    eq(false, view:should_show_panel())
+  end)
+
+  it("FileHistoryView reads file_history_panel.show", function()
+    local view = setmetatable({}, { __index = FileHistoryView })
+
+    config.get_config().file_history_panel.show = true
+    eq(true, view:should_show_panel())
+
+    config.get_config().file_history_panel.show = false
+    eq(false, view:should_show_panel())
+  end)
+
+  it("FileHistoryView is independent of file_panel.show", function()
+    local view = setmetatable({}, { __index = FileHistoryView })
+
+    config.get_config().file_panel.show = false
+    config.get_config().file_history_panel.show = true
+    eq(true, view:should_show_panel())
+
+    config.get_config().file_panel.show = true
+    config.get_config().file_history_panel.show = false
+    eq(false, view:should_show_panel())
   end)
 end)


### PR DESCRIPTION
Add `file_history_panel.show` (default `true`) so `:DiffviewOpen` and `:DiffviewFileHistory` can be configured independently. Previously both views shared `file_panel.show`.

Fixes #162.