### PR TITLE
feat(merge): add `:DiffviewMergeFiles` for external merge drivers

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -197,6 +197,40 @@ COMMANDS                                        *diffview-commands*
             :DiffviewDiffFiles path/to/my\ file.txt path/to/other\ file.txt
 <
 
+                                                *:DiffviewMergeFiles*
+:DiffviewMergeFiles {output} [{base}] {left} {right}
+
+        Opens a 3-way or 4-way merge view backed by on-disk file paths,
+        suitable for use as an external merge tool. Unlike |:DiffviewOpen|,
+        this command does not require a VCS repository and does not query
+        any VCS state: every window's content comes straight from disk.
+
+        {output} is the editable buffer; saving it writes the resolved
+        content back to that path. The other paths open read-only.
+
+        When {base} is provided, the view starts in a 4-way layout
+        (OURS / BASE / THEIRS on top, OUTPUT below); otherwise it starts
+        in a 3-way horizontal layout (OURS | OUTPUT | THEIRS).
+
+        The conflict-marker actions described under |diffview-merge-tool|
+        operate on the {output} buffer and work unchanged here.
+
+        This is the integration point for tools like Jujutsu's
+        |jj-merge-tool|. Example `~/.config/jj/config.toml`: >toml
+
+            [merge-tools.diffview]
+            program = "nvim"
+            merge-args = [
+              "-c", "DiffviewMergeFiles $output $base $left $right",
+            ]
+            merge-tool-edits-conflict-markers = true
+<
+        With `merge-tool-edits-conflict-markers = true`, Jujutsu writes
+        conflict markers into {output} before the editor opens. Saving the
+        file (`:wqa`) returns control to Jujutsu, which checks for
+        remaining markers to decide whether the conflict is resolved. To
+        abort, exit with a non-zero status (`:cq`).
+
                                                 *:DiffviewFileHistory*
 :[range]DiffviewFileHistory [paths] [options]
 

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -150,6 +150,14 @@ function M.diff_files(args)
   end
 end
 
+---@param args string[]
+function M.merge_files(args)
+  local view = lib.diffview_merge_files(args)
+  if view then
+    view:open()
+  end
+end
+
 ---@param tabpage? integer
 ---@param opts? diffview.View.CloseOpts # Forwarded to `view:close`. With
 ---`force = false`, `DiffView` aborts when stage buffers are modified.
