### PR TITLE
fix(vcs): adopt existing `diffview://null` buffer instead of wiping

### DIFF
--- a/lua/diffview/tests/functional/file_spec.lua
+++ b/lua/diffview/tests/functional/file_spec.lua
@@ -43,6 +43,36 @@ describe("diffview.vcs.file", function()
     assert.False(show_called)
   end)
 
+  it("adopts a stale `diffview://null` in a tab's only window without raising E444", function()
+    -- Regression: `_get_null_buffer` used to call `utils.wipe_named_buffer`
+    -- when `nvim_buf_set_name` collided with an existing `diffview://null`
+    -- buffer. `wipe_named_buffer` closes every window showing that buffer,
+    -- which throws E444 when the stale buffer occupies the only window in
+    -- the current tabpage. The function now adopts the existing buffer.
+    local null_buf = File._get_null_buffer()
+
+    -- Stage the scenario: a fresh tab whose only window displays the null
+    -- buffer, mimicking a stale `diffview://null` from a previous session.
+    vim.cmd("tabnew")
+    local tab = vim.api.nvim_get_current_tabpage()
+    vim.api.nvim_set_current_buf(null_buf)
+
+    -- Drop the cached singleton so `_get_null_buffer` re-runs the
+    -- adoption path against the still-named buffer.
+    File.NULL_FILE.bufnr = nil
+
+    local ok, adopted = pcall(File._get_null_buffer)
+
+    assert.is_true(ok)
+    assert.equals(null_buf, adopted)
+    assert.is_true(vim.api.nvim_tabpage_is_valid(tab))
+
+    if vim.api.nvim_tabpage_is_valid(tab) then
+      vim.api.nvim_set_current_tabpage(tab)
+      vim.cmd("tabclose")
+    end
+  end)
+
   it("does not probe binary-ness for a nulled file", function()
     -- A deleted file's gone `LOCAL` path makes `is_binary` false-positive; a
     -- nulled side must not be probed (its result is unused).

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -730,15 +730,29 @@ end
 ---@return integer
 function File._get_null_buffer()
   if not api.nvim_buf_is_loaded(File.NULL_FILE.bufnr or -1) then
-    local bn = api.nvim_create_buf(false, false)
+    local bufname = "diffview://null"
+    -- Adopt an existing `diffview://null` buffer if one is still around
+    -- (e.g., from a previous diffview session). Wiping it would call
+    -- `nvim_win_close` on every window showing it, which throws E444 when
+    -- that buffer happens to occupy the only window in the current tabpage.
+    local bn = utils.find_named_buffer(bufname) or api.nvim_create_buf(false, false)
+    -- An adopted buffer may be unloaded; force-load it so the outer guard
+    -- above sees it as loaded on later calls.
+    if not api.nvim_buf_is_loaded(bn) then
+      vim.fn.bufload(bn)
+    end
+    -- Reset content in case the adopted buffer carries stale lines from a
+    -- previous session; the null buffer must always be empty.
+    vim.bo[bn].modifiable = true
+    api.nvim_buf_set_lines(bn, 0, -1, false, {})
     for option, value in pairs(File.bufopts) do
       vim.bo[bn][option] = value
     end
+    -- `nvim_buf_set_lines` flips `modified`; clear it so a hidden adopted
+    -- null buffer never trips `:quit`/`bdelete` with unsaved-changes errors.
+    vim.bo[bn].modified = false
 
-    local bufname = "diffview://null"
-    local ok = pcall(api.nvim_buf_set_name, bn, bufname)
-    if not ok then
-      utils.wipe_named_buffer(bufname)
+    if vim.fn.bufname(bn) ~= bufname then
       api.nvim_buf_set_name(bn, bufname)
     end
 


### PR DESCRIPTION
Required for session management (issue #217).