### PR TITLE
fix(inline): render extmarks before the buffer becomes visible

### DIFF
--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -58,19 +58,34 @@ local DELETION_HL_WIDTH_CAP = 500
 -- `'foldcolumn'`/`'signcolumn'`/number-column width (`textoff`) is excluded
 -- so the padding string isn't allocated longer than the actual text region.
 -- Capped at `DELETION_HL_WIDTH_CAP` to bound the per-virt_line allocation.
+--
+-- `hint_winid` is folded into the same max so a renderer called before the
+-- buffer is shown there (e.g. `Diff1Inline._prerender`) can still size the
+-- pad: width/`textoff` are window properties, so the value holds even when
+-- the window currently shows a different buffer.
 ---@param bufnr integer
+---@param hint_winid integer?
 ---@return integer
-local function full_width_target(bufnr)
+local function full_width_target(bufnr, hint_winid)
   local max = 0
-  for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
-    if api.nvim_win_is_valid(winid) then
-      local info = vim.fn.getwininfo(winid)[1]
-      local textoff = (info and info.textoff) or 0
-      local w = api.nvim_win_get_width(winid) - textoff
-      if w > max then
-        max = w
-      end
+  local seen = {}
+  local function include(winid)
+    if seen[winid] or not api.nvim_win_is_valid(winid) then
+      return
     end
+    seen[winid] = true
+    local info = vim.fn.getwininfo(winid)[1]
+    local textoff = (info and info.textoff) or 0
+    local w = api.nvim_win_get_width(winid) - textoff
+    if w > max then
+      max = w
+    end
+  end
+  for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+    include(winid)
+  end
+  if hint_winid then
+    include(hint_winid)
   end
   return math.min(max, DELETION_HL_WIDTH_CAP)
 end
@@ -1563,6 +1578,7 @@ end
 ---@field style? "unified"|"overleaf" Default: `"unified"`.
 ---@field deletion_highlight? "text"|"full_width"|"hanging" Extent of the `del_hl` background on virt_line deletions. Default: `"text"`.
 ---@field deletion_treesitter? boolean Layer TS captures over deleted virt_lines. Default: `true`.
+---@field winid? integer Eventual display window. Folded into the `full_width` pad target so a renderer called before the buffer is displayed (e.g. `Diff1Inline._prerender`) can still size padding correctly.
 
 ---@class InlineDiffStyle
 ---@field del_hl string Highlight group for virt_line deletions.
@@ -1658,10 +1674,10 @@ function M.render(bufnr, old_lines, new_lines, opts)
   register_scroll_adjuster(bufnr)
 
   -- Resolve the `full_width` pad target once for the whole render. It depends
