### PR TITLE
fix(panel): clear `winfixbuf` on `BufUnload` so wiped panels don't trip `E1513`

### DIFF
--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -506,6 +506,24 @@ function Panel:init_buffer()
     end,
   })
 
+  -- Clear `winfixbuf` on this buffer's windows when it unloads.
+  -- `Panel.winopts` sets `winfixbuf=true` to protect the panel buffer;
+  -- an external wipe (e.g., `:bw!`) would otherwise latch the flag onto
+  -- a fresh `[No Name]` and trip `E1513` on the next `:edit`.
+  -- `BufUnload`, not `BufWipeout`: by `BufWipeout` time the buffer is
+  -- already detached from its windows.
+  api.nvim_create_autocmd("BufUnload", {
+    group = Panel.au.group,
+    buffer = bn,
+    callback = function()
+      for _, win in ipairs(vim.fn.win_findbuf(bn)) do
+        if api.nvim_win_is_valid(win) then
+          vim.wo[win].winfixbuf = false
+        end
+      end
+    end,
+  })
+
   self:update_components()
   self:render()
   self:redraw()


### PR DESCRIPTION
`Panel.winopts` sets `winfixbuf = true` on panel windows so a stray `:edit` from the panel can't clobber the curated buffer (#169). The flag is window-local, the buffer it protects is buffer-local; when something external unloads the panel buffer (e.g., `%bw!` from a session manager before sourcing a session), the window survives with `winfixbuf` still true holding a fresh `[No Name]` buffer, and any subsequent `:edit` fails with `E1513`.

Required for session management (issue #217).