### PR TITLE
chore!: rename plugin to `diffview+` (`diffview-plus.nvim`)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [sindrets]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
 name: Bug report
-description: Report a problem with diffview.nvim
+description: Report a problem with diffview+
 title: "[Bug] "
 labels: [bug]
 body:
   - type: markdown
     attributes:
       value: |
-        Before reporting: search [existing issues](https://github.com/dlyongemallo/diffview.nvim/issues) and make sure that diffview.nvim is updated to the latest version.
+        Before reporting: search [existing issues](https://github.com/dlyongemallo/diffview-plus.nvim/issues) and make sure that diffview+ is updated to the latest version.
   - type: textarea
     attributes:
       label: "Description"
@@ -93,7 +93,7 @@ body:
         -- ### USAGE: nvim --clean -u mini.lua ###
         -- #######################################
 
-        local root = vim.fn.stdpath("run") .. "/nvim/diffview.nvim"
+        local root = vim.fn.stdpath("run") .. "/nvim/diffview-plus.nvim"
         local plugin_dir = root .. "/plugins"
         vim.fn.mkdir(plugin_dir, "p")
 
@@ -103,7 +103,7 @@ body:
 
         local plugins = {
           { "nvim-web-devicons", url = "https://github.com/nvim-tree/nvim-web-devicons.git" },
-          { "diffview.nvim", url = "https://github.com/dlyongemallo/diffview.nvim.git" },
+          { "diffview-plus.nvim", url = "https://github.com/dlyongemallo/diffview-plus.nvim.git" },
           -- ##################################################################
           -- ### ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE ###
           -- ##################################################################
@@ -122,7 +122,7 @@ body:
 
         require("diffview").setup({
           -- ##############################################################################
-          -- ### ADD DIFFVIEW.NVIM CONFIG THAT IS _NECESSARY_ FOR REPRODUCING THE ISSUE ###
+          -- ### ADD DIFFVIEW+ CONFIG THAT IS _NECESSARY_ FOR REPRODUCING THE ISSUE ###
           -- ##############################################################################
         })
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve `diffview.nvim`. This document covers the local setup
+Thanks for helping improve `diffview+`. This document covers the local setup
 and a few conventions worth knowing before opening a PR.
 
 ## Development setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Diffview.nvim
+# diffview+
 
-> **Note:** This is an **actively maintained fork** of [sindrets/diffview.nvim](https://github.com/sindrets/diffview.nvim) with bug fixes and improvements applied. The original repository has not been updated since June 2024. See [`doc/diffview_changelog.txt`](doc/diffview_changelog.txt) (`:h diffview.changelog`) for breaking changes and notable additions.
+> **Note:** This is an **actively maintained fork** of [sindrets/diffview.nvim](https://github.com/sindrets/diffview.nvim) with bug fixes and improvements applied. See [`doc/diffview_changelog.txt`](doc/diffview_changelog.txt) (`:h diffview.changelog`) for breaking changes and notable additions.
 
 ## Introduction
 
@@ -28,7 +28,7 @@ Supported VCS (at least one required):
 ```lua
 -- Lazy
 {
-    "dlyongemallo/diffview.nvim",
+    "dlyongemallo/diffview-plus.nvim",
     version = "*",
     -- optional: lazy-load on command
     -- cmd = {
@@ -43,7 +43,7 @@ Supported VCS (at least one required):
 
 ```vim
 " Plug
-Plug 'dlyongemallo/diffview.nvim'
+Plug 'dlyongemallo/diffview-plus.nvim'
 ```
 
 ## Quick Start

--- a/USAGE.md
+++ b/USAGE.md
@@ -26,7 +26,7 @@ is different from comparing directly against `origin/HEAD` if the branches have
 diverged, and is usually what you want when comparing changes in a PR. For more
 info see the section on "SPECIFYING REVISIONS" in `man git-rev-parse(1)`.
 
-The `--imply-local` flag option will here make diffview.nvim show the working
+The `--imply-local` flag option will here make diffview+ show the working
 tree versions[^1] of the changed files on the right side of the diff. This means
 that if you have tools such as LSP set up, it will work for all the diff buffers
 on the right side, giving you access to LSP features - such as diagnostics and
@@ -94,7 +94,7 @@ following command will list all stashes in the file history panel:
 
 ## Committing
 
-Creating commits from within nvim is a solved problem, and as such diffview.nvim
+Creating commits from within nvim is a solved problem, and as such diffview+
 does not reinvent the wheel here. Here are a few different ways in which you can
 create a new commit from within the editor:
 

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1,13 +1,13 @@
-*diffview.txt* Diffview.nvim
+*diffview.txt* diffview+
 
 Single tabpage interface to easily cycle through diffs for all modified files
 for any git rev.
 
-Author: Sindre T. Strøm
+Authors: Sindre T. Strøm (diffview.nvim), David Yonge-Mallo (diffview+)
 
 ==============================================================================
 
-INTRODUCTION                                    *diffview.nvim* *diffview*
+INTRODUCTION                  *diffview.nvim* *diffview* *diffview-plus*
 
 Vim's diff mode is pretty good, but there is no convenient way to quickly bring
 up all modified files in a diffsplit. This plugin aims to provide a simple,

--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -65,7 +65,7 @@ See also |diffview.changelog-jj-adapter| for the Jujutsu adapter.
 
                                                 *diffview.changelog-breaking-panel-show*
 
-PR: https://github.com/dlyongemallo/diffview.nvim/pull/165
+PR: https://github.com/dlyongemallo/diffview-plus.nvim/pull/165
 
 `file_panel.show` previously controlled both `:DiffviewOpen` and
 `:DiffviewFileHistory`. Visibility is now split: set `file_panel.show`
@@ -74,7 +74,7 @@ for file-history views.
 
                                                 *diffview.changelog-pin-local*
 
-PR: https://github.com/dlyongemallo/diffview.nvim/pull/158
+PR: https://github.com/dlyongemallo/diffview-plus.nvim/pull/158
 
 The new `:DiffviewFileHistory --pin-local` flag pins the right-hand
 side of the diff to the working-tree copy of the followed path while
@@ -87,7 +87,7 @@ Git only. Cannot be combined with `--base`.
 
                                                 *diffview.changelog-diff1-inline*
 
-PR: https://github.com/dlyongemallo/diffview.nvim/pull/120
+PR: https://github.com/dlyongemallo/diffview-plus.nvim/pull/120
 
 The new `diff1_inline` layout renders unified diffs in a single window
 via extmark overlays. Tree-sitter highlights are preserved on both
@@ -102,9 +102,9 @@ Deletion highlight is configurable via `view.inline.deletion_highlight`.
 
                                                 *diffview.changelog-multi-selection*
 
-PRs: https://github.com/dlyongemallo/diffview.nvim/pull/36,
-     https://github.com/dlyongemallo/diffview.nvim/pull/45,
-     https://github.com/dlyongemallo/diffview.nvim/pull/46
+PRs: https://github.com/dlyongemallo/diffview-plus.nvim/pull/36,
+     https://github.com/dlyongemallo/diffview-plus.nvim/pull/45,
+     https://github.com/dlyongemallo/diffview-plus.nvim/pull/46
 
 The file panel supports multi-file selection for batch operations.
 Default keymaps: `w` to toggle a selection on the current file, `C`
@@ -117,7 +117,7 @@ placement are configurable via `file_panel.mark_placement` and
 
                                                 *diffview.changelog-breaking-nvim-010*
 
-PR: https://github.com/dlyongemallo/diffview.nvim/pull/11
+PR: https://github.com/dlyongemallo/diffview-plus.nvim/pull/11
 
 The minimum required Neovim version has been bumped to 0.10.
 
@@ -317,14 +317,14 @@ update, just make sure plenary is loaded before diffview. Examples:
 PR: https://github.com/sindrets/diffview.nvim/pull/64
 
 This PR introduces some small breaking changes in the config, and for plugins
-integrating diffview.nvim.
+integrating diffview+.
 
 The `use_icons` config table key has been moved out of the `file_panel` table.
 This has been done because `use_icons` now applies to other contexts than just
 the file panel. The correct way to configure this now is to set `use_icons`
 somewhere from the top level of the config table.
 
-For plugins integrating diffview.nvim:
+For plugins integrating diffview+:
 Several of the git utilities have been refactored into their own namespace
 (`lua/diffview/git/`). I (STS) felt this was necessary due to the growing
 scope of the plugin. Most notably this means that the `Rev` class now resides

--- a/lua/diffview/api/init.lua
+++ b/lua/diffview/api/init.lua
@@ -1,4 +1,4 @@
--- Public API surface for diffview.nvim.
+-- Public API surface for diffview+.
 --
 -- Usage:
 --   local api = require("diffview.api")

--- a/lua/diffview/bootstrap.lua
+++ b/lua/diffview/bootstrap.lua
@@ -15,7 +15,7 @@ local uv = vim.uv
 local function err(msg)
   msg = msg:gsub("'", "''")
   vim.cmd("echohl Error")
-  vim.cmd(string.format("echom '[diffview.nvim] %s'", msg))
+  vim.cmd(string.format("echom '[diffview+] %s'", msg))
   vim.cmd("echohl NONE")
 end
 

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -3,7 +3,7 @@
 -- The inline strikethrough rendering for deleted characters in the
 -- "overleaf" style is adapted from the sample code shared by
 -- @tienlonghungson in issue #109:
--- <https://github.com/dlyongemallo/diffview.nvim/issues/109>
+-- <https://github.com/dlyongemallo/diffview-plus.nvim/issues/109>
 -- which was itself modified from inlinediff-nvim:
 -- <https://github.com/YouSame2/inlinediff-nvim>
 --
@@ -1327,7 +1327,7 @@ local function maybe_warn_leak(bufnr, winid)
     if w ~= winid then
       leak_warned = true
       vim.notify(
-        "diffview.nvim: `diff1_inline` highlights may leak into other windows showing this file. "
+        "diffview+: `diff1_inline` highlights may leak into other windows showing this file. "
           .. "Upgrade to Neovim 0.11+ to fix.",
         vim.log.levels.WARN
       )

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -356,7 +356,7 @@ function Panel:open()
     self.winid = vim.api.nvim_open_win(self.bufid, false, utils.sanitize_float_config(config))
     if self.winid == 0 then
       self.winid = nil
-      error("[diffview.nvim] Failed to open float panel window!")
+      error("[diffview+] Failed to open float panel window!")
     end
   end
 

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -43,7 +43,7 @@ function M.notify(msg, level, schedule)
     logger:error(msg)
   end
 
-  vim.notify(msg, level, { title = "diffview.nvim" })
+  vim.notify(msg, level, { title = "diffview+" })
 end
 
 ---@param msg string|string[]


### PR DESCRIPTION
Motivated by https://github.com/sindrets/diffview.nvim/issues/605.