-  -- only on the buffer's displayed windows, so a hunk loop that emits many
-  -- deleted blocks would otherwise repeat a `win_findbuf` + `getwininfo`
-  -- traversal per block.
-  local fw_target = extent == "full_width" and full_width_target(bufnr) or 0
+  -- only on the buffer's displayed windows (plus the optional `opts.winid`
+  -- hint), so a hunk loop that emits many deleted blocks would otherwise
+  -- repeat a `win_findbuf` + `getwininfo` traversal per block.
+  local fw_target = extent == "full_width" and full_width_target(bufnr, opts.winid) or 0
 
   -- TS captures for the entire old side, computed lazily and memoized:
   -- the data is shared across every `render_deleted_block` call below

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -115,10 +115,47 @@ end
 ---@param self Diff1Inline
 ---@param pivot integer?
 Diff1Inline.create = async.void(function(self, pivot)
+  -- See `_prerender` for rationale.
+  await(self:_prerender())
   await(self:create_wins(pivot, {
     { "b", "aboveleft vsp" },
   }, { "b" }))
-  await(self:_render_inline())
+  -- `_prerender` already laid down the extmarks; only the window-scoped
+  -- state remains.
+  self:_install_window_hooks()
+end)
+
+---@override
+---Scope the inline namespace to the b window before `open_files` yields,
+---closing the redraw window that would otherwise leak `_prerender`'s
+---extmarks into other windows showing the same buffer (issue #156).
+---
+---For `full_width` deletions, follow up with a `_repaint` after the buffer
+---is on screen: the create-path `_prerender` ran before `self.b.id` existed,
+---so the pad target wasn't sized to the window. Gated on `full_width` to
+---keep the render-once invariant for other styles.
+---@param self Diff1Inline
+Diff1Inline.create_post = async.void(function(self)
+  self:open_null()
+  -- `self.b:is_valid()` covers both `self.b.id` being set and the underlying
+  -- window still existing; without it, a torn-down layout would feed `nil`
+  -- into `nvim_win_is_valid` inside `attach_to_window` and throw.
+  if
+    self.b
+    and self.b:is_valid()
+    and self.b.file
+    and self.b.file.bufnr
+    and api.nvim_buf_is_valid(self.b.file.bufnr)
+    and not self.b.file.binary
+  then
+    inline_diff.attach_to_window(self.b.file.bufnr --[[@as integer ]], self.b.id)
+  end
+  await(self:open_files())
+  vim.opt.equalalways = self.state.save_equalalways
+  local inline_opt = config.get_config().view.inline or {}
+  if inline_opt.deletion_highlight == "full_width" then
+    self:_repaint()
+  end
 end)
 
 ---@override
@@ -135,8 +172,13 @@ Diff1Inline.use_entry = async.void(function(self, entry)
   self._cached_old_lines = nil
 
   if self:is_valid() then
+    -- See `_prerender` for rationale.
+    await(self:_prerender())
+    if not self:is_valid() then
+      return
+    end
     await(self:open_files())
-    await(self:_render_inline())
+    self:_install_window_hooks()
   end
 end)
 
@@ -166,15 +208,96 @@ end)
 
 ---Build the options table forwarded to `inline_diff.render`. Merges the
 ---effective global `'diffopt'` with the configured inline style.
+---
+---`winid` is forwarded as the `full_width` pad-target hint so `_prerender`
+---can size deletion padding before the b buffer is displayed.
+---@param winid integer?
 ---@return InlineDiffOpts
-local function render_opts()
+local function render_opts(winid)
   local opts = effective_diffopt()
   local inline_opt = config.get_config().view.inline or {}
   opts.style = inline_opt.style
   opts.deletion_highlight = inline_opt.deletion_highlight
   opts.deletion_treesitter = inline_opt.deletion_treesitter
+  if winid and api.nvim_win_is_valid(winid) then
+    opts.winid = winid
+  end
   return opts
 end
