### PR TITLE
feat(view): add `view.single_pane_for_one_sided` option

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -806,6 +806,26 @@ view.x.layout                                   *diffview-config-view.x.layout*
                 │              │
                 └──────────────┘
 
+            {diff1_raw}
+                Auto-selected (not directly settable via `view.x.layout`).
+
+                Selected per-file by |diffview-config-view.single_pane_for_one_sided|
+                when the entry's diff is one-sided (added, untracked, or
+                deleted). A single window with no diff highlighting and no
+                diff folding; the buffer reads like a normal file. For
+                additions and untracked files the window holds the working-
+                tree file directly (editable and `:w`-able); for deletions
+                it holds the pre-deletion content from the index or commit
+                (read-only since the working-tree file is gone).
+
+                ┌──────────────┐
+                │              │
+                │              │
+                │      B       │
+                │              │
+                │              │
+                └──────────────┘
+
             {diff2_horizontal}
                 Available for: diff_view, file_history_view
 
@@ -894,6 +914,34 @@ view.foldlevel                                  *diffview-config-view.foldlevel*
         (same behaviour as upstream sindrets/diffview.nvim). Set to a high
         value (e.g. `99`) to keep all folds open, which can help when another
         plugin's ftplugin creates unrelated folds in diff buffers.
+
+                                                *diffview-config-view.single_pane_for_one_sided*
+view.single_pane_for_one_sided
+        Type: `boolean`, Default: `false`
+
+        When true, files whose diff is one-sided open in a single non-diff
+        window instead of a Diff2 layout with an empty pane. Specifically:
+
+          • Status A or ? (added / untracked): the b-side is opened
+            directly. When b is `LOCAL` (the usual case in diff views)
+            the window holds the working-tree file as an editable,
+            `:w`-able buffer; when b is a commit rev (the usual case in
+            file-history views) it is read-only.
+          • Status D (deleted): the pre-deletion content from the index or
+            commit is shown in a single read-only window.
+
+        Applies to both diff views and file history views. Has no effect for
+        renamed, modified, or merge-conflict files (those keep their Diff2 or
+        merge layout). Also no effect when the configured layout is already a
+        single-window layout (`diff1_plain`, `diff1_inline`) or when file
+        history's `pin_local` mode owns the right-hand window.
+
+        The auto-selected layout is `diff1_raw`. It is excluded from
+        |diffview-config-view.cycle_layouts|: cycling with |g<C-x>| moves
+        through your configured Diff2 layouts. The cycled-to layout
+        replaces the entry's layout in place, so re-selecting the same
+        file simply reuses it; re-applying `diff1_raw` requires a refresh
+        that rebuilds the entry (see |diffview-actions-refresh_files|).
 
 view.cycle_layouts                              *diffview-config-view.cycle_layouts*
         Type: `table`, Default: (see defaults)

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -82,6 +82,10 @@ DEFAULT CONFIG                                  *diffview.defaults*
         pin_local = false,            -- See |diffview-config-view.file_history.pin_local|
       },
       foldlevel = 0,                  -- See |diffview-config-view.foldlevel|
