### PR TITLE
fix(inline): use `DiffviewDiffAdd` for `"skipped"` paired rows

### DIFF
--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -1795,12 +1795,14 @@ function M.render(bufnr, old_lines, new_lines, opts)
         local nl = new_lines[new_start + k] or ""
         local char_result = render_char_highlights(bufnr, row, ol, nl, style.inline_del)
 
-        -- Line highlight. Unified always applies it; overleaf applies it only
-        -- as a fallback when char-level rendering was skipped (fragmented
-        -- pairing) so the reader still sees that the line was modified.
+        -- `"skipped"` draws no `DiffviewDiffAddInline` overlay, so the
+        -- subtle `DiffviewDiffChange` backdrop alone would be a bare
+        -- smudge. Treat as a pure addition — the deletion is still
+        -- echoed above (unified unconditionally; overleaf via the
+        -- fallback below).
         local line_hl = style.change_line_hl
-        if not line_hl and char_result == "skipped" then
-          line_hl = "DiffviewDiffChange"
+        if char_result == "skipped" then
+          line_hl = "DiffviewDiffAdd"
         end
         if line_hl then
           api.nvim_buf_set_extmark(bufnr, M.ns, row, 0, {

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -1112,20 +1112,20 @@ describe("diffview.scene.inline_diff", function()
       assert.are.equal(0, t.inline, "expected no inline deletion virt_text on dissimilar pairing")
     end)
 
-    it("falls back to block echo + line_hl in overleaf when char-level skips", function()
+    it("falls back to block echo + DiffAdd line_hl in overleaf when char-level skips", function()
       -- When overleaf's char-level rendering is gated off, the paired
       -- modification would otherwise be invisible. Verify the fallback
-      -- emits a DiffChange line_hl and a virt_line with the old content
-      -- under the overleaf `del_hl` (so the strikethrough on
-      -- DiffviewDiffDeleteInline is preserved on the echoed line, not
-      -- silently downgraded to the unified DiffviewDiffDelete).
+      -- emits a `DiffviewDiffAdd` line_hl (not `DiffviewDiffChange` — see
+      -- the `"skipped"` branch in `M.render`) and a virt_line under the
+      -- overleaf `del_hl` (preserving the strikethrough on the echoed
+      -- line, not silently downgrading to `DiffviewDiffDelete`).
       local old = "This is a plain, singular window. This is available in case"
       local new = "This is a plain, singular window with no diff rendering —"
       local bufnr = fresh_buf({ new })
       inline_diff.render(bufnr, { old }, { new }, { style = "overleaf" })
 
       local hls = line_hls(extmarks(bufnr))
-      assert.are.same({ { row = 0, hl = "DiffviewDiffChange" } }, hls)
+      assert.are.same({ { row = 0, hl = "DiffviewDiffAdd" } }, hls)
 
       local vls = virt_line_hls(extmarks(bufnr))
       assert.are.same({ "DiffviewDiffDeleteInline" }, vls)


### PR DESCRIPTION
The `"skipped"` path draws no `DiffviewDiffAddInline` overlay, so the first paired row was visually inconsistent with the surrounding overflow rows that carry `DiffviewDiffAdd`.