+
+---Render the inline diff onto the b-side buffer BEFORE it becomes visible
+---in the window so the first redraw that shows the buffer also shows its
+---highlights. See issue #172.
+---
+---The `async.scheduler()` step escapes the fast event context that
+---`produce_data` callbacks land in; without it, the caller's next `await`
+---(`open_files` running `vim.cmd("diffoff!")`) would hit `E5560`.
+---@param self Diff1Inline
+Diff1Inline._prerender = async.void(function(self)
+  if not (self.b and self.b.file) then
+    return
+  end
+  -- Skip binary outright (nothing textual to diff). Nulled b-files are not
+  -- skipped: a deletion still needs the old-side content rendered as
+  -- virt_lines (the "1 added empty line" overshoot from issue #172 is
+  -- suppressed below by feeding `render` an empty `new_lines`).
+  if self.b.file.binary then
+    return
+  end
+  if not self.b.file:is_valid() then
+    if not self.b.file.active then
+      return
+    end
+    await(self.b:load_file())
+  end
+
+  -- Re-validate after the load yield: the b-side may have been swapped or
+  -- the buffer destroyed while we were awaiting.
+  if not (self.b and self.b.file and self.b.file:is_valid()) then
+    return
+  end
+  -- `binary` may have been nil before `load_file` ran; `create_buffer`
+  -- resolves it lazily and points `bufnr` at the shared NULL buffer when
+  -- the file turns out to be binary. Re-check before rendering so we don't
+  -- lay extmarks onto NULL_FILE.
+  if self.b.file.binary then
+    return
+  end
+  local bufnr = self.b.file.bufnr --[[@as integer ]]
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  if self._cached_old_lines == nil then
+    local old_lines = await(self:_load_old_lines())
+    await(async.scheduler())
+    -- Bail if the b-side file was swapped (bufnr differs) or the buffer
+    -- was destroyed while awaiting; otherwise we'd render onto a stale
+    -- buffer that no longer matches `self.b.file`.
+    if
+      not (self.b and self.b.file and self.b.file.bufnr == bufnr and api.nvim_buf_is_valid(bufnr))
+    then
+      return
+    end
+    self._cached_old_lines = old_lines
+  end
+
+  -- A nulled b-file shares the empty `NULL_FILE` buffer; reading its lines
+  -- yields `{""}` which `vim.diff` would treat as "one added empty line".
+  -- Pass `{}` instead so the diff is a pure deletion of the old content.
+  local new_lines = self.b.file.nulled and {} or api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  -- `self.b.id` is the `full_width` pad-target hint: valid in `use_entry`,
+  -- nil in `create` (where `create_post` fires a follow-up `_repaint` once
+  -- the window exists).
+  inline_diff.render(bufnr, self._cached_old_lines, new_lines, render_opts(self.b.id))
+  -- Scope the namespace synchronously so the caller's next yield can't
+  -- redraw with `M.ns` global and leak the extmarks into other windows
+  -- showing the same buffer (issue #156). The `create` path has no window
+  -- yet; `create_post` does the equivalent scoping for it.
+  if self.b.id and api.nvim_win_is_valid(self.b.id) then
+    inline_diff.attach_to_window(bufnr, self.b.id)
+  end
+end)
 
 ---Re-paint extmarks against the buffer's current contents. Called from
 ---`InsertLeave`/`TextChanged` autocmds so edits are reflected without a
@@ -206,8 +329,12 @@ function Diff1Inline:_repaint()
     return
   end
 
-  local new_lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  inline_diff.render(bufnr, old_lines, new_lines, render_opts())
+  -- A nulled b-file feeds `render` an empty `new_lines` to suppress the
+  -- spurious "1 added empty line" hunk from issue #172 (see `_prerender`).
+  -- Needed here too because the `create_post` full_width follow-up calls
+  -- `_repaint`.
+  local new_lines = self.b.file.nulled and {} or api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  inline_diff.render(bufnr, old_lines, new_lines, render_opts(self.b.id))
 end
 
 ---Install buffer-scoped autocmds that repaint on edits. Fires on any
@@ -305,11 +432,18 @@ local function register_repaint_autocmds(self, bufnr)
   end
 end
 
----Apply inline-view winopts on the displayed window and render the unified
----diff as extmarks on the new-side buffer.
+---Install window-scoped state once the b buffer is visible: turn off
+---native diff mode (so it doesn't fight the extmark rendering), scope the
+---namespace to this window (issue #156), and register repaint autocmds.
+---Idempotent.
 ---@param self Diff1Inline
-Diff1Inline._render_inline = async.void(function(self)
+function Diff1Inline:_install_window_hooks()
   if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then
+    return
+  end
+  -- Binary files have no diff to scope or repaint; skip. Nulled files
+  -- (deletions) still need the namespace scope and the winopts override.
+  if self.b.file.binary then
     return
   end
 
@@ -324,26 +458,48 @@ Diff1Inline._render_inline = async.void(function(self)
   pcall(api.nvim_set_option_value, "foldmethod", "manual", { win = winid })
   pcall(api.nvim_set_option_value, "foldenable", false, { win = winid })
 
+  inline_diff.attach_to_window(bufnr, winid)
+  register_repaint_autocmds(self, bufnr)
+end
+
+---Apply inline-view winopts on the displayed window and render the unified
+---diff as extmarks on the new-side buffer.
+---@param self Diff1Inline
+Diff1Inline._render_inline = async.void(function(self)
+  if not (self.b and self.b:is_valid() and self.b.file and self.b.file:is_valid()) then
+    return
+  end
+  -- See `_prerender` for why only `binary` is skipped here; the nulled
+  -- case is handled by passing `new_lines = {}` to `inline_diff.render`.
+  if self.b.file.binary then
+    return
+  end
+  local bufnr = self.b.file.bufnr --[[@as integer ]]
+
   local old_lines = self._cached_old_lines
   if old_lines == nil then
     old_lines = await(self:_load_old_lines())
     await(async.scheduler())
-    if not (self.b and self.b:is_valid() and api.nvim_buf_is_valid(bufnr)) then
+    -- Bail if the b-side file was swapped (bufnr differs) or the buffer
+    -- was destroyed while awaiting; otherwise we'd render onto a stale
+    -- buffer that no longer matches `self.b.file`.
+    if
+      not (
+        self.b
+        and self.b:is_valid()
+        and self.b.file
+        and self.b.file.bufnr == bufnr
+        and api.nvim_buf_is_valid(bufnr)
+      )
+    then
       return
     end
     self._cached_old_lines = old_lines
   end
 
-  local new_lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  inline_diff.render(bufnr, old_lines, new_lines, render_opts())
-  -- Confine the inline-diff highlights to this window so they don't
-  -- leak into other windows that happen to display the same buffer
-  -- (e.g. a working-tree file the user already has open in a normal
-  -- tab — issue #156). Idempotent across repeated renders on the
-  -- same window, and a no-op on Neovim < 0.11 where window-scoped
-  -- namespaces aren't available.
-  inline_diff.attach_to_window(bufnr, winid)
-  register_repaint_autocmds(self, bufnr)
+  local new_lines = self.b.file.nulled and {} or api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  inline_diff.render(bufnr, old_lines, new_lines, render_opts(self.b.id))
+  self:_install_window_hooks()
 end)
 
 ---Replace the new-side content of every hunk overlapping `[first, last]`

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -566,6 +566,65 @@ describe("diffview.scene.inline_diff", function()
       assert.are.equal(math.min(text_width, FULL_WIDTH_CAP) - 7, #chunks[2][1])
     end)
 
+    -- Simulates the `Diff1Inline._prerender` use_entry path: the b buffer
+    -- isn't yet displayed in the target diffview window (that window is
+    -- still showing the previous file's buffer), but the caller knows the
+    -- winid and forwards it so the pad target can be computed against the
+    -- eventual display target. Without the hint the bufnr wouldn't be in
+    -- `win_findbuf` so the pad would resolve to 0 and no padding chunk
+    -- would be emitted.
+    it("'full_width' uses opts.winid when the buffer isn't displayed yet", function()
+      local target = fresh_buf({ "tail" })
+      vim.cmd("vsplit")
+      local winid = api.nvim_get_current_win()
+      -- Crucially, do NOT put `target` into `winid`; keep some other buffer
+      -- there so `win_findbuf(target)` returns nothing.
+      local other = fresh_buf({ "other" })
+      api.nvim_win_set_buf(winid, other)
+      assert.are.same({}, vim.fn.win_findbuf(target))
+      local info = vim.fn.getwininfo(winid)[1]
+      local textoff = (info and info.textoff) or 0
+      local text_width = api.nvim_win_get_width(winid) - textoff
+
+      inline_diff.render(
+        target,
+        { "deleted", "tail" },
+        { "tail" },
+        { deletion_highlight = "full_width", winid = winid }
+      )
+
+      local lines = virt_line_chunks(extmarks(target))
+      assert.are.equal(1, #lines)
+      local chunks = lines[1]
+      assert.are.equal(2, #chunks)
+      -- "deleted" is 7 display cells; padding fills the rest of the hint window.
+      assert.are.equal(math.min(text_width, FULL_WIDTH_CAP) - 7, #chunks[2][1])
+    end)
+
+    -- Confirms the previous test isn't a false positive: with no hint and
+    -- no window showing the buffer, the pad target is 0 and no padding
+    -- chunk is emitted.
+    it(
+      "'full_width' emits no padding when the buffer is undisplayed and no winid hint is given",
+      function()
+        local target = fresh_buf({ "tail" })
+        assert.are.same({}, vim.fn.win_findbuf(target))
+
+        inline_diff.render(
+          target,
+          { "deleted", "tail" },
+          { "tail" },
+          { deletion_highlight = "full_width" }
+        )
+
+        local lines = virt_line_chunks(extmarks(target))
+        assert.are.equal(1, #lines)
+        -- Only the deletion text, no padding chunk.
+        assert.are.equal(1, #lines[1])
+        assert.are.equal("deleted", lines[1][1][1])
+      end
+    )
+
     it("'full_width' pads in overleaf style under the overleaf del_hl", function()
       local bufnr = fresh_buf({ "alpha" })
       vim.cmd("vsplit")

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -571,6 +571,549 @@ describe("diffview.layout symbols", function()
     )
   end)
 
+  -- Regression suite for issue #172: the b buffer must not be shown without
+  -- inline-diff extmarks. The fix renders the extmarks onto the b buffer
+  -- BEFORE `open_files` switches the window to that buffer, so the first
+  -- redraw that shows the new buffer also shows its highlights.
+  describe("Diff1Inline:_prerender", function()
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+    local inline_diff = require("diffview.scene.inline_diff")
+    local api = vim.api
+    -- Mirrors `WIN_SCOPE_SUPPORTED` in `inline_diff.lua`: the namespace
+    -- scoping APIs landed in 0.11 (`nvim__ns_set`) / 0.12
+    -- (`nvim_win_add_ns`); on older Neovim `attach_to_window` is a
+    -- one-shot warning and never populates `_scoped_wins_by_buf`.
+    -- Bracket-index `nvim__ns_set` to keep type-check-tests clean.
+    local scope_supported = (api.nvim_win_add_ns ~= nil and api.nvim_win_remove_ns ~= nil)
+      or api["nvim__ns_set"] ~= nil
+
+    it(
+      "renders extmarks on the b buffer before it is opened in a window",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "TWO", "three" })
+
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = {
+            bufnr = bufnr,
+            active = true,
+            is_valid = function()
+              return true
+            end,
+          },
+        }
+        inst.a_file = { nulled = false, binary = false }
+        inst._cached_old_lines = { "one", "two", "three" }
+
+        async.await(inst:_prerender())
+
+        -- The mismatch on line 2 should produce at least one extmark.
+        local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+        assert.is_true(#marks > 0)
+
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    it(
+      "is a no-op when b.file is missing",
+      helpers.async_test(function()
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {}
+        async.await(inst:_prerender())
+        -- No exception; nothing else to assert.
+      end)
+    )
+
+    -- A deleted file still needs its old-side content rendered as deletion
+    -- virt_lines. `_prerender` substitutes `new_lines = {}` for the nulled
+    -- buffer so `vim.diff(content, "")` yields a pure deletion, dodging the
+    -- spurious "1 added empty line" hunk from issue #172.
+    it(
+      "renders deletion virt_lines when b.file is nulled but a-side has content",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = {
+            bufnr = bufnr,
+            nulled = true,
+            binary = false,
+            active = true,
+            is_valid = function()
+              return true
+            end,
+          },
+        }
+        inst.a_file = { nulled = false, binary = false }
+        inst._cached_old_lines = { "removed-1", "removed-2" }
+
+        async.await(inst:_prerender())
+
+        local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+        assert.is_true(#marks > 0)
+
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    -- Temp layout (a-side and b-side both nulled) has no content on either
+    -- side: `vim.diff("", "")` returns no hunks, so the render is a true
+    -- no-op. This is the path that produced the green sliver before #172.
+    it(
+      "is a no-op when both a- and b-side are nulled",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = {
+            bufnr = bufnr,
+            nulled = true,
+            binary = false,
+            active = true,
+            is_valid = function()
+              return true
+            end,
+          },
+        }
+        inst.a_file = { nulled = true, binary = false }
+
+        async.await(inst:_prerender())
+
+        local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+        eq(0, #marks)
+
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    it(
+      "is a no-op when b.file is binary",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = {
+            bufnr = bufnr,
+            nulled = false,
+            binary = true,
+            active = true,
+            is_valid = function()
+              return true
+            end,
+          },
+        }
+        inst.a_file = { nulled = false, binary = true }
+
+        async.await(inst:_prerender())
+
+        local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+        eq(0, #marks)
+
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    -- The render call happens before `open_files` yields, so without
+    -- scoping the redraw triggered by that yield would expose extmarks
+    -- in any other window already displaying the same buffer (#156).
+    -- `_prerender` scopes the namespace synchronously after the render.
+    it(
+      "scopes the inline namespace to self.b.id after rendering",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "TWO", "three" })
+        local winid = api.nvim_get_current_win()
+
+        -- Clear any prior scope state for this buffer so we're asserting
+        -- the attach made by `_prerender`, not lingering state.
+        inline_diff.detach(bufnr)
+
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = {
+            bufnr = bufnr,
+            active = true,
+            is_valid = function()
+              return true
+            end,
+          },
+          id = winid,
+        }
+        inst.a_file = { nulled = false, binary = false }
+        inst._cached_old_lines = { "one", "two", "three" }
+
+        async.await(inst:_prerender())
+
+        if scope_supported then
+          local set = inline_diff._scoped_wins_by_buf[bufnr]
+          assert.is_not_nil(set)
+          assert.is_true(set[winid])
+        else
+          -- `attach_to_window` is a no-op on this Neovim; just confirm
+          -- `_prerender` didn't error and left the scope table empty.
+          assert.is_nil(inline_diff._scoped_wins_by_buf[bufnr])
+        end
+
+        inline_diff.detach(bufnr)
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    -- The `create` path runs `_prerender` before `create_wins`, so the
+    -- b window doesn't exist yet. The attach call must early-return
+    -- rather than error on a nil/invalid winid; `create_post` handles
+    -- the create-path scoping separately.
+    it(
+      "skips scoping (no error) when self.b.id is not a real window",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "TWO", "three" })
+
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = {
+            bufnr = bufnr,
+            active = true,
+            is_valid = function()
+              return true
+            end,
+          },
+          -- No `id`: the create path runs `_prerender` before `create_wins`.
+        }
+        inst.a_file = { nulled = false, binary = false }
+        inst._cached_old_lines = { "one", "two", "three" }
+
+        async.await(inst:_prerender())
+
+        local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+        assert.is_true(#marks > 0)
+
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+  end)
+
+  -- `create_post` runs between `create_wins` (which created `self.b.id`)
+  -- and `open_files` (which yields, allowing a redraw). `_prerender`
+  -- already wrote the extmarks, so the override must scope the
+  -- namespace before the yield to prevent leakage (#156).
+  describe("Diff1Inline.create_post", function()
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+    local inline_diff = require("diffview.scene.inline_diff")
+    local api = vim.api
+    -- See the `_prerender` block's note: on pre-0.11 Neovim there's no
+    -- scoping API, so `attach_to_window` (and by extension `create_post`)
+    -- can't populate `_scoped_wins_by_buf`.
+    local scope_supported = (api.nvim_win_add_ns ~= nil and api.nvim_win_remove_ns ~= nil)
+      or api["nvim__ns_set"] ~= nil
+
+    it(
+      "scopes the inline namespace to self.b.id before open_files runs",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        local winid = api.nvim_get_current_win()
+        inline_diff.detach(bufnr)
+
+        local scope_at_open_files
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = { bufnr = bufnr, binary = false },
+          id = winid,
+          is_valid = function()
+            return true
+          end,
+        }
+        inst.state = { save_equalalways = vim.o.equalalways }
+        inst.open_null = function() end
+        inst.open_files = async.void(function()
+          local set = inline_diff._scoped_wins_by_buf[bufnr]
+          scope_at_open_files = set ~= nil and set[winid] == true
+        end)
+
+        async.await(inst:create_post())
+
+        if scope_supported then
+          assert.is_true(
+            scope_at_open_files,
+            "expected inline namespace to be scoped to self.b.id when open_files starts"
+          )
+        else
+          -- Without the scoping API, `attach_to_window` is a no-op; the
+          -- override still ran without erroring, which is the most we
+          -- can check.
+          assert.is_false(scope_at_open_files)
+        end
+
+        inline_diff.detach(bufnr)
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    -- A binary b-file has no extmarks to scope; skipping the attach
+    -- mirrors the binary skip in `_prerender` and `_install_window_hooks`.
+    it(
+      "skips scoping when b.file is binary",
+      helpers.async_test(function()
+        local bufnr = api.nvim_create_buf(false, true)
+        local winid = api.nvim_get_current_win()
+        inline_diff.detach(bufnr)
+
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = { bufnr = bufnr, binary = true },
+          id = winid,
+          is_valid = function()
+            return true
+          end,
+        }
+        inst.state = { save_equalalways = vim.o.equalalways }
+        inst.open_null = function() end
+        inst.open_files = async.void(function() end)
+
+        async.await(inst:create_post())
+
+        assert.is_nil(inline_diff._scoped_wins_by_buf[bufnr])
+
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+      end)
+    )
+
+    -- The `create` path runs `_prerender` before `create_wins`, so the b
+    -- window doesn't exist yet and `full_width_target` can't size the
+    -- pad against it. After `open_files` displays the buffer, `create_post`
+    -- fires a follow-up `_repaint` so the deletion virt_lines pick up the
+    -- now-known window width.
+    it(
+      "fires a follow-up _repaint after open_files when full_width is configured",
+      helpers.async_test(function()
+        local config = require("diffview.config")
+        local original_config = vim.deepcopy(config.get_config())
+        config.setup({ view = { inline = { deletion_highlight = "full_width" } } })
+
+        local bufnr = api.nvim_create_buf(false, true)
+        local winid = api.nvim_get_current_win()
+        inline_diff.detach(bufnr)
+
+        local repaint_count = 0
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = { bufnr = bufnr, binary = false },
+          id = winid,
+          is_valid = function()
+            return true
+          end,
+        }
+        inst.state = { save_equalalways = vim.o.equalalways }
+        inst.open_null = function() end
+        inst.open_files = async.void(function() end)
+        inst._repaint = function()
+          repaint_count = repaint_count + 1
+        end
+
+        local ok, err = pcall(function()
+          async.await(inst:create_post())
+          eq(1, repaint_count)
+        end)
+
+        inline_diff.detach(bufnr)
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+        config.setup(original_config)
+
+        if not ok then
+          error(err)
+        end
+      end)
+    )
+
+    -- For `text` / `hanging` deletion extents the pad isn't a function of
+    -- the window width, so the create-path follow-up `_repaint` would be
+    -- a redundant render. The override gates it on `full_width` to keep
+    -- the render-once invariant for the other styles.
+    it(
+      "skips the follow-up _repaint when deletion_highlight isn't full_width",
+      helpers.async_test(function()
+        local config = require("diffview.config")
+        local original_config = vim.deepcopy(config.get_config())
+        config.setup({ view = { inline = { deletion_highlight = "text" } } })
+
+        local bufnr = api.nvim_create_buf(false, true)
+        local winid = api.nvim_get_current_win()
+        inline_diff.detach(bufnr)
+
+        local repaint_count = 0
+        local inst = setmetatable({}, { __index = Diff1Inline })
+        inst.b = {
+          file = { bufnr = bufnr, binary = false },
+          id = winid,
+          is_valid = function()
+            return true
+          end,
+        }
+        inst.state = { save_equalalways = vim.o.equalalways }
+        inst.open_null = function() end
+        inst.open_files = async.void(function() end)
+        inst._repaint = function()
+          repaint_count = repaint_count + 1
+        end
+
+        local ok, err = pcall(function()
+          async.await(inst:create_post())
+          eq(0, repaint_count)
+        end)
+
+        inline_diff.detach(bufnr)
+        pcall(api.nvim_buf_delete, bufnr, { force = true })
+        config.setup(original_config)
+
+        if not ok then
+          error(err)
+        end
+      end)
+    )
+  end)
+
+  it(
+    "Diff1Inline:_render_inline renders deletion virt_lines when b.file is nulled",
+    helpers.async_test(function()
+      local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+      local inline_diff = require("diffview.scene.inline_diff")
+      local api = vim.api
+
+      local bufnr = api.nvim_create_buf(false, true)
+      local winid = api.nvim_get_current_win()
+
+      local inst = setmetatable({}, { __index = Diff1Inline })
+      inst.b = {
+        file = {
+          bufnr = bufnr,
+          nulled = true,
+          binary = false,
+          is_valid = function()
+            return true
+          end,
+        },
+        is_valid = function()
+          return true
+        end,
+        id = winid,
+      }
+      inst.a_file = { nulled = false, binary = false }
+      inst._cached_old_lines = { "removed-1", "removed-2" }
+
+      async.await(inst:_render_inline())
+
+      local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+      assert.is_true(#marks > 0)
+
+      inst:teardown_render()
+      pcall(api.nvim_buf_delete, bufnr, { force = true })
+    end)
+  )
+
+  -- `_repaint` is invoked by the `create_post` full_width follow-up
+  -- (among other places). Without the nulled handling it would feed
+  -- `inline_diff.render` the NULL_FILE buffer's lone empty line, which
+  -- `vim.diff` reports as a modification (and the "1 added empty line"
+  -- green sliver from issue #172) instead of a pure deletion.
+  it("Diff1Inline:_repaint emits no DiffChange/DiffAdd row hl when b.file is nulled", function()
+    local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+    local inline_diff = require("diffview.scene.inline_diff")
+    local api = vim.api
+
+    local bufnr = api.nvim_create_buf(false, true)
+    local winid = api.nvim_get_current_win()
+
+    local inst = setmetatable({}, { __index = Diff1Inline })
+    inst.b = {
+      file = {
+        bufnr = bufnr,
+        nulled = true,
+        binary = false,
+        is_valid = function()
+          return true
+        end,
+      },
+      is_valid = function()
+        return true
+      end,
+      id = winid,
+    }
+    inst.a_file = { nulled = false, binary = false }
+    inst._cached_old_lines = { "removed-1", "removed-2" }
+
+    inst:_repaint()
+
+    local marks = api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, { details = true })
+    for _, m in ipairs(marks) do
+      local hl = m[4] and m[4].line_hl_group
+      assert(
+        hl ~= "DiffviewDiffChange" and hl ~= "DiffviewDiffAdd",
+        "unexpected line_hl_group: " .. tostring(hl)
+      )
+    end
+
+    inst:teardown_render()
+    pcall(api.nvim_buf_delete, bufnr, { force = true })
+  end)
+
+  it(
+    "Diff1Inline.use_entry renders extmarks before open_files displays the buffer",
+    helpers.async_test(function()
+      -- The fix guarantees that by the time `open_files` (which displays
+      -- the b buffer) starts running, the inline-diff extmarks are already
+      -- on the b buffer. Drive `use_entry` against a real `Diff1Inline`
+      -- instance whose `open_files` records the extmark count at entry,
+      -- then assert it is greater than zero.
+      local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+      local inline_diff = require("diffview.scene.inline_diff")
+      local api = vim.api
+
+      local bufnr = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "TWO", "three" })
+
+      local marks_at_open_files
+      local b_file = {
+        bufnr = bufnr,
+        active = true,
+        is_valid = function()
+          return true
+        end,
+        symbol = "b",
+      }
+      local a_file = { nulled = true, binary = false }
+      local inst = Diff1Inline({ b = b_file, a = a_file })
+      inst.b.is_valid = function()
+        return true
+      end
+      inst.is_valid = function()
+        return true
+      end
+      -- Override `_load_old_lines` to return a fixed old side synchronously
+      -- so `_prerender` doesn't depend on a real adapter.
+      inst._load_old_lines = async.wrap(function(_, callback)
+        callback({ "one", "two", "three" })
+      end, 2)
+      inst.open_files = async.void(function()
+        marks_at_open_files = #api.nvim_buf_get_extmarks(bufnr, inline_diff.ns, 0, -1, {})
+      end)
+      inst._install_window_hooks = function() end
+
+      local entry = { layout = Diff1Inline({ b = b_file, a = a_file }) }
+
+      async.await(inst:use_entry(entry))
+
+      assert.is_not_nil(marks_at_open_files)
+      assert.is_true(
+        marks_at_open_files > 0,
+        "expected extmarks already on buffer when open_files starts"
+      )
+
+      pcall(api.nvim_buf_delete, bufnr, { force = true })
+    end)
+  )
+
   it("Diff2 declares symbols { 'a', 'b' }", function()
     eq({ "a", "b" }, Diff2.symbols)
   end)


### PR DESCRIPTION
Fixes #172.