+      -- See |diffview-config-view.single_pane_for_one_sided|. When true,
+      -- one-sided diffs (status A/?/D) open in a single non-diff window
+      -- instead of a Diff2 layout with an empty pane.
+      single_pane_for_one_sided = false,
       -- Layouts to cycle through with `cycle_layout` action. Each view's
       -- configured layout (e.g. view.default.layout) is automatically
       -- appended to its cycle if missing, so cycling always returns to it.

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -10,6 +10,7 @@ local Diff1Inline = lazy.access("diffview.scene.layouts.diff_1_inline", "Diff1In
 local Diff1InlinePinned =
   lazy.access("diffview.scene.layouts.diff_1_inline_pinned", "Diff1InlinePinned") ---@type Diff1InlinePinned|LazyModule
 local Diff1Pinned = lazy.access("diffview.scene.layouts.diff_1_pinned", "Diff1Pinned") ---@type Diff1Pinned|LazyModule
+local Diff1Raw = lazy.access("diffview.scene.layouts.diff_1_raw", "Diff1Raw") ---@type Diff1Raw|LazyModule
 local Diff2 = lazy.access("diffview.scene.layouts.diff_2", "Diff2") ---@type Diff2|LazyModule
 local Diff2Hor = lazy.access("diffview.scene.layouts.diff_2_hor", "Diff2Hor") ---@type Diff2Hor|LazyModule
 local Diff2HorPinned = lazy.access("diffview.scene.layouts.diff_2_hor_pinned", "Diff2HorPinned") ---@type Diff2HorPinned|LazyModule
@@ -288,6 +289,7 @@ M.defaults = {
   ---@field merge_tool DiffviewMergeViewTypeConfig
   ---@field file_history DiffviewStandardViewTypeConfig
   ---@field foldlevel integer
+  ---@field single_pane_for_one_sided boolean
   ---@field cycle_layouts DiffviewCycleLayouts
   ---@field inline DiffviewInlineConfig
 
@@ -296,6 +298,7 @@ M.defaults = {
   ---@field merge_tool? DiffviewMergeViewTypeConfig.user Config for conflicted files in diff views during a merge or rebase.
   ---@field file_history? DiffviewStandardViewTypeConfig.user Config for changed files in file history views.
   ---@field foldlevel? integer See `|diffview-config-view.foldlevel|`.
+  ---@field single_pane_for_one_sided? boolean When true, files whose diff is one-sided (status `A`/`?` or `D`) open in a single non-diff window instead of a Diff2 layout with an empty pane. `A`/`?` shows the b-side directly: editable working-tree buffer when b is `LOCAL` (the usual case in diff views), read-only when b is a commit rev (the usual case in file-history views). `D` shows the pre-deletion content from the index/commit in a read-only window. Applies to both diff views and file history views. Has no effect for renames, modifications, or merge conflicts. See `|diffview-config-view.single_pane_for_one_sided|`.
   ---@field cycle_layouts? DiffviewCycleLayouts.user Layouts to cycle through with `cycle_layout`.
   ---@field inline? DiffviewInlineConfig.user Options that apply to the `diff1_inline` layout.
   view = {
@@ -348,6 +351,13 @@ M.defaults = {
     -- Initial 'foldlevel' for diff buffers. Default 0 collapses unchanged
     -- regions; set to a high value (e.g. 99) to keep all folds open.
     foldlevel = 0,
+    -- When true, files whose diff is one-sided (added, untracked, or
+    -- deleted) open in a single non-diff window. Working-tree additions
+    -- and untracked files open as editable buffers backed by the file on
+    -- disk; deletions show the pre-deletion content from the index or
+    -- commit in a single read-only window. Has no effect for renames,
+    -- modifications, or merge conflicts.
+    single_pane_for_one_sided = false,
 
     ---@class DiffviewCycleLayouts
     ---@field default DiffviewStandardLayout[]
@@ -921,6 +931,7 @@ end
 ---       | "diff1_plain_pinned"
 ---       | "diff1_inline"
 ---       | "diff1_inline_pinned"
+---       | "diff1_raw"
 ---       | "diff2_horizontal"
 ---       | "diff2_horizontal_pinned"
 ---       | "diff2_vertical"
@@ -935,6 +946,7 @@ local layout_map = {
   diff1_plain_pinned = Diff1Pinned,
   diff1_inline = Diff1Inline,
   diff1_inline_pinned = Diff1InlinePinned,
+  diff1_raw = Diff1Raw,
   diff2_horizontal = Diff2Hor,
   diff2_horizontal_pinned = Diff2HorPinned,
   diff2_vertical = Diff2Ver,

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -2,9 +2,11 @@ local lazy = require("diffview.lazy")
 local oop = require("diffview.oop")
 
 local Diff1 = lazy.access("diffview.scene.layouts.diff_1", "Diff1") ---@type Diff1|LazyModule
+local Diff1Raw = lazy.access("diffview.scene.layouts.diff_1_raw", "Diff1Raw") ---@type Diff1Raw|LazyModule
 local Diff2 = lazy.access("diffview.scene.layouts.diff_2", "Diff2") ---@type Diff2|LazyModule
 local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
+local config = lazy.require("diffview.config") ---@module "diffview.config"
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
 local api = vim.api
@@ -280,11 +282,61 @@ end
 ---@field pinned_path? string # Deprecated: when `pinned_b_file` is supplied the layout takes its b-side from that shared File and `pinned_path` is ignored. Retained as a fallback for adapters that haven't been wired to the view's pin_local cache yet.
 ---@field pinned_b_file? vcs.File # The view-owned, shared working-tree `vcs.File` for `pin_local` mode. When set, the layout's b-side reuses this exact instance instead of constructing a fresh one, so identity is preserved across every entry the view ever shows. The instance outlives entry teardown via the layout's `shared_symbols`, and is destroyed by `FileHistoryView:close()`. One carve-out: if the layout's `should_null` says the b-side should render as absent AND the working-tree path no longer exists on disk, the b-side falls back to a one-off nulled file so a status="D" entry doesn't open an empty/editable buffer for a missing path.
 
+---Class-level "is `cls` equal to `target` or a subclass of `target`?". The
+---`instanceof` method on `Object` requires an instance; here we walk the
+---`super_class` chain directly so the check works on raw class tables.
+---@param cls table?
+---@param target table
+---@return boolean
+local function class_descends_from(cls, target)
+  while cls do
+    if cls == target then
+      return true
+    end
+    cls = cls.super_class
+  end
+  return false
+end
+
+---Pick the effective layout class for an entry. Substitutes `Diff1Raw` for a
+---Diff2 when `view.single_pane_for_one_sided` is on and the file's diff is
+---one-sided (status `A`/`?`/`D`). Falls through (returns the input class)
+---when the precondition isn't met, leaving every other layout path untouched.
+---Bails out for pinned-b mode (the view owns the b-side) and for non-Diff2
+---inputs (merge layouts, user-set `diff1_*` layouts, etc.).
+---@param default_class Layout (class)
+---@param opt FileEntry.with_layout.Opt
+---@return Layout (class)
+local function select_layout_for_status(default_class, opt)
+  if not config.get_config().view.single_pane_for_one_sided then
+    return default_class
+  end
+  if opt.pinned_b_file then
+    return default_class
+  end
+  if not vim.tbl_contains({ "A", "?", "D" }, opt.status) then
+    return default_class
+  end
+  if not class_descends_from(default_class, Diff2.__get()) then
+    return default_class
+  end
+  return Diff1Raw.__get()
+end
+
 ---@param layout_class Layout (class)
 ---@param opt FileEntry.with_layout.Opt
 ---@return FileEntry
 function FileEntry.with_layout(layout_class, opt)
   local extra_owned = {}
+  local effective_class = select_layout_for_status(layout_class, opt)
+  local using_raw = effective_class == Diff1Raw.__get()
+  -- For status `D` against a LOCAL/STAGE b-side, Diff2 would null the b-pane.
+  -- Substitute `revs.a` for the b-rev so the single Diff1Raw window shows
+  -- the pre-deletion content instead of being empty.
+  local b_substituted = using_raw
+      and opt.revs.b
+      and try_should_null(Diff2.__get(), opt.revs.b, opt.status, "b")
+    or false
 
   local function create_file(rev, symbol)
     local fallback_for_shared = false
@@ -297,7 +349,7 @@ function FileEntry.with_layout(layout_class, opt)
       -- overlay case (file exists in WT but not in this commit), where
       -- `try_should_null` would also return true but the b-side must
       -- still show the LOCAL file.
-      local null_b = try_should_null(layout_class, rev, opt.status, symbol)
+      local null_b = try_should_null(effective_class, rev, opt.status, symbol)
         and vim.fn.filereadable(opt.pinned_b_file.absolute_path) ~= 1
       if not null_b then
         return opt.pinned_b_file
@@ -318,6 +370,19 @@ function FileEntry.with_layout(layout_class, opt)
       path = opt.path
     end
 
+    -- For Diff1Raw, the windowed b-side is guaranteed non-null (we
+    -- substituted to revs.a when the natural b would have been nulled).
+    -- Unwindowed slots fall back to Diff2's nulled semantics so a
+    -- round-trip via `FileEntry:convert_layout` produces correct flags.
+    local nulled_flag
+    if using_raw and symbol == "b" then
+      nulled_flag = false
+    elseif using_raw then
+      nulled_flag = try_should_null(Diff2.__get(), rev, opt.status, symbol)
+    else
+      nulled_flag = try_should_null(effective_class, rev, opt.status, symbol)
+    end
+
     local file = File({
       adapter = opt.adapter,
       path = path,
@@ -325,7 +390,7 @@ function FileEntry.with_layout(layout_class, opt)
       commit = opt.commit,
       get_data = opt.get_data,
       rev = rev,
-      nulled = utils.sate(opt.nulled, try_should_null(layout_class, rev, opt.status, symbol)),
+      nulled = utils.sate(opt.nulled, nulled_flag),
     }) --[[@as vcs.File ]]
 
     if fallback_for_shared then
@@ -334,6 +399,18 @@ function FileEntry.with_layout(layout_class, opt)
 
     return file
   end
+
+  -- For substituted Diff1Raw, dropping the unwindowed a-side avoids fetching
+  -- the same content twice (the windowed b-side already uses revs.a). The a
+  -- slot is rebuilt on demand by `convert_layout`'s fallback when the user
+  -- cycles back to a Diff2 layout. Use an explicit branch instead of a
+  -- `cond and nil or create_file(...)` ternary, which would always fall
+  -- through to `create_file` because `nil or X == X` in Lua.
+  local a_file
+  if not (using_raw and b_substituted) then
+    a_file = create_file(opt.revs.a, "a")
+  end
+  local b_file = create_file(b_substituted and opt.revs.a or opt.revs.b, "b")
 
   return FileEntry({
     adapter = opt.adapter,
@@ -345,11 +422,12 @@ function FileEntry.with_layout(layout_class, opt)
     commit = opt.commit,
     revs = opt.revs,
     _extra_owned = extra_owned,
-    layout = layout_class({
-      a = create_file(opt.revs.a, "a"),
-      b = create_file(opt.revs.b, "b"),
+    layout = effective_class({
+      a = a_file,
+      b = b_file,
       c = create_file(opt.revs.c, "c"),
       d = create_file(opt.revs.d, "d"),
+      b_substituted = b_substituted,
     }),
   })
 end

--- a/lua/diffview/scene/layouts/diff_1_raw.lua
+++ b/lua/diffview/scene/layouts/diff_1_raw.lua
@@ -1,0 +1,87 @@
+local Diff1 = require("diffview.scene.layouts.diff_1").Diff1
+local Layout = require("diffview.scene.layout").Layout
+local oop = require("diffview.oop")
+
+local M = {}
+
+---Single-window layout that shows the file as a plain (non-diff) buffer. Used
+---by `view.single_pane_for_one_sided` when a file's diff would be one-sided
+---(status `A`/`?` or `D`). Window opts disabling `diff`, `scrollbind`, and
+---diff folding are merged in by `StandardView` via the `diff1_raw` winopts
+---key; the layout itself just wires the single `b` window.
+---@class Diff1Raw : Diff1
+---@field a_file vcs.File? Old-side file kept for ownership / `convert_layout` round-tripping; never windowed.
+---@field _b_substituted boolean True when `b`'s `vcs.File` was rewritten to point at `revs.a` (status `D` round-trip) so `convert_layout` doesn't promote the wrong-rev file back into a Diff2.
+local Diff1Raw = oop.create_class("Diff1Raw", Diff1)
+
+---@class Diff1Raw.init.Opt : Diff1.init.Opt
+---@field a vcs.File? Unwindowed a-side file (constructed by `FileEntry.with_layout`).
+---@field b_substituted? boolean When true, `b.file.rev` is `revs.a`, not `revs.b`; `get_file_for("b")` then returns nil so conversion rebuilds a natural b-side.
+
+Diff1Raw.name = "diff1_raw"
+Diff1Raw.symbols = { "b" }
+
+---@param opt Diff1Raw.init.Opt
+function Diff1Raw:init(opt)
+  self:super(opt)
+  self.a_file = opt and opt.a or nil
+  if self.a_file then
+    self.a_file.symbol = "a"
+  end
+  self._b_substituted = opt and opt.b_substituted or false
+end
+
+---@override
+---@return Diff1Raw
+function Diff1Raw:clone()
+  local clone = Layout.clone(self) --[[@as Diff1Raw ]]
+  clone.a_file = self.a_file
+  clone._b_substituted = self._b_substituted
+  return clone
+end
+
+---@override
+---The single `b` window always holds the side with content (either the
+---natural `b` rev for additions, or the substituted `a` rev for deletions),
+---so it is never nulled at this layer. The selection logic in
+---`FileEntry.with_layout` is the gatekeeper for when `Diff1Raw` is chosen.
+---@param rev Rev
+---@param status string
+---@param sym Diff1.WindowSymbol
+---@diagnostic disable-next-line: unused-local
+function Diff1Raw.should_null(rev, status, sym)
+  assert(sym == "b")
+  return false
+end
+
+---@override
+---Expose `a_file` so `FileEntry:destroy` tears it down alongside the windowed
+---`b`. Same pattern as `Diff1Inline`.
+---@return vcs.File[]
+function Diff1Raw:owned_files()
+  local out = Layout.owned_files(self)
+  if self.a_file and not vim.tbl_contains(out, self.a_file) then
+    out[#out + 1] = self.a_file
+  end
+  return out
+end
+
+---@override
+---Expose `a_file` under the `"a"` slot so `convert_layout` reuses it when
+---transitioning to a 2-way layout. For `"b"`, return nil when the windowed
+---file was rewritten (status `D` substitution) so conversion rebuilds the
+---natural b-side via `try_should_null`; otherwise defer to the base.
+---@param sym string
+---@return vcs.File?
+function Diff1Raw:get_file_for(sym)
+  if sym == "a" then
+    return self.a_file
+  end
+  if sym == "b" and self._b_substituted then
+    return nil
+  end
+  return Layout.get_file_for(self, sym)
+end
+
+M.Diff1Raw = Diff1Raw
+return M

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -2,6 +2,7 @@ local async = require("diffview.async")
 local lazy = require("diffview.lazy")
 
 local Diff1 = lazy.access("diffview.scene.layouts.diff_1", "Diff1") ---@type Diff1|LazyModule
+local Diff1Raw = lazy.access("diffview.scene.layouts.diff_1_raw", "Diff1Raw") ---@type Diff1Raw|LazyModule
 local Diff2 = lazy.access("diffview.scene.layouts.diff_2", "Diff2") ---@type Diff2|LazyModule
 local Diff3 = lazy.access("diffview.scene.layouts.diff_3", "Diff3") ---@type Diff3|LazyModule
 local Diff4 = lazy.access("diffview.scene.layouts.diff_4", "Diff4") ---@type Diff4|LazyModule
@@ -35,6 +36,31 @@ function StandardView:init(opt)
   self.winopts = opt.winopts
     or {
       diff1 = { a = {} },
+      -- Force `diff` and diff folding off for Diff1Raw's single window,
+      -- and drop only the diff remaps that `vcs.File` prepended so the
+      -- buffer reads like a normal file without clobbering any other
+      -- winhl entries the user inherited from the tab/window (#515).
+      -- Scroll/cursor binding are irrelevant with only one window, but
+      -- explicit `false` avoids inheriting stale binding state when the
+      -- layout class swaps mid-session.
+      diff1_raw = {
+        b = {
+          diff = false,
+          scrollbind = false,
+          cursorbind = false,
+          foldmethod = "manual",
+          foldenable = true,
+          foldcolumn = "0",
+          foldlevel = 99,
+          winhl = {
+            "DiffAdd:DiffviewDiffAdd",
+            "DiffDelete:DiffviewDiffDelete",
+            "DiffChange:DiffviewDiffChange",
+            "DiffText:DiffviewDiffText",
+            opt = { method = "remove" },
+          },
+        },
+      },
       diff2 = { a = {}, b = {} },
       diff3 = { a = {}, b = {}, c = {} },
       diff4 = { a = {}, b = {}, c = {}, d = {} },
@@ -154,7 +180,10 @@ end
 StandardView.use_entry = async.void(function(self, entry)
   local layout_key
 
-  if entry.layout:instanceof(Diff1.__get()) then
+  -- Check Diff1Raw before Diff1 since it's a subclass.
+  if entry.layout:instanceof(Diff1Raw.__get()) then
+    layout_key = "diff1_raw"
+  elseif entry.layout:instanceof(Diff1.__get()) then
     layout_key = "diff1"
   elseif entry.layout:instanceof(Diff2.__get()) then
     layout_key = "diff2"

--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -196,10 +196,12 @@ Window.open_file = async.void(function(self)
   end
 
   -- Apply the configured foldlevel before `_save_winopts` so the saved
-  -- value covers the key we're about to override. Always set it, even
-  -- when the incoming winopts omit the key, so a custom `winopts` table
-  -- cannot silently drop the user's configured value.
-  if self.file.winopts then
+  -- value covers the key we're about to override. Scope this to diff
+  -- buffers (where `diff` is not explicitly false), matching the
+  -- documented purpose of `view.foldlevel`; non-diff layouts like
+  -- `diff1_raw` opt out via `diff = false` and supply their own
+  -- foldlevel via the layout winopts.
+  if self.file.winopts and self.file.winopts.diff ~= false then
     self.file.winopts.foldlevel = conf.view.foldlevel
   end
 

--- a/lua/diffview/tests/functional/single_pane_for_one_sided_spec.lua
+++ b/lua/diffview/tests/functional/single_pane_for_one_sided_spec.lua
@@ -1,0 +1,196 @@
+local FileEntry = require("diffview.scene.file_entry").FileEntry
+local Diff1Raw = require("diffview.scene.layouts.diff_1_raw").Diff1Raw
+local Diff2Hor = require("diffview.scene.layouts.diff_2_hor").Diff2Hor
+local RevType = require("diffview.vcs.rev").RevType
+local config = require("diffview.config")
+
+local function commit_rev()
+  return {
+    type = RevType.COMMIT,
+    commit = "abc1234567",
+    object_name = function(_, n)
+      return ("abc1234567"):sub(1, n or 10)
+    end,
+  }
+end
+
+local function local_rev()
+  -- `vcs.File:init` always evaluates the winbar `object_path` substitution
+  -- via `rev:object_name`, regardless of rev type. Stub it for LOCAL too.
+  return {
+    type = RevType.LOCAL,
+    object_name = function(_, n)
+      return ("0"):rep(n or 10)
+    end,
+  }
+end
+
+local function make_entry(status, opts)
+  opts = opts or {}
+  local adapter = { ctx = { toplevel = vim.uv.cwd() } }
+  return FileEntry.with_layout(opts.layout_class or Diff2Hor, {
+    adapter = adapter,
+    path = opts.path or "foo.txt",
+    oldpath = opts.oldpath,
+    status = status,
+    kind = "working",
+    revs = opts.revs or { a = commit_rev(), b = local_rev() },
+    pinned_b_file = opts.pinned_b_file,
+  })
+end
+
+describe("view.single_pane_for_one_sided", function()
+  local original
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+  end)
+
+  after_each(function()
+    config.setup(original)
+  end)
+
+  describe("config schema", function()
+    it("defaults to false", function()
+      config.setup({})
+      assert.is_false(config.get_config().view.single_pane_for_one_sided)
+    end)
+
+    it("can be set to true via user config", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      assert.is_true(config.get_config().view.single_pane_for_one_sided)
+    end)
+
+    it("does not affect unrelated view options when toggled", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local conf = config.get_config()
+      assert.equals("diff2_horizontal", conf.view.default.layout)
+      assert.equals(0, conf.view.foldlevel)
+    end)
+  end)
+
+  describe("FileEntry.with_layout layout selection", function()
+    it("falls through to the default layout when the option is off", function()
+      config.setup({})
+      local entry = make_entry("A")
+      assert.equals(Diff2Hor, entry.layout.class)
+    end)
+
+    it("substitutes Diff1Raw for an added (A) file when enabled", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("A")
+      assert.equals(Diff1Raw, entry.layout.class)
+    end)
+
+    it("substitutes Diff1Raw for an untracked (?) file when enabled", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("?")
+      assert.equals(Diff1Raw, entry.layout.class)
+    end)
+
+    it("substitutes Diff1Raw for a deleted (D) file when enabled", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("D")
+      assert.equals(Diff1Raw, entry.layout.class)
+    end)
+
+    it("leaves modified (M) files on the default Diff2 layout", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("M")
+      assert.equals(Diff2Hor, entry.layout.class)
+    end)
+
+    it("leaves renamed (R) files on the default Diff2 layout", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("R", { oldpath = "old.txt" })
+      assert.equals(Diff2Hor, entry.layout.class)
+    end)
+
+    it("leaves pinned_b_file entries on the pin-aware Diff2 layout", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local Diff2HorPinned = require("diffview.scene.layouts.diff_2_hor_pinned").Diff2HorPinned
+      local rev_b = local_rev()
+      local shared = {
+        path = "foo.txt",
+        absolute_path = vim.fn.tempname() .. "-missing",
+      } --[[@as vcs.File ]]
+      local entry = make_entry("D", {
+        layout_class = Diff2HorPinned,
+        revs = { a = commit_rev(), b = rev_b },
+        pinned_b_file = shared,
+      })
+      assert.equals(Diff2HorPinned, entry.layout.class)
+    end)
+  end)
+
+  describe("b-side rev substitution", function()
+    it("uses the LOCAL b-rev for added files (editable on-disk buffer)", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("A")
+      assert.equals(RevType.LOCAL, entry.layout.b.file.rev.type)
+    end)
+
+    it("swaps in revs.a for deleted files (pre-deletion content)", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local rev_a = commit_rev()
+      local entry = make_entry("D", { revs = { a = rev_a, b = local_rev() } })
+      assert.equals(rev_a, entry.layout.b.file.rev)
+    end)
+
+    it("drops the unwindowed a-side File when the b-side is substituted", function()
+      -- Avoids fetching the same scratch content twice.
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("D")
+      assert.is_nil(entry.layout.a_file)
+    end)
+
+    it("keeps the unwindowed a-side File for non-substituted Diff1Raw entries", function()
+      -- Needed by `convert_layout` to round-trip back to Diff2 without
+      -- losing the COMMIT-side file metadata.
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("A")
+      assert.is_not_nil(entry.layout.a_file)
+    end)
+  end)
+
+  describe("Diff1Raw layout shape", function()
+    it("owned_files includes the unwindowed a_file", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("A")
+      local owned = entry.layout:owned_files()
+      assert.is_true(vim.tbl_contains(owned, entry.layout.a_file))
+      assert.is_true(vim.tbl_contains(owned, entry.layout.b.file))
+    end)
+
+    it("get_file_for('a') returns the unwindowed a_file", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("A")
+      assert.equals(entry.layout.a_file, entry.layout:get_file_for("a"))
+    end)
+
+    it("get_file_for('b') returns nil when the b-side was substituted", function()
+      -- convert_layout's fallback rebuilds a natural b-side with the right
+      -- nulled flag instead of carrying the substituted COMMIT-rev File
+      -- into a Diff2's b-slot.
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("D")
+      assert.is_nil(entry.layout:get_file_for("b"))
+    end)
+
+    it("get_file_for('b') delegates to the base when not substituted", function()
+      config.setup({ view = { single_pane_for_one_sided = true } })
+      local entry = make_entry("A")
+      assert.equals(entry.layout.b.file, entry.layout:get_file_for("b"))
+    end)
+
+    it("should_null returns false for the b slot", function()
+      assert.is_false(Diff1Raw.should_null(local_rev(), "A", "b"))
+      assert.is_false(Diff1Raw.should_null(commit_rev(), "D", "b"))
+    end)
+
+    it("registers as a known layout name", function()
+      local cls = config.name_to_layout("diff1_raw")
+      assert.equals(Diff1Raw, cls)
+    end)
+  end)
+end)

--- a/lua/diffview/tests/functional/utils_spec.lua
+++ b/lua/diffview/tests/functional/utils_spec.lua
@@ -214,3 +214,105 @@ describe("diffview.utils.str_pad wrappers", function()
     eq(" ab  ", utils.str_center_pad("ab", 5))
   end)
 end)
+
+describe("diffview.utils.set_local list-like remove", function()
+  -- Window-local `winhighlight` is the canonical list-like option that the
+  -- gsub-based remove path is meant to handle. Each test seeds the option
+  -- directly, runs `set_local` with `method = "remove"`, then reads back the
+  -- resulting value via `vim.wo`.
+
+  local winid
+
+  before_each(function()
+    winid = vim.api.nvim_get_current_win()
+    vim.wo[winid].winhighlight = ""
+  end)
+
+  after_each(function()
+    vim.wo[winid].winhighlight = ""
+  end)
+
+  it("removes a leading block and consumes its trailing comma", function()
+    -- Regression: previously the trailing comma was left behind, producing a
+    -- malformed `winhighlight` like ",Normal:User".
+    vim.wo[winid].winhighlight = "DiffAdd:DiffviewDiffAdd,Normal:User"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffAdd:DiffviewDiffAdd",
+        opt = { method = "remove" },
+      },
+    })
+    eq("Normal:User", vim.wo[winid].winhighlight)
+  end)
+
+  it("removes a trailing block and consumes its leading comma", function()
+    vim.wo[winid].winhighlight = "Normal:User,DiffAdd:DiffviewDiffAdd"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffAdd:DiffviewDiffAdd",
+        opt = { method = "remove" },
+      },
+    })
+    eq("Normal:User", vim.wo[winid].winhighlight)
+  end)
+
+  it("removes a middle block without doubling separators", function()
+    vim.wo[winid].winhighlight = "Normal:User,DiffAdd:DiffviewDiffAdd,CursorLine:UserCl"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffAdd:DiffviewDiffAdd",
+        opt = { method = "remove" },
+      },
+    })
+    eq("Normal:User,CursorLine:UserCl", vim.wo[winid].winhighlight)
+  end)
+
+  it("removes a multi-entry block prepended ahead of user entries", function()
+    -- Mirrors the `Diff1Raw` flow: `vcs.File` prepends a block, the view then
+    -- removes the same block. The result must keep the user's entries intact.
+    vim.wo[winid].winhighlight = "DiffAdd:DiffviewDiffAdd,DiffDelete:DiffviewDiffDelete,Normal:User"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffAdd:DiffviewDiffAdd",
+        "DiffDelete:DiffviewDiffDelete",
+        opt = { method = "remove" },
+      },
+    })
+    eq("Normal:User", vim.wo[winid].winhighlight)
+  end)
+
+  it("clears the option when the removed block is the only entry", function()
+    vim.wo[winid].winhighlight = "DiffAdd:DiffviewDiffAdd"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffAdd:DiffviewDiffAdd",
+        opt = { method = "remove" },
+      },
+    })
+    eq("", vim.wo[winid].winhighlight)
+  end)
+
+  it("is a no-op when the value is absent", function()
+    vim.wo[winid].winhighlight = "Normal:User"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffAdd:DiffviewDiffAdd",
+        opt = { method = "remove" },
+      },
+    })
+    eq("Normal:User", vim.wo[winid].winhighlight)
+  end)
+
+  it("does not corrupt entries that share a prefix with the removed value", function()
+    -- Regression: substring matching used to strip `DiffDelete:DiffviewDiffDelete`
+    -- out of `DiffDelete:DiffviewDiffDeleteDim`, leaving a stray `Dim` behind.
+    vim.wo[winid].winhighlight = "DiffDelete:DiffviewDiffDeleteDim,Normal:User"
+    utils.set_local(winid, {
+      winhighlight = {
+        "DiffDelete:DiffviewDiffDelete",
+        opt = { method = "remove" },
+      },
+    })
+    eq("DiffDelete:DiffviewDiffDeleteDim,Normal:User", vim.wo[winid].winhighlight)
+  end)
+end)

