### PR TITLE
fix: clear winbar on diff windows when winbar_info is disabled

### DIFF
--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -132,6 +132,8 @@ function Window:open_fallback()
 
   if self:show_winbar_info() then
     vim.wo[self.id].winbar = self.file.winbar
+  else
+    vim.wo[self.id].winbar = ""
   end
 
   self.emitter:emit("post_open")
@@ -255,6 +257,8 @@ Window.open_file = async.void(function(self)
 
   if self:show_winbar_info() then
     vim.wo[self.id].winbar = self.file.winbar
+  else
+    vim.wo[self.id].winbar = ""
   end
 
   self.emitter:emit("post_open")


### PR DESCRIPTION
The old code only set `vim.wo[...].winbar` when `winbar_info` was true. When false, the window option was left untouched, which means any external winbar plugin (dropbar, navic, etc.) would still show its content inside diffview diff windows. Users who explicitly set `winbar_info = false` reasonably expect no winbar at all.

Add an else branch in both open_fallback() and open_file() to explicitly clear `vim.wo[...].winbar` to "" when `show_winbar_info()` returns false.
