### PR TITLE
fix(render): keep `use_icons` intact when no icon provider is loaded

### DIFF
--- a/lua/diffview/hl.lua
+++ b/lua/diffview/hl.lua
@@ -5,6 +5,7 @@ local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
 local api = vim.api
 local web_devicons, mini_icons
+local provider_resolved = false
 local icon_cache = {}
 
 local M = {}
@@ -302,21 +303,23 @@ function M.get_file_icon(name, ext, render_data, line_idx, offset)
   end
 
   if not (web_devicons or mini_icons) then
-    local ok
-    ok, web_devicons = pcall(require, "nvim-web-devicons")
-
-    if not ok then
-      ok, mini_icons = pcall(require, "mini.icons")
-      web_devicons = nil
+    if provider_resolved then
+      return ""
     end
 
-    if not ok then
-      config.get_config().use_icons = false
-      utils.warn(
-        "nvim-web-devicons or mini.icons is required to use file icons! "
-          .. "Set `use_icons = false` in your config to stop seeing this message."
-      )
+    local ok, mod = pcall(require, "nvim-web-devicons")
+    if ok then
+      web_devicons = mod
+    else
+      ok, mod = pcall(require, "mini.icons")
+      if ok then
+        mini_icons = mod
+      end
+    end
 
+    provider_resolved = true
+
+    if not ok then
       return ""
     end
   end

--- a/lua/diffview/tests/functional/panel_render_spec.lua
+++ b/lua/diffview/tests/functional/panel_render_spec.lua
@@ -1460,28 +1460,6 @@ describe("panel_render", function()
     local FOLDER_OPEN = "<<OPEN>>"
     local FOLDER_CLOSED = "<<CLOSED>>"
 
-    local saved_devicons
-
-    before_each(function()
-      -- Stub nvim-web-devicons so hl.get_file_icon does not flip
-      -- `use_icons` back to false mid-render when neither icon plugin is
-      -- installed in the test environment.
-      saved_devicons = package.loaded["nvim-web-devicons"]
-      package.loaded["nvim-web-devicons"] = {
-        get_icon = function()
-          return "", nil
-        end,
-      }
-    end)
-
-    after_each(function()
-      package.loaded["nvim-web-devicons"] = saved_devicons
-      -- Drop the cached module reference inside hl.lua so the next test
-      -- re-resolves devicons via our stub (or its absence).
-      package.loaded["diffview.hl"] = nil
-      require("diffview.hl")
-    end)
-
     local function make_tree_panel(entries, use_icons)
       local conf = config.get_config()
       conf.use_icons = use_icons


### PR DESCRIPTION
`get_file_icon` flipped `config.use_icons` to `false` on the first call when no provider was installed, silently dropping user-configured folder glyphs. Resolve once via a module-local flag, and avoid leaking `pcall` error strings into `web_devicons`/`mini_icons`.

Fixes #221.