@@ -250,6 +258,10 @@ M.completers = {
   end,
   ---@param ctx CmdLineContext
   DiffviewDiffFiles = function(ctx)
+    return vim.fn.getcompletion(ctx.arg_lead, "file", false)
+  end,
+  ---@param ctx CmdLineContext
+  DiffviewMergeFiles = function(ctx)
     return vim.fn.getcompletion(ctx.arg_lead, "file", false)
   end,
   ---@param ctx CmdLineContext

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -5,6 +5,7 @@ require("diffview.bootstrap")
 
 local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
 local FileDiffView = lazy.access("diffview.scene.views.diff.file_diff_view", "FileDiffView") ---@type FileDiffView|LazyModule
+local FileMergeView = lazy.access("diffview.scene.views.diff.file_merge_view", "FileMergeView") ---@type FileMergeView|LazyModule
 local FileHistoryView =
   lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
 local GitAdapter = lazy.access("diffview.vcs.adapters.git", "GitAdapter") ---@type GitAdapter|LazyModule
@@ -250,6 +251,68 @@ function M.diffview_diff_files(args)
 
   table.insert(M.views, v)
   logger:debug("FileDiffView instantiation successful!")
+
+  return v
+end
+
+---Entry point for external merge drivers (jj, hg's external merge tool, etc.)
+---that hand the editor four on-disk file paths. The `output` file is the
+---resolved-content sink that the driver reads after the editor exits.
+---Argument order matches `jj-diffconflicts` and jj's documented `$output
+---$base $left $right` substitution order.
+---@param args string[]
+function M.diffview_merge_files(args)
+  local argo = arg_parser.parse(args)
+
+  logger:info("[command call] :DiffviewMergeFiles " .. table.concat(args, " "))
+
+  if #argo.args ~= 3 and #argo.args ~= 4 then
+    utils.err(
+      "DiffviewMergeFiles requires three or four file paths: <output> [<base>] <left> <right>."
+    )
+    return
+  end
+
+  local output_path = pl:absolute(pl:vim_expand(argo.args[1]))
+  local base_path, left_path, right_path
+
+  if #argo.args == 4 then
+    base_path = pl:absolute(pl:vim_expand(argo.args[2]))
+    left_path = pl:absolute(pl:vim_expand(argo.args[3]))
+    right_path = pl:absolute(pl:vim_expand(argo.args[4]))
+  else
+    left_path = pl:absolute(pl:vim_expand(argo.args[2]))
+    right_path = pl:absolute(pl:vim_expand(argo.args[3]))
+  end
+
+  -- `$output` is the only path that must already exist on disk: jj creates
+  -- it (empty or pre-populated with markers depending on
+  -- `merge-tool-edits-conflict-markers`). Missing read-only sides are
+  -- expected when the conflict has an add/delete side and render as empty
+  -- buffers via `FileMergeView`'s reader.
+  if vim.fn.filereadable(output_path) ~= 1 then
+    utils.err(("Output file not readable: %s"):format(output_path))
+    return
+  end
+
+  local toplevel = pl:parent(output_path) or "."
+  ---@diagnostic disable-next-line: missing-parameter, param-type-mismatch
+  local adapter = NullAdapter.create({ toplevel = toplevel })
+
+  local v = FileMergeView({
+    adapter = adapter,
+    output_path = output_path,
+    base_path = base_path,
+    left_path = left_path,
+    right_path = right_path,
+  })
+
+  if not v:is_valid() then
+    return
+  end
+
+  table.insert(M.views, v)
+  logger:debug("FileMergeView instantiation successful!")
 
   return v
 end

--- a/lua/diffview/scene/views/diff/file_merge_view.lua
+++ b/lua/diffview/scene/views/diff/file_merge_view.lua
@@ -1,0 +1,167 @@
+local lazy = require("diffview.lazy")
+local oop = require("diffview.oop")
+
+local Diff3Hor = lazy.access("diffview.scene.layouts.diff_3_hor", "Diff3Hor") ---@type Diff3Hor|LazyModule
+local Diff4Mixed = lazy.access("diffview.scene.layouts.diff_4_mixed", "Diff4Mixed") ---@type Diff4Mixed|LazyModule
+local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
+local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
+local FileEntry = lazy.access("diffview.scene.file_entry", "FileEntry") ---@type FileEntry|LazyModule
+local NullRev = lazy.access("diffview.vcs.adapters.null.rev", "NullRev") ---@type NullRev|LazyModule
+local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
+local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
+
+local fmt = string.format
+local pl = lazy.access(utils, "path") --[[@as PathLib ]]
+
+local M = {}
+
+---Read a file from disk into a list of lines. Returns an empty table if the
+---file is missing — jj invokes the merge tool with `$base = /dev/null`-style
+---paths when one of the conflict sides is an add/delete, so missing inputs
+---must render as empty rather than error.
+---@param path string
+---@return string[]
+local function read_lines(path)
+  if vim.fn.filereadable(path) ~= 1 then
+    return {}
+  end
+  return vim.fn.readfile(path)
+end
+
+---FileMergeView is the entry point used by external merge drivers (jj, hg
+---resolve, etc.) that pass on-disk file paths to the editor. Unlike
+---`DiffView` it does not query a VCS: the four buffer sources come straight
+---from the filesystem. The `output` window is bound to the real file on
+---disk via `RevType.LOCAL` so `:write` flushes there; the read-only sides
+---use `RevType.CUSTOM` with a `get_data` reader.
+---@class FileMergeView : DiffView
+---@operator call : FileMergeView
+---@field output_path string # Absolute path the resolved content writes back to.
+---@field base_path? string # Absolute path of the common ancestor; nil for 3-way merges.
+---@field left_path string # Absolute path of OURS / "left" side.
+---@field right_path string # Absolute path of THEIRS / "right" side.
+local FileMergeView = oop.create_class("FileMergeView", DiffView.__get())
+
+---@class FileMergeView.init.Opt
+---@field adapter NullAdapter
+---@field output_path string
+---@field base_path? string
+---@field left_path string
+---@field right_path string
+
+---@param opt FileMergeView.init.Opt
+function FileMergeView:init(opt)
+  local output_rev = NullRev(RevType.LOCAL)
+  local left_rev = NullRev(RevType.CUSTOM)
+  local right_rev = NullRev(RevType.CUSTOM)
+  local base_rev = opt.base_path and NullRev(RevType.CUSTOM) or nil
+
+  -- DiffView's `left`/`right` are used for the panel header and rev-arg
+  -- bookkeeping. We pass the OURS/THEIRS revs here since they correspond
+  -- to the visual left and right sides of the diff.
+  self:super({
+    adapter = opt.adapter,
+    path_args = {},
+    rev_arg = nil,
+    left = left_rev,
+    right = right_rev,
+    options = {},
+  })
+
+  self.output_path = opt.output_path
+  self.base_path = opt.base_path
+  self.left_path = opt.left_path
+  self.right_path = opt.right_path
+
+  self.panel.rev_pretty_name = pl:basename(self.output_path)
+
+  local function make_file(path, rev, label, reader_path)
+    local f = File({
+      adapter = self.adapter,
+      path = path,
+      kind = "conflicting",
+      get_data = reader_path and function()
+        return read_lines(reader_path)
+      end or nil,
+      rev = rev,
+    }) --[[@as vcs.File ]]
+    f.winbar = fmt(" %s - %s", label, pl:basename(path))
+    return f
+  end
+
+  local a_file = make_file(self.left_path, left_rev, "OURS (Current changes)", self.left_path)
+  local b_file = make_file(self.output_path, output_rev, "MERGED (Output)", nil)
+  local c_file = make_file(self.right_path, right_rev, "THEIRS (Incoming changes)", self.right_path)
+
+  local layout
+  if self.base_path then
+    local d_file = make_file(self.base_path, base_rev, "BASE (Common ancestor)", self.base_path)
+    layout = Diff4Mixed.__get()({ a = a_file, b = b_file, c = c_file, d = d_file })
+  else
+    layout = Diff3Hor.__get()({ a = a_file, b = b_file, c = c_file })
+  end
+
+  local entry = FileEntry({
+    adapter = self.adapter,
+    path = self.output_path,
+    status = "U",
+    kind = "conflicting",
+    revs = { a = left_rev, b = output_rev, c = right_rev, d = base_rev },
+    layout = layout,
+  })
+
+  self.files:set_conflicting({ entry })
+  self.files:update_file_trees()
+end
+
+---@override
+function FileMergeView:post_open()
+  vim.cmd("redraw")
+
+  self:init_event_listeners()
+
+  local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
+  self.commit_log_panel = CommitLogPanel(self, self.adapter, {
+    name = fmt("diffview://%s/log/%d/%s", self.adapter.ctx.dir, self.tabpage, "commit_log"),
+  })
+
+  vim.schedule(function()
+    self:file_safeguard()
+    self.is_loading = false
+    self.panel.is_loading = false
+    self.panel:render()
+    self.panel:redraw()
+
+    local files = self.panel:ordered_file_list()
+    if files and files[1] then
+      self:set_file(files[1], false, true)
+    end
+
+    self.ready = true
+  end)
+end
+
+---@override
+---Hide the file panel: there is only one entry and no VCS metadata to show.
+function FileMergeView:init_layout()
+  local curwin = vim.api.nvim_get_current_win()
+
+  self:use_layout(FileMergeView.get_temp_layout())
+  self.cur_layout:create()
+
+  if not vim.t[self.tabpage].diffview_view_initialized then
+    vim.api.nvim_win_close(curwin, false)
+    vim.t[self.tabpage].diffview_view_initialized = true
+  end
+
+  self.panel:focus(true)
+  self.emitter:emit("post_layout")
+end
+
+---@override
+---No-op: the file list is static; there is no VCS state to re-query.
+function FileMergeView:update_files() end
+
+M.FileMergeView = FileMergeView
+
+return M

--- a/lua/diffview/tests/functional/file_merge_view_spec.lua
+++ b/lua/diffview/tests/functional/file_merge_view_spec.lua
@@ -1,0 +1,237 @@
+local helpers = require("diffview.tests.helpers")
+local lib = require("diffview.lib")
+local Diff3Hor = require("diffview.scene.layouts.diff_3_hor").Diff3Hor
+local Diff4Mixed = require("diffview.scene.layouts.diff_4_mixed").Diff4Mixed
+local FileMergeView = require("diffview.scene.views.diff.file_merge_view").FileMergeView
+local NullAdapter = require("diffview.vcs.adapters.null").NullAdapter
+local RevType = require("diffview.vcs.rev").RevType
+
+local eq = helpers.eq
+
+local function tmpfile(content)
+  local path = vim.fn.tempname()
+  local f = io.open(path, "w")
+  f:write(content)
+  f:close()
+  return path
+end
+
+describe("diffview.scene.views.diff.file_merge_view", function()
+  describe("FileMergeView constructor", function()
+    local output_path, base_path, left_path, right_path
+
+    before_each(function()
+      output_path = tmpfile("output\n")
+      base_path = tmpfile("base\n")
+      left_path = tmpfile("left\n")
+      right_path = tmpfile("right\n")
+    end)
+
+    after_each(function()
+      for _, p in ipairs({ output_path, base_path, left_path, right_path }) do
+        os.remove(p)
+      end
+    end)
+
+    it("creates a valid view in 4-way mode when base is provided", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        base_path = base_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      assert.True(view:is_valid())
+      eq(output_path, view.output_path)
+      eq(base_path, view.base_path)
+      eq(left_path, view.left_path)
+      eq(right_path, view.right_path)
+    end)
+
+    it("creates a 3-way layout when base is omitted", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      assert.True(view:is_valid())
+      assert.is_nil(view.base_path)
+      assert.True(view.files.conflicting[1].layout:instanceof(Diff3Hor))
+    end)
+
+    it("uses Diff4Mixed when base is provided", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        base_path = base_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      assert.True(view.files.conflicting[1].layout:instanceof(Diff4Mixed))
+    end)
+
+    it("populates conflicting (not working) with a single entry", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        base_path = base_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      eq(1, view.files:len())
+      eq(0, #view.files.working)
+      eq(0, #view.files.staged)
+      eq(1, #view.files.conflicting)
+      eq("conflicting", view.files.conflicting[1].kind)
+    end)
+
+    it("binds the output side to a LOCAL rev (editable, real file)", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        base_path = base_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      -- b is the editable middle window, bound to $output.
+      eq(RevType.LOCAL, view.files.conflicting[1].revs.b.type)
+    end)
+
+    it("uses CUSTOM revs for the read-only inputs", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        base_path = base_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      local revs = view.files.conflicting[1].revs
+      eq(RevType.CUSTOM, revs.a.type) -- left/OURS
+      eq(RevType.CUSTOM, revs.c.type) -- right/THEIRS
+      eq(RevType.CUSTOM, revs.d.type) -- base
+    end)
+
+    it("binds each window's file to the matching on-disk path", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        base_path = base_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      local layout = view.files.conflicting[1].layout
+      eq(left_path, layout.a.file.path) -- OURS
+      eq(output_path, layout.b.file.path) -- OUTPUT (editable)
+      eq(right_path, layout.c.file.path) -- THEIRS
+      eq(base_path, layout.d.file.path) -- BASE
+    end)
+  end)
+
+  describe("lib.diffview_merge_files", function()
+    it("returns nil when given fewer than three args", function()
+      assert.is_nil(lib.diffview_merge_files({}))
+      assert.is_nil(lib.diffview_merge_files({ "a" }))
+      assert.is_nil(lib.diffview_merge_files({ "a", "b" }))
+    end)
+
+    it("returns nil when given more than four args", function()
+      assert.is_nil(lib.diffview_merge_files({ "a", "b", "c", "d", "e" }))
+    end)
+
+    it("returns nil when the output file does not exist", function()
+      local left = tmpfile("l\n")
+      local right = tmpfile("r\n")
+      local view = lib.diffview_merge_files({ "/nonexistent/output", left, right })
+      assert.is_nil(view)
+      os.remove(left)
+      os.remove(right)
+    end)
+
+    it("creates a 3-way FileMergeView for three existing paths", function()
+      local output = tmpfile("o\n")
+      local left = tmpfile("l\n")
+      local right = tmpfile("r\n")
+
+      local view = lib.diffview_merge_files({ output, left, right })
+      assert.is_not_nil(view)
+      assert.True(view:is_valid())
+      assert.is_nil(view.base_path)
+      eq(1, view.files:len())
+
+      for i, v in ipairs(lib.views) do
+        if v == view then
+          table.remove(lib.views, i)
+          break
+        end
+      end
+
+      os.remove(output)
+      os.remove(left)
+      os.remove(right)
+    end)
+
+    it("creates a 4-way FileMergeView when base is provided", function()
+      local output = tmpfile("o\n")
+      local base = tmpfile("b\n")
+      local left = tmpfile("l\n")
+      local right = tmpfile("r\n")
+
+      local view = lib.diffview_merge_files({ output, base, left, right })
+      assert.is_not_nil(view)
+      assert.True(view:is_valid())
+      eq(base, view.base_path)
+      eq(1, view.files:len())
+
+      for i, v in ipairs(lib.views) do
+        if v == view then
+          table.remove(lib.views, i)
+          break
+        end
+      end
+
+      for _, p in ipairs({ output, base, left, right }) do
+        os.remove(p)
+      end
+    end)
+  end)
+
+  describe("FileMergeView:update_files", function()
+    it("is a no-op", function()
+      local output = tmpfile("o\n")
+      local left = tmpfile("l\n")
+      local right = tmpfile("r\n")
+
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output,
+        left_path = left,
+        right_path = right,
+      })
+
+      assert.has_no.errors(function()
+        view:update_files()
+      end)
+      eq(1, view.files:len())
+
+      os.remove(output)
+      os.remove(left)
+      os.remove(right)
+    end)
+  end)
+end)

--- a/plugin/diffview.lua
+++ b/plugin/diffview.lua
@@ -32,6 +32,10 @@ command("DiffviewDiffFiles", function(ctx)
   diffview.diff_files(arg_parser.scan(ctx.args).args)
 end, { nargs = "+", complete = completion })
 
+command("DiffviewMergeFiles", function(ctx)
+  diffview.merge_files(arg_parser.scan(ctx.args).args)
+end, { nargs = "+", complete = completion })
+
 command("DiffviewFileHistory", function(ctx)
   local range
 


### PR DESCRIPTION
Opens a 3-way or 4-way merge view backed by on-disk file paths (`output`, optional `base`, `left`, `right`), suitable for use as Jujutsu's `[merge-tools.diffview]`. The `output` window uses `RevType.LOCAL` so `:write` flushes to disk; read-only sides use `RevType.CUSTOM` with a file reader. Layout is `Diff4Mixed` when `base` is provided, `Diff3Hor` otherwise.

Conflict-marker actions (`<leader>co/ct/cb/ca`, `dx`, `2do/3do`, `]x`/`[x`) operate on the output buffer and work unchanged.

Relates to https://github.com/dlyongemallo/diffview.nvim/issues/139#issuecomment-4477594120 and https://github.com/sindrets/diffview.nvim/issues/562.