### PR TITLE
feat(config): wire `file_history_panel.log_options` to `jj`

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1180,17 +1180,33 @@ log_options                                     *diffview-config-log_options*
         top-level config field.
 
         This table allows you to control the default options that are passed
-        to git-log in order to produce the file history. The table is divided
-        into the sub-tables `single_file`, and `multi_file`. This allows you
-        to define different default log options for history targeting singular
-        files, and history targeting multiple paths, and/or directories.
+        to the underlying VCS log command in order to produce the file
+        history. The table is keyed by adapter name (`git`, `hg`, `jj`, `p4`),
+        and each adapter table is divided into the sub-tables `single_file`
+        and `multi_file`. This allows you to define different default log
+        options per VCS, and within each VCS for history targeting singular
+        files versus history targeting multiple paths and/or directories.
+
+        Note: The available fields differ per adapter, because each schema
+        mirrors the flags of the underlying VCS log command. Only the Git
+        schema is documented in detail in this help file
+        (|diffview.git.LogOptions|); the field lists for the other adapters
+        live alongside their type definitions (`HgLogOptions`,
+        `JjLogOptions`) in `lua/diffview/config.lua`. Perforce (`p4`) reuses
+        the Mercurial (`hg`) schema.
 
         Fields: ~
-            {single_file} (`LogOptions`)
-                See |diffview.git.LogOptions|.
+            {git} (`{ single_file: GitLogOptions, multi_file: GitLogOptions }`)
+                Log options for Git. See |diffview.git.LogOptions|.
 
-            {multi_file} (`LogOptions`)
-                See |diffview.git.LogOptions|.
+            {hg} (`{ single_file: HgLogOptions, multi_file: HgLogOptions }`)
+                Log options for Mercurial.
+
+            {jj} (`{ single_file: JjLogOptions, multi_file: JjLogOptions }`)
+                Log options for Jujutsu.
+
+            {p4} (`{ single_file: HgLogOptions, multi_file: HgLogOptions }`)
+                Log options for Perforce (reuses the `HgLogOptions` schema).
 
 default_args                                    *diffview-config-default_args*
         Type: `table<string, string[]>`, Default: `{}`

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -142,6 +142,10 @@ DEFAULT CONFIG                                  *diffview.defaults*
           single_file = {},
           multi_file = {},
         },
