### PR TITLE
feat(dir-diff): add `:DiffviewDiffDirs` for two/three-directory diff

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -197,6 +197,36 @@ COMMANDS                                        *diffview-commands*
             :DiffviewDiffFiles path/to/my\ file.txt path/to/other\ file.txt
 <
 
+                                                *:DiffviewDiffDirs*
+:DiffviewDiffDirs {left} {right} [{output}]
+
+        Opens a diff view comparing two directories on disk, with no VCS
+        involvement. The file panel lists every path that differs between
+        {left} and {right} (in content or existence). Each entry opens a
+        side-by-side diff backed by the on-disk files; saving a buffer
+        writes through to its path.
+
+        When {output} is omitted (2-pane mode), both sides are editable and
+        mirror |:DiffviewDiffFiles| semantics. When {output} is provided
+        (3-pane mode), the left and right sides are read-only references
+        and the middle buffer points at the matching `{output}/{relpath}`
+        file, which is what the user edits.
+
+        This is the integration point for tools like Jujutsu's diff editor
+        (`jj squash -i`, `jj split -i`, `jj diffedit`). Example
+        `~/.config/jj/config.toml`: >toml
+
+            [ui]
+            diff-editor = "diffview"
+
+            [merge-tools.diffview]
+            program = "nvim"
+            edit-args = [
+              "-c", "DiffviewDiffDirs $left $right $output",
+            ]
+<
+        Drop the `$output` argument for 2-pane mode.
+
                                                 *:DiffviewMergeFiles*
 :DiffviewMergeFiles {output} [{base}] {left} {right}
 

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -158,6 +158,14 @@ function M.merge_files(args)
   end
 end
 
+---@param args string[]
+function M.dir_diff(args)
+  local view = lib.diffview_dir_diff(args)
+  if view then
+    view:open()
+  end
+end
+
 ---@param tabpage? integer
 ---@param opts? diffview.View.CloseOpts # Forwarded to `view:close`. With
 ---`force = false`, `DiffView` aborts when stage buffers are modified.
