### PR TITLE
fix(vcs): defer cfile `readlink` behind cwd in repo lookup

### DIFF
--- a/lua/diffview/tests/functional/append_implicit_indicators_spec.lua
+++ b/lua/diffview/tests/functional/append_implicit_indicators_spec.lua
@@ -1,0 +1,110 @@
+local VCSAdapter = require("diffview.vcs.adapter").VCSAdapter
+local helpers = require("diffview.tests.helpers")
+local utils = require("diffview.utils")
+
+local eq = helpers.eq
+local pl = utils.path
+
+describe("VCSAdapter.append_implicit_indicators", function()
+  local prev_buf
+  local tmpdirs
+
+  before_each(function()
+    prev_buf = vim.api.nvim_get_current_buf()
+    tmpdirs = {}
+  end)
+
+  after_each(function()
+    if vim.api.nvim_buf_is_valid(prev_buf) then
+      vim.api.nvim_set_current_buf(prev_buf)
+    end
+    for _, dir in ipairs(tmpdirs) do
+      pcall(vim.fn.delete, dir, "rf")
+    end
+  end)
+
+  local function make_tmpdir()
+    local dir = vim.fn.tempname()
+    assert.equals(1, vim.fn.mkdir(dir, "p"))
+    table.insert(tmpdirs, dir)
+    return dir
+  end
+
+  -- Replace the current buffer with a fresh one whose name and buftype are
+  -- under the test's control.  Returns the bufnr so the test can clean up.
+  local function set_current_buffer(name, buftype)
+    local buf = vim.api.nvim_create_buf(false, false)
+    vim.api.nvim_set_current_buf(buf)
+    if name and name ~= "" then
+      vim.api.nvim_buf_set_name(buf, name)
+    end
+    vim.bo[buf].buftype = buftype or ""
+    return buf
+  end
+
+  it("uses cpath alone when given, ignoring buffer state", function()
+    local dir = make_tmpdir()
+    -- Even with a named normal-file buffer, cpath wins outright.
+    set_current_buffer(dir .. "/should_be_ignored.txt", "")
+
+    local indicators = {}
+    VCSAdapter.append_implicit_indicators(indicators, dir)
+
+    eq({ pl:realpath(dir) }, indicators)
+  end)
+
+  it("falls back to cwd realpath when buftype is non-empty", function()
+    -- A terminal/scratch/help buffer should not contribute its name; the
+    -- only implicit indicator is the cwd.
+    set_current_buffer("/tmp/scratch", "nofile")
+
+    local indicators = {}
+    VCSAdapter.append_implicit_indicators(indicators, nil)
+
+    eq({ pl:realpath(".") }, indicators)
+  end)
+
+  it("falls back to cwd realpath when buffer is unnamed", function()
+    -- `:enew`-style buffer with no file name behind it.
+    set_current_buffer(nil, "")
+
+    local indicators = {}
+    VCSAdapter.append_implicit_indicators(indicators, nil)
+
+    eq({ pl:realpath(".") }, indicators)
+  end)
+
+  it("appends absolute cfile and cwd for a named non-symlink file buffer", function()
+    local dir = make_tmpdir()
+    local file = dir .. "/real.txt"
+    assert(io.open(file, "w")):close()
+
+    set_current_buffer(file, "")
+
+    local indicators = {}
+    VCSAdapter.append_implicit_indicators(indicators, nil)
+
+    eq({ pl:absolute(file), pl:realpath(".") }, indicators)
+  end)
+
+  it("also appends the resolved target when the buffer's path is a symlink", function()
+    local dir = make_tmpdir()
+    local target = dir .. "/target.txt"
+    local link = dir .. "/link.txt"
+    assert(io.open(target, "w")):close()
+    -- Relative target exercises the `pl:parent(absolute_cfile)` resolution.
+    assert(vim.uv.fs_symlink("target.txt", link))
+
+    set_current_buffer(link, "")
+
+    local indicators = {}
+    VCSAdapter.append_implicit_indicators(indicators, nil)
+
+    local absolute_link = pl:absolute(link)
+    eq({
+      absolute_link,
+      pl:realpath("."),
+      pl:absolute("target.txt", pl:parent(absolute_link)),
+    }, indicators)
+  end)
+end)

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -130,24 +130,47 @@ function VCSAdapter.build_top_indicators(path_args, cpath)
     end
   end
 
