### PR TITLE
fix(file): load existing unloaded buffer in `_create_local_buffer`

### DIFF
--- a/lua/diffview/tests/functional/file_spec.lua
+++ b/lua/diffview/tests/functional/file_spec.lua
@@ -690,4 +690,59 @@ describe("diffview.vcs.file", function()
       end)
     )
   end)
+
+  -- Regression: project-scanning plugins (LSP, file managers, fzf-lua warm
+  -- caches, ...) can register a buffer by name without loading its
+  -- contents. `_create_local_buffer` reuses any buffer whose name matches
+  -- the file path, so without a `bufload` guard it would hand the inline
+  -- renderer an empty bufnr -- producing zero hunks and stranding the
+  -- cursor at line 1 of an apparently-empty buffer.
+  describe("LOCAL rev with a pre-existing unloaded buffer", function()
+    local tmpdir, tmpfile, prelim
+
+    before_each(function()
+      tmpdir = vim.fn.tempname()
+      vim.fn.mkdir(tmpdir, "p")
+      tmpfile = tmpdir .. "/working_unloaded.txt"
+      vim.fn.writefile({ "line 1", "line 2", "line 3" }, tmpfile)
+      prelim = nil
+    end)
+
+    after_each(function()
+      if prelim then
+        pcall(vim.api.nvim_buf_delete, prelim, { force = true })
+      end
+      vim.fn.delete(tmpdir, "rf")
+    end)
+
+    it("loads content into a pre-existing unloaded buffer", function()
+      -- Mimic a project-scanning plugin that adds the file to the buffer
+      -- list without ever loading it.
+      prelim = vim.fn.bufadd(tmpfile)
+      assert.is_true(prelim > 0)
+      assert.is_false(vim.api.nvim_buf_is_loaded(prelim))
+
+      local adapter = {
+        ctx = { toplevel = tmpdir, dir = tmpdir },
+        is_binary = function()
+          return false
+        end,
+        on_local_buffer_reused = function() end,
+      }
+
+      local file = File({
+        adapter = adapter,
+        path = "working_unloaded.txt",
+        absolute_path = tmpfile,
+        kind = "working",
+        rev = GitRev(RevType.LOCAL),
+      })
+
+      async.await(file:create_buffer())
+
+      assert.equals(prelim, file.bufnr)
+      assert.is_true(vim.api.nvim_buf_is_loaded(file.bufnr))
+      assert.equals(3, vim.api.nvim_buf_line_count(file.bufnr))
+    end)
+  end)
 end)

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -184,6 +184,18 @@ function File:_create_local_buffer()
     -- Track this buffer as created by diffview so it can be cleaned up on close.
     File.created_bufs[self.bufnr] = true
   else
+    -- Plugins that scan the project (LSP, file managers, grapple/harpoon-style
+    -- pickers, fzf-lua warm caches, ...) sometimes register a buffer by name
+    -- without ever loading its contents. `find_file_buffer` matches on name,
+    -- so we'd happily reuse the empty placeholder -- `inline_diff.render`
+    -- would then diff an empty new-side against the old-side content, the
+    -- hunk cache wouldn't get populated, and `jump_to_first_change` would
+    -- land on line 1 (or, in `diff1_inline`, error past the empty buffer's
+    -- end). Force a load if the buffer is unloaded so its contents come from
+    -- disk before we hand the bufnr to the diff renderer.
+    if not api.nvim_buf_is_loaded(self.bufnr) then
+      vim.fn.bufload(self.bufnr)
+    end
     -- NOTE: LSP servers might load buffers in the background and unlist
     -- them. Explicitly set the buffer as listed when loading it here.
     vim.bo[self.bufnr].buflisted = true


### PR DESCRIPTION
Makes rapidly switching files (by pressing `<tab>`/`<s-tab>`) much more stable.