### PR TITLE
feat(hl): split selected-commit overlay into `DiffviewCommitSelected`

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1034,12 +1034,15 @@ file_history_panel                              *diffview-config-file_history_pa
                 remote-tracking ref (pushed) and `DiffviewCommitLocalOnly`
                 for commits that are not (unpushed). `"plain"` uses a
                 single colour for all.
-                On the selected commit `DiffviewFilePanelSelected` is
+                On the selected commit `DiffviewCommitSelected` is
                 layered on top of the ref-aware highlight; with the
                 default (foreground-only) groups the selected colour
-                wins. To see the pushed/unpushed colour at the same time
-                as the selection marker, link `DiffviewFilePanelSelected`
-                to a background-only highlight, e.g. `Visual`.
+                wins. To see the pushed/unpushed colour at the same
+                time as the selection marker, link
+                `DiffviewCommitSelected` to a background-only
+                highlight, e.g. `Visual`. This is separate from
+                `DiffviewFilePanelSelected`, which governs the active
+                filename colour.
                 Default: `"ref_aware"`
 
             {commit_format} (string[])

--- a/lua/diffview/hl.lua
+++ b/lua/diffview/hl.lua
@@ -409,6 +409,7 @@ M.hl_links = {
   FilePanelRootPath = "DiffviewFilePanelTitle",
   FilePanelFileName = "Normal",
   FilePanelSelected = "Type",
+  CommitSelected = "Type",
   FilePanelPath = "Comment",
   FilePanelInsertions = "diffAdded",
   FilePanelDeletions = "diffRemoved",

--- a/lua/diffview/scene/views/file_history/render.lua
+++ b/lua/diffview/scene/views/file_history/render.lua
@@ -199,17 +199,20 @@ local formatters = {
     local text = " " .. subject
     comp:add_text(text, base_hl)
 
-    -- Layer the selected highlight on top of the ref-aware base so users who
-    -- customize `DiffviewFilePanelSelected` to define only a background still
-    -- see the pushed/unpushed foreground. With default highlight groups (both
-    -- foreground-only) the layered group wins, matching prior behaviour.
+    -- Layer the commit-selected highlight on top of the ref-aware base so
+    -- users who customize `DiffviewCommitSelected` to define only a
+    -- background still see the pushed/unpushed foreground. With default
+    -- highlight groups (both foreground-only) the layered group wins,
+    -- matching prior behaviour. `DiffviewCommitSelected` is distinct from
+    -- `DiffviewFilePanelSelected` (the active-filename colour) so each can
+    -- be restyled without affecting the other.
     -- The leading separator space is excluded from the range so a custom
-    -- background on `DiffviewFilePanelSelected` doesn't bleed into the gap
+    -- background on `DiffviewCommitSelected` doesn't bleed into the gap
     -- between columns.
     if ctx.panel.cur_item[1] == entry then
       local end_col = #comp.line_buffer
       local start_col = end_col - #subject
-      comp:add_hl("DiffviewFilePanelSelected", #comp.lines, start_col, end_col)
+      comp:add_hl("DiffviewCommitSelected", #comp.lines, start_col, end_col)
     end
   end,
 

--- a/lua/diffview/tests/functional/file_history_render_spec.lua
+++ b/lua/diffview/tests/functional/file_history_render_spec.lua
@@ -347,7 +347,7 @@ describe("file_history_render", function()
       eq("DiffviewCommitLocalOnly", render_subject_hl(entry, false))
     end)
 
-    it("layers DiffviewFilePanelSelected on top of the ref-aware base when selected", function()
+    it("layers DiffviewCommitSelected on top of the ref-aware base when selected", function()
       local conf = config.get_config()
       conf.file_history_panel.subject_highlight = "ref_aware"
       config.setup(conf)
@@ -365,16 +365,17 @@ describe("file_history_render", function()
       eq(" test", comp.lines[1][1].text)
 
       -- The selected highlight is layered over the subject's byte range, so
-      -- the user can customize `DiffviewFilePanelSelected` to bg-only and
-      -- still see the pushed/unpushed colour. The leading separator space is
+      -- the user can customize `DiffviewCommitSelected` (e.g. with a bg)
+      -- without affecting the active filename's colour, which is controlled
+      -- by `DiffviewFilePanelSelected`. The leading separator space is
       -- excluded so a bg customization doesn't bleed into the gap.
       eq(1, #comp.extra_hls)
-      eq("DiffviewFilePanelSelected", comp.extra_hls[1].group)
+      eq("DiffviewCommitSelected", comp.extra_hls[1].group)
       eq(#" ", comp.extra_hls[1].first)
       eq(#" test", comp.extra_hls[1].last)
     end)
 
-    it("does not layer DiffviewFilePanelSelected when entry is not selected", function()
+    it("does not layer DiffviewCommitSelected when entry is not selected", function()
       local conf = config.get_config()
       conf.file_history_panel.subject_highlight = "ref_aware"
       config.setup(conf)


### PR DESCRIPTION
Relates to #175.