+        jj = {
+          single_file = {},
+          multi_file = {},
+        },
         p4 = {
           single_file = {},
           multi_file = {},

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -501,11 +501,13 @@ M.defaults = {
     ---@class DiffviewFileHistoryLogOptions
     ---@field git ConfigLogOptions
     ---@field hg ConfigLogOptions
+    ---@field jj ConfigLogOptions
     ---@field p4 ConfigLogOptions
 
     ---@class DiffviewFileHistoryLogOptions.user
     ---@field git? ConfigLogOptions.user Log options for git.
     ---@field hg? ConfigLogOptions.user Log options for hg.
+    ---@field jj? ConfigLogOptions.user Log options for Jujutsu.
     ---@field p4? ConfigLogOptions.user Log options for Perforce.
 
     ---@class ConfigLogOptions
@@ -528,6 +530,11 @@ M.defaults = {
       },
       ---@type ConfigLogOptions.user
       hg = {
+        single_file = {},
+        multi_file = {},
+      },
+      ---@type ConfigLogOptions.user
+      jj = {
         single_file = {},
         multi_file = {},
       },
@@ -764,7 +771,13 @@ M._config = M.defaults
 ---@field exclude? string
 ---@field path_args string[]
 
----@alias LogOptions GitLogOptions|HgLogOptions
+---@class JjLogOptions
+---@field limit integer
+---@field reversed boolean
+---@field revisions? string
+---@field path_args string[]
+
+---@alias LogOptions GitLogOptions|HgLogOptions|JjLogOptions
 
 ---@class GitLogOptions.user
 ---@field follow? boolean
@@ -805,7 +818,13 @@ M._config = M.defaults
 ---@field exclude? string
 ---@field path_args? string[]
 
----@alias LogOptions.user GitLogOptions.user|HgLogOptions.user
+---@class JjLogOptions.user
+---@field limit? integer
+---@field reversed? boolean
+---@field revisions? string
+---@field path_args? string[]
+
+---@alias LogOptions.user GitLogOptions.user|HgLogOptions.user|JjLogOptions.user
 
 M.log_option_defaults = {
   ---@type GitLogOptions
@@ -844,6 +863,13 @@ M.log_option_defaults = {
     exclude = nil,
     path_args = {},
   },
+  ---@type JjLogOptions
+  jj = {
+    limit = 256,
+    reversed = false,
+    revisions = nil,
+    path_args = {},
+  },
 }
 
 ---@return DiffviewConfig
@@ -856,10 +882,11 @@ function M.get_config()
 end
 
 ---@param single_file boolean
----@param t GitLogOptions|HgLogOptions
----@param vcs "git"|"hg"|"p4" # P4 reuses the `HgLogOptions` schema.
----@return GitLogOptions|HgLogOptions
+---@param t? LogOptions|LogOptions.user # Optional overrides; defaults to `{}`. The returned table is a deep copy callers may mutate safely.
+---@param vcs "git"|"hg"|"jj"|"p4" # P4 reuses the `HgLogOptions` schema.
+---@return LogOptions
 function M.get_log_options(single_file, t, vcs)
+  t = t or {}
   local log_options
 
   if single_file then
@@ -868,13 +895,11 @@ function M.get_log_options(single_file, t, vcs)
     log_options = M._config.file_history_panel.log_options[vcs].multi_file
   end
 
-  if t then
-    log_options = vim.tbl_extend("force", log_options, t)
+  log_options = vim.tbl_extend("force", utils.tbl_deep_clone(log_options), t)
 
-    for k, _ in pairs(log_options) do
-      if t[k] == "" then
-        log_options[k] = nil
-      end
+  for k, _ in pairs(log_options) do
+    if t[k] == "" then
+      log_options[k] = nil
     end
   end
 
@@ -1251,9 +1276,9 @@ function M.setup(user_config)
   end
 
   for _, name in ipairs({ "single_file", "multi_file" }) do
-    for _, vcs in ipairs({ "git", "hg" }) do
+    for _, vcs in ipairs({ "git", "hg", "jj" }) do
       local t = M._config.file_history_panel.log_options[vcs]
-      t[name] = vim.tbl_extend("force", M.log_option_defaults[vcs], t[name])
+      t[name] = vim.tbl_extend("force", utils.tbl_deep_clone(M.log_option_defaults[vcs]), t[name])
       for k, _ in pairs(t[name]) do
         if t[name][k] == "" then
           t[name][k] = nil

--- a/lua/diffview/tests/functional/config_options_spec.lua
+++ b/lua/diffview/tests/functional/config_options_spec.lua
@@ -255,3 +255,98 @@ describe("view.inline.deletion_treesitter", function()
     assert.equals(true, conf.view.inline.deletion_treesitter)
   end)
 end)
+
+describe("file_history_panel.log_options.jj", function()
+  local original
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+  end)
+
+  after_each(function()
+    config.setup(original)
+  end)
+
+  it("exposes a jj sub-table with single_file and multi_file slots", function()
+    local conf = setup_with({})
+    local jj = conf.file_history_panel.log_options.jj
+    assert.is_table(jj)
+    assert.is_table(jj.single_file)
+    assert.is_table(jj.multi_file)
+  end)
+
+  it("merges JjLogOptions defaults into empty single_file/multi_file", function()
+    local conf = setup_with({})
+    local defaults = require("diffview.config").log_option_defaults.jj
+    assert.equals(defaults.limit, conf.file_history_panel.log_options.jj.single_file.limit)
+    assert.equals(defaults.limit, conf.file_history_panel.log_options.jj.multi_file.limit)
+    assert.equals(defaults.reversed, conf.file_history_panel.log_options.jj.single_file.reversed)
+  end)
+
+  it("preserves user overrides while filling in missing defaults", function()
+    local conf = setup_with({
+      file_history_panel = {
+        log_options = {
+          jj = {
+            single_file = { limit = 100, revisions = "main..@" },
+          },
+        },
+      },
+    })
+    local sf = conf.file_history_panel.log_options.jj.single_file
+    assert.equals(100, sf.limit) -- user value preserved
+    assert.equals("main..@", sf.revisions) -- user value preserved
+    assert.equals(false, sf.reversed) -- default filled in
+  end)
+
+  it("get_log_options returns merged single_file options for jj", function()
+    setup_with({
+      file_history_panel = {
+        log_options = {
+          jj = { single_file = { limit = 42 } },
+        },
+      },
+    })
+    local opts = config.get_log_options(true, {}, "jj")
+    assert.equals(42, opts.limit)
+    assert.equals(false, opts.reversed)
+  end)
+
+  it("get_log_options merges per-call overrides on top of config", function()
+    setup_with({
+      file_history_panel = {
+        log_options = {
+          jj = { multi_file = { limit = 50 } },
+        },
+      },
+    })
+    local opts = config.get_log_options(false, { limit = 7 }, "jj")
+    assert.equals(7, opts.limit) -- call-site wins over config
+  end)
+
+  it("get_log_options returns a deep copy callers can mutate", function()
+    setup_with({})
+    local opts = config.get_log_options(true, {}, "jj")
+    table.insert(opts.path_args, "scratch")
+    local conf = config.get_config()
+    -- The stored defaults must not have been mutated through the alias.
+    assert.equals(0, #conf.file_history_panel.log_options.jj.single_file.path_args)
+  end)
+
+  it("get_log_options tolerates a nil overrides table", function()
+    setup_with({})
+    local opts = config.get_log_options(true, nil, "jj")
+    assert.is_table(opts)
+    assert.equals(256, opts.limit)
+  end)
+
+  it("setup gives single_file and multi_file independent list defaults", function()
+    local conf = setup_with({})
+    local sf = conf.file_history_panel.log_options.jj.single_file
+    local mf = conf.file_history_panel.log_options.jj.multi_file
+    -- The shared default `path_args = {}` must not alias across slots or back
+    -- to `log_option_defaults`.
+    assert.is_false(rawequal(sf.path_args, mf.path_args))
+    assert.is_false(rawequal(sf.path_args, config.log_option_defaults.jj.path_args))
+  end)
+end)


### PR DESCRIPTION
Note: The `JjAdapter` itself still fails on `:DiffviewFileHistory`; this commit only puts the config schema in place so later code can read it.

Relates to #139.