-  local cfile = pl:vim_expand("%")
-  cfile = pl:readlink(cfile) or cfile
-
   for _, path in ipairs(paths) do
     table.insert(top_indicators, pl:absolute(path, cpath))
     break
   end
 
-  table.insert(
-    top_indicators,
-    cpath and pl:realpath(cpath) or (vim.bo.buftype == "" and pl:absolute(cfile) or nil)
-  )
-
-  if not cpath then
-    table.insert(top_indicators, pl:realpath("."))
-  end
+  VCSAdapter.append_implicit_indicators(top_indicators, cpath)
 
   return paths, top_indicators
+end
+
+---Append the implicit indicator (the one used when no explicit path arg
+---resolves to a repo) to `top_indicators`.  When `cpath` is given (from the
+---`-C` flag), it is the sole implicit indicator; otherwise a three-tier
+---fallback is tried in order until one resolves to a repo:
+---  1. The buffer's literal path: the common case of editing a real file in a repo.
+---  2. `cwd`: the explicit-`cd` workflow, and the rescue when the buffer is a symlink
+---     whose literal location is outside any repo (e.g., a session-restored file linked
+---     from `$HOME`).
+---  3. The buffer's `readlink`'d target: last-resort rescue for symlink-managed dotfiles
+---     (stow, chezmoi, etc.) where the literal path isn't in a repo but the target is.
+---@param top_indicators string[]
+---@param cpath string?
+function VCSAdapter.append_implicit_indicators(top_indicators, cpath)
+  if cpath then
+    table.insert(top_indicators, pl:realpath(cpath))
+    return
+  end
+
+  local cfile = pl:vim_expand("%")
+  if vim.bo.buftype ~= "" or cfile == "" then
+    table.insert(top_indicators, pl:realpath("."))
+    return
+  end
+
+  local absolute_cfile = pl:absolute(cfile)
+  table.insert(top_indicators, absolute_cfile)
+  table.insert(top_indicators, pl:realpath("."))
+  local resolved = pl:readlink(cfile)
+  if resolved and resolved ~= cfile then
+    table.insert(top_indicators, pl:absolute(resolved, pl:parent(absolute_cfile)))
+  end
 end
 
 ---Iterate top-level indicators and resolve the repository root using a

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -142,9 +142,6 @@ function GitAdapter.get_repo_paths(path_args, cpath)
     end
   end
 
-  local cfile = pl:vim_expand("%")
-  cfile = pl:readlink(cfile) or cfile
-
   for _, path in ipairs(paths) do
     if GitAdapter.pathspec_split(path) == "" then
       table.insert(top_indicators, pl:absolute(path, cpath))
@@ -152,14 +149,7 @@ function GitAdapter.get_repo_paths(path_args, cpath)
     end
   end
 
-  table.insert(
-    top_indicators,
-    cpath and pl:realpath(cpath) or (vim.bo.buftype == "" and pl:absolute(cfile) or nil)
-  )
-
-  if not cpath then
-    table.insert(top_indicators, pl:realpath("."))
-  end
+  VCSAdapter.append_implicit_indicators(top_indicators, cpath)
 
   return paths, top_indicators
 end


### PR DESCRIPTION
The buffer's `readlink`'d path was placed ahead of `cwd` in `top_indicators`, so a session manager restoring a symlinked buffer could steer `:DiffviewOpen <rev>` into an unrelated repo. Try the literal buffer path first, then `cwd`, then the `readlink`'d cfile as a last-resort rescue (e.g., for stow-managed dotfiles). Applies to `GitAdapter.get_repo_paths` and `VCSAdapter.build_top_indicators`.

Required for session management (issue #217).