### PR TITLE
feat(config): add `show_root_path` option for panel headers

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -529,6 +529,12 @@ show_help_hints                                 *diffview-config-show_help_hints
 
         Show hints for how to open the help panel.
 
+show_root_path                                  *diffview-config-show_root_path*
+        Type: `boolean`, Default: `true`
+
+        Show the repository root path in the file panel and file history panel
+        headers.
+
 watch_index                                     *diffview-config-watch_index*
         Type: `boolean`, Default: `true`
 

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -12,6 +12,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
     rename_threshold = nil,   -- Integer 0-100 for rename detection similarity. Nil uses git default (50%). Invalid values are ignored.
     use_icons = true,         -- Requires nvim-web-devicons or mini.icons
     show_help_hints = true,   -- Show hints for how to open the help panel
+    show_root_path = true,    -- Show repository root path in panel headers.
     watch_index = true,       -- Update views and index buffers when the git index changes.
     hide_merge_artifacts = false, -- Hide merge artifact files (*.orig, *.BACKUP.*, *.BASE.*, *.LOCAL.*, *.REMOTE.*)
     auto_close_on_empty = false, -- Close diffview when the last file is staged/resolved

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -402,6 +402,7 @@ M.defaults = {
   ---@field always_show_marks boolean
   ---@field mark_placement DiffviewMarkPlacement
   ---@field show_branch_name boolean
+  ---@field show_root_path boolean
 
   ---@class DiffviewFilePanelConfig.user
   ---@field listing_style? DiffviewListingStyle "list" or "tree".
@@ -414,6 +415,7 @@ M.defaults = {
   ---@field always_show_marks? boolean Show selection marks even when no files are selected.
   ---@field mark_placement? DiffviewMarkPlacement Where to render selection marks.
   ---@field show_branch_name? boolean Show branch name in the file panel header.
+  ---@field show_root_path? boolean Show repository root path in the file panel header.
   file_panel = {
     listing_style = "tree",
     sort_file = nil, -- Custom file comparator: function(a_name, b_name, a_data, b_data) -> boolean
@@ -460,6 +462,7 @@ M.defaults = {
     always_show_marks = false, -- Show selection marks even when no files are selected.
     mark_placement = "inline", -- Where to show selection marks: "inline" (next to file names) or "sign_column" (in the sign column).
     show_branch_name = false, -- Show branch name in the file panel header.
+    show_root_path = true, -- Show repository root path in the file panel header.
   },
 
   ---@alias DiffviewStatStyle "number"|"bar"|"both"

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -108,6 +108,7 @@ local common_panel_keymaps = {
 ---@field rename_threshold? integer
 ---@field use_icons boolean
 ---@field show_help_hints boolean
+---@field show_root_path boolean
 ---@field watch_index boolean
 ---@field hide_merge_artifacts boolean
 ---@field auto_close_on_empty boolean
@@ -138,6 +139,7 @@ local common_panel_keymaps = {
 ---@field rename_threshold? integer Rename detection similarity (0-100). Nil uses git default (50%).
 ---@field use_icons? boolean Requires nvim-web-devicons or mini.icons.
 ---@field show_help_hints? boolean Show hints for how to open the help panel.
+---@field show_root_path? boolean Show repository root path in panel headers.
 ---@field watch_index? boolean Update views and index buffers when the git index changes.
 ---@field hide_merge_artifacts? boolean Hide merge artifact files (*.orig, *.BACKUP.*, *.BASE.*, *.LOCAL.*, *.REMOTE.*).
 ---@field auto_close_on_empty? boolean Close diffview when the last file is staged/resolved.
@@ -170,6 +172,7 @@ M.defaults = {
   rename_threshold = nil, -- Similarity threshold for rename detection (e.g. 40 for 40%). Nil uses git default (50%).
   use_icons = true,
   show_help_hints = true,
+  show_root_path = true, -- Show repository root path in panel headers.
   watch_index = true,
   hide_merge_artifacts = false, -- Hide merge artifact files (*.orig, *.BACKUP.*, etc.)
   auto_close_on_empty = false, -- Automatically close diffview when the last file is staged/resolved.
@@ -402,7 +405,6 @@ M.defaults = {
   ---@field always_show_marks boolean
   ---@field mark_placement DiffviewMarkPlacement
   ---@field show_branch_name boolean
-  ---@field show_root_path boolean
 
   ---@class DiffviewFilePanelConfig.user
   ---@field listing_style? DiffviewListingStyle "list" or "tree".
@@ -415,7 +417,6 @@ M.defaults = {
   ---@field always_show_marks? boolean Show selection marks even when no files are selected.
   ---@field mark_placement? DiffviewMarkPlacement Where to render selection marks.
   ---@field show_branch_name? boolean Show branch name in the file panel header.
-  ---@field show_root_path? boolean Show repository root path in the file panel header.
   file_panel = {
     listing_style = "tree",
     sort_file = nil, -- Custom file comparator: function(a_name, b_name, a_data, b_data) -> boolean
@@ -462,7 +463,6 @@ M.defaults = {
     always_show_marks = false, -- Show selection marks even when no files are selected.
     mark_placement = "inline", -- Where to show selection marks: "inline" (next to file names) or "sign_column" (in the sign column).
     show_branch_name = false, -- Show branch name in the file panel header.
-    show_root_path = true, -- Show repository root path in the file panel header.
   },
 
   ---@alias DiffviewStatStyle "number"|"bar"|"both"

--- a/lua/diffview/scene/views/diff/render.lua
+++ b/lua/diffview/scene/views/diff/render.lua
@@ -397,10 +397,12 @@ local function render_panel(panel)
 
   local comp = panel.components.path.comp
 
-  comp:add_line(
-    pl:truncate(pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~"), width - 6),
-    "DiffviewFilePanelRootPath"
-  )
+  if conf.file_panel.show_root_path then
+    comp:add_line(
+      pl:truncate(pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~"), width - 6),
+      "DiffviewFilePanelRootPath"
+    )
+  end
 
   if conf.file_panel.show_branch_name then
     local branch_name = panel.adapter:get_branch_name()

--- a/lua/diffview/scene/views/diff/render.lua
+++ b/lua/diffview/scene/views/diff/render.lua
@@ -397,7 +397,7 @@ local function render_panel(panel)
 
   local comp = panel.components.path.comp
 
-  if conf.file_panel.show_root_path then
+  if conf.show_root_path then
     comp:add_line(
       pl:truncate(pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~"), width - 6),
       "DiffviewFilePanelRootPath"

--- a/lua/diffview/scene/views/file_history/render.lua
+++ b/lua/diffview/scene/views/file_history/render.lua
@@ -325,16 +325,18 @@ return {
     local log_options = panel:get_log_options()
     local cached = cache[panel]
 
-    -- root path (computed fresh each render so auto-resize truncation
-    -- reflects the current panel width)
-    local root_path = panel.state.form == "column"
-        and pl:truncate(
-          pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~"),
-          math.max(panel:infer_width() - 6, 1)
-        )
-      or pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~")
-    comp:add_text(root_path, "DiffviewFilePanelRootPath")
-    comp:ln()
+    if conf.show_root_path then
+      -- Computed fresh each render so auto-resize truncation reflects the
+      -- current panel width.
+      local root_path = panel.state.form == "column"
+          and pl:truncate(
+            pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~"),
+            math.max(panel:infer_width() - 6, 1)
+          )
+        or pl:vim_fnamemodify(panel.adapter.ctx.toplevel, ":~")
+      comp:add_text(root_path, "DiffviewFilePanelRootPath")
+      comp:ln()
+    end
 
     if panel.single_file then
       if #panel.entries > 0 then

--- a/lua/diffview/tests/functional/config_features_spec.lua
+++ b/lua/diffview/tests/functional/config_features_spec.lua
@@ -83,6 +83,32 @@ describe("show_branch_name", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- show_root_path
+-- ---------------------------------------------------------------------------
+
+describe("show_root_path", function()
+  local original
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+  end)
+
+  after_each(function()
+    config.setup(original)
+  end)
+
+  it("defaults to true", function()
+    local conf = setup_with({})
+    assert.is_true(conf.file_panel.show_root_path)
+  end)
+
+  it("survives setup() when explicitly set to false", function()
+    local conf = setup_with({ file_panel = { show_root_path = false } })
+    assert.is_false(conf.file_panel.show_root_path)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- rename_threshold (commit c5b9200)
 -- ---------------------------------------------------------------------------
 

--- a/lua/diffview/tests/functional/config_features_spec.lua
+++ b/lua/diffview/tests/functional/config_features_spec.lua
@@ -99,12 +99,12 @@ describe("show_root_path", function()
 
   it("defaults to true", function()
     local conf = setup_with({})
-    assert.is_true(conf.file_panel.show_root_path)
+    assert.is_true(conf.show_root_path)
   end)
 
   it("survives setup() when explicitly set to false", function()
-    local conf = setup_with({ file_panel = { show_root_path = false } })
-    assert.is_false(conf.file_panel.show_root_path)
+    local conf = setup_with({ show_root_path = false })
+    assert.is_false(conf.show_root_path)
   end)
 end)
 


### PR DESCRIPTION
Adds `show_root_path` as a boolean option in the `file_panel` configuration, allowing a user to hide the launch directory at the top of the file panel by passing `false`.