@@ -263,6 +271,10 @@ M.completers = {
   ---@param ctx CmdLineContext
   DiffviewMergeFiles = function(ctx)
     return vim.fn.getcompletion(ctx.arg_lead, "file", false)
+  end,
+  ---@param ctx CmdLineContext
+  DiffviewDiffDirs = function(ctx)
+    return vim.fn.getcompletion(ctx.arg_lead, "dir", false)
   end,
   ---@param ctx CmdLineContext
   DiffviewFileHistory = function(ctx)

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -5,6 +5,8 @@ require("diffview.bootstrap")
 
 local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
 local FileDiffView = lazy.access("diffview.scene.views.diff.file_diff_view", "FileDiffView") ---@type FileDiffView|LazyModule
+local FileDirDiffView =
+  lazy.access("diffview.scene.views.diff.file_dir_diff_view", "FileDirDiffView") ---@type FileDirDiffView|LazyModule
 local FileMergeView = lazy.access("diffview.scene.views.diff.file_merge_view", "FileMergeView") ---@type FileMergeView|LazyModule
 local FileHistoryView =
   lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
@@ -313,6 +315,65 @@ function M.diffview_merge_files(args)
 
   table.insert(M.views, v)
   logger:debug("FileMergeView instantiation successful!")
+
+  return v
+end
+
+---Entry point for external diff-editor drivers (jj's `diff-editor`, etc.)
+---that hand the editor two directories plus optionally an editable
+---`$output` directory. Argument order matches jj's documented `$left
+---$right $output` substitution order; omit the third arg for 2-pane mode.
+---@param args string[]
+function M.diffview_dir_diff(args)
+  local argo = arg_parser.parse(args)
+
+  logger:info("[command call] :DiffviewDiffDirs " .. table.concat(args, " "))
+
+  if #argo.args ~= 2 and #argo.args ~= 3 then
+    utils.err("DiffviewDiffDirs requires two or three directory paths: <left> <right> [<output>].")
+    return
+  end
+
+  local left_path = pl:absolute(pl:vim_expand(argo.args[1]))
+  local right_path = pl:absolute(pl:vim_expand(argo.args[2]))
+  local output_path = argo.args[3] and pl:absolute(pl:vim_expand(argo.args[3])) or nil
+
+  for _, p in ipairs({ left_path, right_path, output_path }) do
+    if p and not pl:is_dir(p) then
+      utils.err(("Not a directory: %s"):format(p))
+      return
+    end
+  end
+
+  -- Walk before constructing the view so we can bail out with a clear
+  -- message when the two sides match: an empty `FileDirDiffView` would
+  -- otherwise present an editor with no file panel content, which is
+  -- particularly opaque for external diff-editor drivers like jj.
+  local FileDirDiffViewMod = require("diffview.scene.views.diff.file_dir_diff_view")
+  local diffs = FileDirDiffViewMod.diff_dirs(left_path, right_path)
+  if next(diffs) == nil then
+    utils.info("No differences between the given directories.")
+    return
+  end
+
+  local toplevel = output_path or right_path
+  ---@diagnostic disable-next-line: missing-parameter, param-type-mismatch
+  local adapter = NullAdapter.create({ toplevel = toplevel })
+
+  local v = FileDirDiffView({
+    adapter = adapter,
+    left_path = left_path,
+    right_path = right_path,
+    output_path = output_path,
+    diffs = diffs,
+  })
+
+  if not v:is_valid() then
+    return
+  end
+
+  table.insert(M.views, v)
+  logger:debug("FileDirDiffView instantiation successful!")
 
   return v
 end

--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -604,6 +604,50 @@ function PathLib:readable(path)
   return false
 end
 
+---Recursively enumerate regular files under `dir`, returning their paths
+---relative to `dir` using `self.sep`. Directories are descended into;
+---symlinks are not followed. Returns an empty table when `dir` is not a
+---readable directory.
+---
+---`uv.fs_scandir_next` may report `nil`/`"unknown"` for `ftype` on
+---filesystems that don't expose `d_type` (XFS without `ftype=1`, some NFS
+---mounts). Falling back to `uv.fs_lstat` (not `fs_stat`) keeps such entries
+---visible without following symlinks, so a symlinked directory -- or
+---symlink cycle -- doesn't cause out-of-tree traversal or stack overflow.
+---@param dir string
+---@return string[]
+function PathLib:files_under(dir)
+  local out = {}
+  local sep = self.sep
+
+  local function walk(absdir, prefix)
+    local fd = uv.fs_scandir(absdir)
+    if not fd then
+      return
+    end
+    while true do
+      local name, ftype = uv.fs_scandir_next(fd)
+      if not name then
+        break
+      end
+      local rel = prefix == "" and name or prefix .. sep .. name
+      local abs = absdir .. sep .. name
+      if not ftype or ftype == "unknown" then
+        local st = uv.fs_lstat(abs)
+        ftype = st and st.type
+      end
+      if ftype == "directory" then
+        walk(abs, rel)
+      elseif ftype == "file" then
+        out[#out + 1] = rel
+      end
+    end
+  end
+
+  walk(dir, "")
+  return out
+end
+
 ---@class PathLib.touch.Opt
 ---@field mode? integer
 ---@field parents? boolean

--- a/lua/diffview/scene/views/diff/file_dir_diff_view.lua
+++ b/lua/diffview/scene/views/diff/file_dir_diff_view.lua
@@ -1,0 +1,276 @@
+local lazy = require("diffview.lazy")
+local oop = require("diffview.oop")
+
+local Diff2Hor = lazy.access("diffview.scene.layouts.diff_2_hor", "Diff2Hor") ---@type Diff2Hor|LazyModule
+local Diff3Hor = lazy.access("diffview.scene.layouts.diff_3_hor", "Diff3Hor") ---@type Diff3Hor|LazyModule
+local DiffView = lazy.access("diffview.scene.views.diff.diff_view", "DiffView") ---@type DiffView|LazyModule
+local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
+local FileEntry = lazy.access("diffview.scene.file_entry", "FileEntry") ---@type FileEntry|LazyModule
+local NullRev = lazy.access("diffview.vcs.adapters.null.rev", "NullRev") ---@type NullRev|LazyModule
+local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
+local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
+
+local fmt = string.format
+local pl = lazy.access(utils, "path") --[[@as PathLib ]]
+local uv = vim.uv
+
+local M = {}
+
+local FILES_EQUAL_CHUNK = 65536
+
+---Read a file from disk into a list of lines. Returns an empty table when
+---the file is missing — for left-only / right-only entries the absent side
+---must render as an empty buffer rather than error.
+---@param path string
+---@return string[]
+local function read_lines(path)
+  if vim.fn.filereadable(path) ~= 1 then
+    return {}
+  end
+  return vim.fn.readfile(path)
+end
+
+---Content-equality check used to filter out files that exist on both sides
+---but are identical. Reads both files in 64 KiB chunks via `uv.fs_read` and
+---bails on the first mismatch, so identical files no larger than the
+---kernel's read-ahead cache pay one buffer's worth of memory and differing
+---files don't have to be fully read.
+---@param a string
+---@param b string
+---@return boolean
+local function files_equal(a, b)
+  local stat_a = pl:stat(a)
+  local stat_b = pl:stat(b)
+  if stat_a and stat_b and stat_a.size ~= stat_b.size then
+    return false
+  end
+
+  local fd_a = uv.fs_open(a, "r", 0)
+  if not fd_a then
+    return false
+  end
+  local fd_b = uv.fs_open(b, "r", 0)
+  if not fd_b then
+    uv.fs_close(fd_a)
+    return false
+  end
+
+  local equal = true
+  while true do
+    local chunk_a = uv.fs_read(fd_a, FILES_EQUAL_CHUNK) or ""
+    local chunk_b = uv.fs_read(fd_b, FILES_EQUAL_CHUNK) or ""
+    if chunk_a ~= chunk_b then
+      equal = false
+      break
+    end
+    if chunk_a == "" then
+      break
+    end
+  end
+  uv.fs_close(fd_a)
+  uv.fs_close(fd_b)
+  return equal
+end
+
+---Resolve the per-file status by comparing existence and content on the two
+---reference sides ($left and $right). The $output side, when present, does
+---not participate in the diff classification: it starts as a copy of one
+---side and the user mutates it.
+---@param left_root string
+---@param right_root string
+---@return table<string, "A"|"D"|"M">
+function M.diff_dirs(left_root, right_root)
+  local left_set, right_set = {}, {}
+  for _, rel in ipairs(pl:files_under(left_root)) do
+    left_set[rel] = true
+  end
+  for _, rel in ipairs(pl:files_under(right_root)) do
+    right_set[rel] = true
+  end
+
+  local entries = {}
+  for rel in pairs(left_set) do
+    if right_set[rel] then
+      if not files_equal(pl:join(left_root, rel), pl:join(right_root, rel)) then
+        entries[rel] = "M"
+      end
+    else
+      entries[rel] = "D"
+    end
+  end
+  for rel in pairs(right_set) do
+    if not left_set[rel] then
+      entries[rel] = "A"
+    end
+  end
+  return entries
+end
+
+---FileDirDiffView compares two on-disk directories (and optionally writes
+---results into a third "$output" directory) without consulting any VCS. The
+---file panel lists every path that differs in content or existence between
+---`$left` and `$right`. Each file entry's b-side is bound to a real on-disk
+---path via `RevType.LOCAL` so `:write` flushes to that location.
+---
+---Two-pane mode mirrors `FileDiffView`: a = `$left/<rel>`, b = `$right/<rel>`,
+---both LOCAL and editable. Three-pane mode mirrors jj's diff-editor 3-pane
+---contract: a = `$left/<rel>` (read-only), b = `$output/<rel>` (LOCAL,
+---editable), c = `$right/<rel>` (read-only).
+---@class FileDirDiffView : DiffView
+---@operator call : FileDirDiffView
+---@field left_path string Absolute path to the "$left" directory.
+---@field right_path string Absolute path to the "$right" directory.
+---@field output_path? string Absolute path to the editable "$output" directory; nil for 2-pane mode.
+local FileDirDiffView = oop.create_class("FileDirDiffView", DiffView.__get())
+
+---@class FileDirDiffView.init.Opt
+---@field adapter NullAdapter
+---@field left_path string
+---@field right_path string
+---@field output_path? string
+---@field diffs? table<string, "A"|"D"|"M"> # Precomputed `M.diff_dirs` result; lets callers skip a redundant walk after checking for empty diffs.
+
+---@param opt FileDirDiffView.init.Opt
+function FileDirDiffView:init(opt)
+  local three_pane = opt.output_path ~= nil
+  local a_rev = NullRev(RevType.CUSTOM) -- read-only $left (3-pane) or LOCAL $left (2-pane); fixed up below
+  local b_rev = NullRev(RevType.LOCAL) -- editable target ($right in 2-pane, $output in 3-pane)
+  local c_rev = three_pane and NullRev(RevType.CUSTOM) or nil
+
+  if not three_pane then
+    -- 2-pane mirrors `FileDiffView`: both sides LOCAL so the user can edit
+    -- either. jj reads back from `$right` after exit; edits to `$left` are
+    -- ignored on the jj side and persist as filesystem edits otherwise.
+    a_rev = NullRev(RevType.LOCAL)
+  end
+
+  self:super({
+    adapter = opt.adapter,
+    path_args = {},
+    rev_arg = nil,
+    left = a_rev,
+    right = b_rev,
+    options = {},
+  })
+
+  self.left_path = opt.left_path
+  self.right_path = opt.right_path
+  self.output_path = opt.output_path
+
+  self.panel.rev_pretty_name = fmt(
+    "%s \u{2194} %s",
+    pl:basename(self.left_path),
+    pl:basename(self.output_path or self.right_path)
+  )
+
+  local diffs = opt.diffs or M.diff_dirs(self.left_path, self.right_path)
+  local rels = vim.tbl_keys(diffs)
+  table.sort(rels)
+
+  local entries = {}
+  for _, rel in ipairs(rels) do
+    entries[#entries + 1] = self:_build_entry(rel, diffs[rel], a_rev, b_rev, c_rev)
+  end
+
+  self.files:set_working(entries)
+  self.files:update_file_trees()
+end
+
+---Build the FileEntry for a single differing path. Mirrors the per-symbol
+---`File` construction used by `FileMergeView`: each window's underlying
+---`File` is built by hand so its `path` can point at a different on-disk
+---absolute path while sharing one `NullAdapter`.
+---@param rel string Relative path under the diff roots.
+---@param status "A"|"D"|"M"
+---@param a_rev Rev
+---@param b_rev Rev
+---@param c_rev? Rev
+---@return FileEntry
+function FileDirDiffView:_build_entry(rel, status, a_rev, b_rev, c_rev)
+  local three_pane = c_rev ~= nil
+  local left_abs = pl:join(self.left_path, rel)
+  local right_abs = pl:join(self.right_path, rel)
+  local b_abs = three_pane and pl:join(self.output_path, rel) or right_abs
+
+  local function make_file(path, rev, label, reader)
+    local f = File({
+      adapter = self.adapter,
+      path = path,
+      kind = "working",
+      get_data = reader,
+      rev = rev,
+    }) --[[@as vcs.File ]]
+    if label then
+      f.winbar = fmt(" %s - %s", label, rel)
+    end
+    return f
+  end
+
+  local a_file, b_file, c_file
+  if three_pane then
+    a_file = make_file(left_abs, a_rev, "LEFT", function()
+      return read_lines(left_abs)
+    end)
+    b_file = make_file(b_abs, b_rev, "OUTPUT", nil)
+    c_file = make_file(right_abs, c_rev, "RIGHT", function()
+      return read_lines(right_abs)
+    end)
+  else
+    -- Both sides editable; mirrors `FileDiffView`. No winbar override so the
+    -- default WORKING TREE winbar from `File:init` is used, matching
+    -- `:DiffviewDiffFiles`.
+    a_file = make_file(left_abs, a_rev, nil, nil)
+    b_file = make_file(b_abs, b_rev, nil, nil)
+  end
+
+  local layout
+  if three_pane then
+    layout = Diff3Hor.__get()({ a = a_file, b = b_file, c = c_file })
+  else
+    layout = Diff2Hor.__get()({ a = a_file, b = b_file })
+  end
+
+  return FileEntry({
+    adapter = self.adapter,
+    path = rel,
+    status = status,
+    kind = "working",
+    revs = { a = a_rev, b = b_rev, c = c_rev },
+    layout = layout,
+  })
+end
+
+---@override
+function FileDirDiffView:post_open()
+  vim.cmd("redraw")
+
+  self:init_event_listeners()
+
+  local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
+  self.commit_log_panel = CommitLogPanel(self, self.adapter, {
+    name = fmt("diffview://%s/log/%d/%s", self.adapter.ctx.dir, self.tabpage, "commit_log"),
+  })
+
+  vim.schedule(function()
+    self:file_safeguard()
+    self.is_loading = false
+    self.panel.is_loading = false
+    self.panel:render()
+    self.panel:redraw()
+
+    local files = self.panel:ordered_file_list()
+    if files and files[1] then
+      self:set_file(files[1], false, true)
+    end
+
+    self.ready = true
+  end)
+end
+
+---@override
+---No-op: the file list is static; this view does not query any VCS.
+function FileDirDiffView:update_files() end
+
+M.FileDirDiffView = FileDirDiffView
+
+return M

--- a/lua/diffview/tests/functional/file_dir_diff_view_spec.lua
+++ b/lua/diffview/tests/functional/file_dir_diff_view_spec.lua
@@ -1,0 +1,252 @@
+local helpers = require("diffview.tests.helpers")
+local lib = require("diffview.lib")
+local Diff2Hor = require("diffview.scene.layouts.diff_2_hor").Diff2Hor
+local Diff3Hor = require("diffview.scene.layouts.diff_3_hor").Diff3Hor
+local FileDirDiffView = require("diffview.scene.views.diff.file_dir_diff_view").FileDirDiffView
+local NullAdapter = require("diffview.vcs.adapters.null").NullAdapter
+local RevType = require("diffview.vcs.rev").RevType
+
+local eq = helpers.eq
+
+local function mktmpdir()
+  local path = vim.fn.tempname()
+  vim.fn.mkdir(path, "p")
+  return path
+end
+
+local function write_file(path, content)
+  local fd = io.open(path, "w")
+  fd:write(content)
+  fd:close()
+end
+
+local function rm_rf(path)
+  vim.fn.delete(path, "rf")
+end
+
+---Populate a directory triple shaped like jj would lay it out: $left
+---contains "before" content, $right contains "after" content, $output is a
+---copy of $right ready for the user to edit. Returns paths to all three
+---plus the shared parent (for cleanup).
+---@return string left
+---@return string right
+---@return string output
+---@return string root
+local function fixture()
+  local root = mktmpdir()
+  local left = root .. "/left"
+  local right = root .. "/right"
+  local output = root .. "/output"
+  vim.fn.mkdir(left .. "/sub", "p")
+  vim.fn.mkdir(right .. "/sub", "p")
+  vim.fn.mkdir(output .. "/sub", "p")
+
+  write_file(left .. "/same.txt", "shared\n")
+  write_file(right .. "/same.txt", "shared\n")
+  write_file(output .. "/same.txt", "shared\n")
+
+  write_file(left .. "/changed.txt", "before\n")
+  write_file(right .. "/changed.txt", "after\n")
+  write_file(output .. "/changed.txt", "after\n")
+
+  write_file(left .. "/only_left.txt", "left-only\n")
+  write_file(right .. "/only_right.txt", "right-only\n")
+  write_file(output .. "/only_right.txt", "right-only\n")
+
+  write_file(left .. "/sub/nested.txt", "nested-before\n")
+  write_file(right .. "/sub/nested.txt", "nested-after\n")
+  write_file(output .. "/sub/nested.txt", "nested-after\n")
+
+  return left, right, output, root
+end
+
+describe("diffview.scene.views.diff.file_dir_diff_view", function()
+  local left, right, output, root
+
+  before_each(function()
+    left, right, output, root = fixture()
+  end)
+
+  after_each(function()
+    rm_rf(root)
+  end)
+
+  describe("FileDirDiffView constructor (2-pane)", function()
+    it("creates a valid view", function()
+      local adapter = NullAdapter.create({ toplevel = right })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+      })
+
+      assert.True(view:is_valid())
+      eq(left, view.left_path)
+      eq(right, view.right_path)
+      assert.is_nil(view.output_path)
+    end)
+
+    it("lists exactly the differing paths", function()
+      local adapter = NullAdapter.create({ toplevel = right })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+      })
+
+      local paths = {}
+      for _, e in ipairs(view.files.working) do
+        paths[e.path] = e.status
+      end
+
+      eq("M", paths["changed.txt"])
+      eq("D", paths["only_left.txt"])
+      eq("A", paths["only_right.txt"])
+      eq("M", paths["sub/nested.txt"]) -- recursive walk
+      assert.is_nil(paths["same.txt"]) -- identical content filtered out
+    end)
+
+    it("uses Diff2Hor with both sides bound to LOCAL", function()
+      local adapter = NullAdapter.create({ toplevel = right })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+      })
+
+      local e = view.files.working[1]
+      assert.True(e.layout:instanceof(Diff2Hor))
+      eq(RevType.LOCAL, e.revs.a.type)
+      eq(RevType.LOCAL, e.revs.b.type)
+    end)
+
+    it("points each entry's a/b file at the matching left/right path", function()
+      local adapter = NullAdapter.create({ toplevel = right })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+      })
+
+      for _, e in ipairs(view.files.working) do
+        eq(left .. "/" .. e.path, e.layout.a.file.path)
+        eq(right .. "/" .. e.path, e.layout.b.file.path)
+      end
+    end)
+  end)
+
+  describe("FileDirDiffView constructor (3-pane)", function()
+    it("uses Diff3Hor when output is provided", function()
+      local adapter = NullAdapter.create({ toplevel = output })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+        output_path = output,
+      })
+
+      local e = view.files.working[1]
+      assert.True(e.layout:instanceof(Diff3Hor))
+    end)
+
+    it("makes the b-side LOCAL (editable output) and a/c CUSTOM (read-only)", function()
+      local adapter = NullAdapter.create({ toplevel = output })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+        output_path = output,
+      })
+
+      local e = view.files.working[1]
+      eq(RevType.CUSTOM, e.revs.a.type)
+      eq(RevType.LOCAL, e.revs.b.type)
+      eq(RevType.CUSTOM, e.revs.c.type)
+    end)
+
+    it("points b at $output/<rel>, a at $left/<rel>, c at $right/<rel>", function()
+      local adapter = NullAdapter.create({ toplevel = output })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+        output_path = output,
+      })
+
+      for _, e in ipairs(view.files.working) do
+        eq(left .. "/" .. e.path, e.layout.a.file.path)
+        eq(output .. "/" .. e.path, e.layout.b.file.path)
+        eq(right .. "/" .. e.path, e.layout.c.file.path)
+      end
+    end)
+  end)
+
+  describe("lib.diffview_dir_diff", function()
+    local function dispose(view)
+      for i, v in ipairs(lib.views) do
+        if v == view then
+          table.remove(lib.views, i)
+          break
+        end
+      end
+    end
+
+    it("returns nil when given fewer than two paths", function()
+      assert.is_nil(lib.diffview_dir_diff({}))
+      assert.is_nil(lib.diffview_dir_diff({ left }))
+    end)
+
+    it("returns nil when given more than three paths", function()
+      assert.is_nil(lib.diffview_dir_diff({ left, right, output, "extra" }))
+    end)
+
+    it("returns nil when a path is not a directory", function()
+      local file_path = left .. "/changed.txt"
+      assert.is_nil(lib.diffview_dir_diff({ file_path, right }))
+    end)
+
+    it("returns nil when a directory does not exist", function()
+      assert.is_nil(lib.diffview_dir_diff({ left, "/nonexistent/dir" }))
+    end)
+
+    it("creates a 2-pane FileDirDiffView from two valid dirs", function()
+      local view = lib.diffview_dir_diff({ left, right })
+      assert.is_not_nil(view)
+      assert.True(view:is_valid())
+      assert.is_nil(view.output_path)
+      dispose(view)
+    end)
+
+    it("creates a 3-pane FileDirDiffView when output is provided", function()
+      local view = lib.diffview_dir_diff({ left, right, output })
+      assert.is_not_nil(view)
+      assert.True(view:is_valid())
+      eq(output, view.output_path)
+      dispose(view)
+    end)
+
+    it("returns nil when the two sides have no differences", function()
+      -- Use the same directory as both inputs so the walks produce identical
+      -- file sets with identical content. External diff drivers like jj
+      -- would otherwise be left in an editor with no file panel content.
+      assert.is_nil(lib.diffview_dir_diff({ left, left }))
+    end)
+  end)
+
+  describe("FileDirDiffView:update_files", function()
+    it("is a no-op", function()
+      local adapter = NullAdapter.create({ toplevel = right })
+      local view = FileDirDiffView({
+        adapter = adapter,
+        left_path = left,
+        right_path = right,
+      })
+
+      local len = view.files:len()
+      assert.has_no.errors(function()
+        view:update_files()
+      end)
+      eq(len, view.files:len())
+    end)
+  end)
+end)

--- a/plugin/diffview.lua
+++ b/plugin/diffview.lua
@@ -36,6 +36,10 @@ command("DiffviewMergeFiles", function(ctx)
   diffview.merge_files(arg_parser.scan(ctx.args).args)
 end, { nargs = "+", complete = completion })
 
+command("DiffviewDiffDirs", function(ctx)
+  diffview.dir_diff(arg_parser.scan(ctx.args).args)
+end, { nargs = "+", complete = completion })
+
 command("DiffviewFileHistory", function(ctx)
   local range
 


### PR DESCRIPTION
Relates to https://github.com/sindrets/diffview.nvim/issues/286 and  https://github.com/sindrets/diffview.nvim/issues/562.