--- a/lua/diffview/tests/functional/window_spec.lua
+++ b/lua/diffview/tests/functional/window_spec.lua
@@ -266,6 +266,40 @@ describe("diffview.scene.window", function()
         vim.api.nvim_buf_delete(bufnr, { force = true })
       end)
     )
+
+    it(
+      "preserves the layout's `foldlevel` for non-diff windows (`diff = false`)",
+      helpers.async_test(function()
+        -- `diff1_raw` opens the buffer as a plain file, so the user's
+        -- `view.foldlevel` (which targets diff buffers) must not clobber
+        -- the layout's high foldlevel.
+        config.setup({ view = { foldlevel = 0 } })
+
+        local adapter = mock_adapter()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local win, file = make_window(adapter)
+        file.bufnr = bufnr
+        file.winopts = {
+          diff = false,
+          scrollbind = false,
+          cursorbind = false,
+          foldmethod = "manual",
+          foldlevel = 99,
+        }
+        win.parent = stub_parent()
+
+        async.await(win:open_file())
+
+        assert.equals(99, vim.wo[win.id].foldlevel)
+
+        if vim.api.nvim_win_is_valid(test_winid) then
+          vim.api.nvim_win_close(test_winid, true)
+        end
+        test_winid = nil
+        Window.winopt_store[bufnr] = nil
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+    )
   end)
 
   it(

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -413,7 +413,22 @@ function M.set_local(winids, option_map, opt)
         else
           if o.method == "remove" then
             if is_list_like then
-              vim.opt_local[fullname] = cur_value:gsub(",?" .. vim.pesc(tostring(value)), "")
+              -- Split `cur_value` on commas and drop entries that exactly
+              -- match an entry in `value`. A substring-based `gsub` would
+              -- corrupt entries that share a prefix with `value` (e.g.,
+              -- removing `DiffDelete:DiffviewDiffDelete` from a list that
+              -- also contains `DiffDelete:DiffviewDiffDeleteDim`).
+              local to_remove = {}
+              for entry in tostring(value):gmatch("[^,]+") do
+                to_remove[entry] = true
+              end
+              local kept = {}
+              for entry in cur_value:gmatch("[^,]+") do
+                if not to_remove[entry] then
+                  kept[#kept + 1] = entry
+                end
+              end
+              vim.opt_local[fullname] = table.concat(kept, ",")
             else
               vim.opt_local[fullname]:remove(value)
             end


### PR DESCRIPTION
When enabled, files whose diff would be one-sided open in a single non-diff window via a new `Diff1Raw` layout instead of a `Diff2` with an empty pane (default `false`).

Fixes #184.