### PR TITLE
docs(license): add new maintainer copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Diffview.nvim is a tool for Neovim that adds an interface that enables
 easy review of changes made in any Git revision.
 Copyright (C) 2021 Sindre T. Strøm
+Copyright (C) 2025 David Yonge-Mallo
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Add new copyright line alongside the original author's to cover contributions made since taking over maintenance in 2025.