### PR TITLE
 feat(file_panel): add follow navigation

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1177,6 +1177,12 @@ file_panel                                      *diffview-config-file_panel*
             {show_branch_name} (boolean)
                 Show branch name in the file panel header. Default: `false`
 
+            {follow_navigation} (boolean)
+                Open the file under the cursor after `next_entry` and
+                `prev_entry` navigation in the file panel. The diff is opened
+                with `focus=false`, so focus remains in the file panel.
+                Default: `false`
+
 file_history_panel                              *diffview-config-file_history_panel*
         Type: `table`, Default: (see defaults)
 
@@ -1806,6 +1812,13 @@ next_entry                                      *diffview-actions-next_entry*
 
         Bring the cursor in the subject panel to the next entry.
 
+next_entry_follow                        *diffview-actions-next_entry_follow*
+        Contexts: `file_panel`
+
+        Bring the cursor in the file panel to the next file entry and open its
+        diff without focusing the diff window. Directory entries are skipped
+        for opening: the cursor still moves, but no diff is selected.
+
 open_all_folds                                  *diffview-actions-open_all_folds*
         Contexts: `file_panel`, `file_history_panel`
 
@@ -1852,6 +1865,13 @@ prev_entry                                      *diffview-actions-prev_entry*
         Contexts: `view`, `panel`
 
         Bring the cursor in the subject panel to the previous entry.
+
+prev_entry_follow                        *diffview-actions-prev_entry_follow*
+        Contexts: `file_panel`
+
+        Bring the cursor in the file panel to the previous file entry and open
+        its diff without focusing the diff window. Directory entries are
+        skipped for opening: the cursor still moves, but no diff is selected.
 
 refresh_files                                   *diffview-actions-refresh_files*
         Contexts: `view`, `panel`

--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -47,6 +47,7 @@ local pl = lazy.access(utils, "path") --[[@as PathLib ]]
 ---@field focus_files fun()
 ---@field listing_style fun()
 ---@field next_entry fun()
+---@field next_entry_follow fun()
 ---@field next_entry_in_commit fun()
 ---@field open_all_folds fun()
 ---@field open_commit_in_browser fun()
@@ -55,6 +56,7 @@ local pl = lazy.access(utils, "path") --[[@as PathLib ]]
 ---@field open_in_diffview fun()
 ---@field options fun()
 ---@field prev_entry fun()
+---@field prev_entry_follow fun()
 ---@field prev_entry_in_commit fun()
 ---@field restore_entry fun()
 ---@field select_entry fun()
@@ -1176,6 +1178,7 @@ local action_names = {
   "focus_files",
   "listing_style",
   "next_entry",
+  "next_entry_follow",
   "next_entry_in_commit",
   "open_all_folds",
   "open_commit_in_browser",
@@ -1184,6 +1187,7 @@ local action_names = {
   "open_in_diffview",
   "options",
   "prev_entry",
+  "prev_entry_follow",
   "prev_entry_in_commit",
   "restore_entry",
   "select_entry",

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -442,6 +442,7 @@ M.defaults = {
   ---@field always_show_marks boolean
   ---@field mark_placement DiffviewMarkPlacement
   ---@field show_branch_name boolean
+  ---@field follow_navigation boolean
 
   ---@class DiffviewFilePanelConfig.user
   ---@field listing_style? DiffviewListingStyle "list" or "tree".
@@ -454,6 +455,7 @@ M.defaults = {
   ---@field always_show_marks? boolean Show selection marks even when no files are selected.
   ---@field mark_placement? DiffviewMarkPlacement Where to render selection marks.
   ---@field show_branch_name? boolean Show branch name in the file panel header.
+  ---@field follow_navigation? boolean Preview the file under the cursor after file-panel navigation.
   file_panel = {
     listing_style = "tree",
     sort_file = nil, -- Custom file comparator: function(a_name, b_name, a_data, b_data) -> boolean
@@ -500,6 +502,7 @@ M.defaults = {
     always_show_marks = false, -- Show selection marks even when no files are selected.
     mark_placement = "inline", -- Where to show selection marks: "inline" (next to file names) or "sign_column" (in the sign column).
     show_branch_name = false, -- Show branch name in the file panel header.
+    follow_navigation = false, -- Preview the file under the cursor after file-panel navigation.
   },
 
   ---@alias DiffviewStatStyle "number"|"bar"|"both"
@@ -1708,6 +1711,9 @@ function M.setup(user_config)
   )
   validate.boolean(file_panel, "show_branch_name", d.file_panel.show_branch_name, {
     path = "file_panel.show_branch_name",
+  })
+  validate.boolean(file_panel, "follow_navigation", d.file_panel.follow_navigation, {
+    path = "file_panel.follow_navigation",
   })
 
   -- file_history_panel

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -51,6 +51,20 @@ return function(view)
     end
   end
 
+  local function preview_file_at_cursor()
+    if not view.panel:is_open() then
+      return
+    end
+
+    ---@type any
+    local item = view.panel:get_item_at_cursor()
+    if not item or type(item.collapsed) == "boolean" or view.panel.cur_file == item then
+      return
+    end
+
+    view:set_file(item, false, false)
+  end
+
   return {
     tab_enter = function()
       local file = view.panel.cur_file
@@ -151,9 +165,23 @@ return function(view)
     end,
     next_entry = function()
       view.panel:highlight_next_file()
+      if config.get_config().file_panel.follow_navigation then
+        preview_file_at_cursor()
+      end
     end,
     prev_entry = function()
       view.panel:highlight_prev_file()
+      if config.get_config().file_panel.follow_navigation then
+        preview_file_at_cursor()
+      end
+    end,
+    next_entry_follow = function()
+      view.panel:highlight_next_file()
+      preview_file_at_cursor()
+    end,
+    prev_entry_follow = function()
+      view.panel:highlight_prev_file()
+      preview_file_at_cursor()
     end,
     select_entry = function()
       if view.panel:is_open() then

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -177,6 +177,15 @@ function StandardView:restore_panel_cursor()
   end
 end
 
+---@param panel_was_focused boolean
+function StandardView:restore_focus_after_layout_swap(panel_was_focused)
+  if panel_was_focused then
+    self.panel:focus(true)
+  elseif self.cur_layout:is_focused() then
+    self.cur_layout:get_main_win():focus()
+  end
+end
+
 ---@param self StandardView
 ---@param entry FileEntry
 StandardView.use_entry = async.void(function(self, entry)
@@ -203,6 +212,7 @@ StandardView.use_entry = async.void(function(self, entry)
   end
 
   local old_layout = self.cur_layout
+  local panel_was_focused = self.panel:is_focused()
   self.cur_entry = entry
 
   if entry.layout.class == self.cur_layout.class then
@@ -228,9 +238,7 @@ StandardView.use_entry = async.void(function(self, entry)
       vim.cmd("wincmd =")
     end
 
-    if self.cur_layout:is_focused() then
-      self.cur_layout:get_main_win():focus()
-    end
+    self:restore_focus_after_layout_swap(panel_was_focused)
   end
 end)
 

--- a/lua/diffview/tests/functional/actions_spec.lua
+++ b/lua/diffview/tests/functional/actions_spec.lua
@@ -12,6 +12,11 @@ describe("diffview.actions goto_file API", function()
     assert.is_function(actions.goto_file_tab)
   end)
 
+  it("exports follow-navigation actions for file panel keymaps", function()
+    assert.is_function(actions.next_entry_follow)
+    assert.is_function(actions.prev_entry_follow)
+  end)
+
   -- The goto_file functions require an active DiffView to operate.
   -- Without one, prepare_goto_file accesses a nil view, which is the
   -- expected pre-existing behaviour (they are only called from keymaps

--- a/lua/diffview/tests/functional/config_spec.lua
+++ b/lua/diffview/tests/functional/config_spec.lua
@@ -1,3 +1,4 @@
+local actions = require("diffview.actions")
 local config = require("diffview.config")
 local utils = require("diffview.utils")
 
@@ -38,6 +39,19 @@ describe("diffview.config default keymaps", function()
     return nil
   end
 
+  local function has_action(keymaps, action)
+    for _, section in pairs(keymaps) do
+      if type(section) == "table" then
+        for _, km in ipairs(section) do
+          if km[3] == action then
+            return true
+          end
+        end
+      end
+    end
+    return false
+  end
+
   it("shared nav keymaps appear in view section", function()
     local keymaps = config.defaults.keymaps
     -- <tab> is a common nav keymap that should be in view.
@@ -70,6 +84,15 @@ describe("diffview.config default keymaps", function()
         "file_history_panel missing " .. lhs
       )
     end
+  end)
+
+  it("follow-navigation actions are opt-in and do not replace j/k defaults", function()
+    local keymaps = config.defaults.keymaps
+    assert.is_false(config.defaults.file_panel.follow_navigation)
+    assert.same(actions.next_entry, find_keymap(keymaps.file_panel, "j")[3])
+    assert.same(actions.prev_entry, find_keymap(keymaps.file_panel, "k")[3])
+    assert.falsy(has_action(keymaps, actions.next_entry_follow))
+    assert.falsy(has_action(keymaps, actions.prev_entry_follow))
   end)
 
   it("section-specific keymaps are not leaked to other sections", function()

--- a/lua/diffview/tests/functional/diff_view_spec.lua
+++ b/lua/diffview/tests/functional/diff_view_spec.lua
@@ -668,6 +668,116 @@ describe("diffview.scene.views.diff.DiffView", function()
     end)
   end)
 
+  describe("file panel follow navigation", function()
+    local listeners_factory = require("diffview.scene.views.diff.listeners")
+
+    local function make_view(item)
+      local set_file_calls = {}
+      local view = {
+        files = { working = {}, conflicting = {} },
+        adapter = {
+          has_local = function()
+            return false
+          end,
+        },
+        left = {},
+        right = {},
+        ready = false,
+        panel = {
+          cur_file = nil,
+          is_open = function()
+            return true
+          end,
+          highlight_next_file = function(self)
+            self.highlight_next_calls = (self.highlight_next_calls or 0) + 1
+          end,
+          highlight_prev_file = function(self)
+            self.highlight_prev_calls = (self.highlight_prev_calls or 0) + 1
+          end,
+          get_item_at_cursor = function()
+            return item
+          end,
+          prune_selections = function() end,
+        },
+        set_file = function(_, file, focus, highlight)
+          set_file_calls[#set_file_calls + 1] =
+            { file = file, focus = focus, highlight = highlight }
+        end,
+      }
+      return view, set_file_calls
+    end
+
+    it("moves to the next file and previews it without focusing the diff window", function()
+      local file = { path = "foo.txt" }
+      local view, set_file_calls = make_view(file)
+      local listeners = listeners_factory(view)
+
+      listeners.next_entry_follow()
+
+      eq(1, view.panel.highlight_next_calls)
+      eq({ { file = file, focus = false, highlight = false } }, set_file_calls)
+    end)
+
+    it("moves to the previous file and previews it without focusing the diff window", function()
+      local file = { path = "foo.txt" }
+      local view, set_file_calls = make_view(file)
+      local listeners = listeners_factory(view)
+
+      listeners.prev_entry_follow()
+
+      eq(1, view.panel.highlight_prev_calls)
+      eq({ { file = file, focus = false, highlight = false } }, set_file_calls)
+    end)
+
+    it("does not preview during default next/prev navigation", function()
+      local original_config = vim.deepcopy(config.get_config())
+      config.setup({ file_panel = { follow_navigation = false } })
+      local file = { path = "foo.txt" }
+      local view, set_file_calls = make_view(file)
+      local listeners = listeners_factory(view)
+
+      listeners.next_entry()
+      listeners.prev_entry()
+
+      eq(1, view.panel.highlight_next_calls)
+      eq(1, view.panel.highlight_prev_calls)
+      eq({}, set_file_calls)
+
+      config.setup(original_config)
+    end)
+
+    it("previews during next/prev navigation when follow_navigation is enabled", function()
+      local original_config = vim.deepcopy(config.get_config())
+      config.setup({ file_panel = { follow_navigation = true } })
+      local file = { path = "foo.txt" }
+      local view, set_file_calls = make_view(file)
+      local listeners = listeners_factory(view)
+
+      listeners.next_entry()
+      listeners.prev_entry()
+
+      eq(1, view.panel.highlight_next_calls)
+      eq(1, view.panel.highlight_prev_calls)
+      eq({
+        { file = file, focus = false, highlight = false },
+        { file = file, focus = false, highlight = false },
+      }, set_file_calls)
+
+      config.setup(original_config)
+    end)
+
+    it("does not preview directory entries", function()
+      local dir = { collapsed = true }
+      local view, set_file_calls = make_view(dir)
+      local listeners = listeners_factory(view)
+
+      listeners.next_entry_follow()
+
+      eq(1, view.panel.highlight_next_calls)
+      eq({}, set_file_calls)
+    end)
+  end)
+
   -- `_set_file` rapid-navigation coalescing is exercised against
   -- `StandardView` (the shared owner of the worker) in
   -- `standard_view_spec.lua`; DiffView inherits the behavior unchanged.

--- a/lua/diffview/tests/functional/standard_view_spec.lua
+++ b/lua/diffview/tests/functional/standard_view_spec.lua
@@ -191,6 +191,102 @@ describe("diffview.standard_view should_show_panel", function()
   end)
 end)
 
+describe("diffview.standard_view layout-swap focus", function()
+  it("restores focus to the file panel when the panel was focused before the swap", function()
+    local panel_focus_calls = 0
+    local main_focus_calls = 0
+
+    ---@diagnostic disable-next-line: missing-fields
+    local view = setmetatable({
+      panel = {
+        focus = function(_, no_open)
+          panel_focus_calls = panel_focus_calls + 1
+          eq(true, no_open)
+        end,
+      },
+      cur_layout = {
+        is_focused = function()
+          return true
+        end,
+        get_main_win = function()
+          return {
+            focus = function()
+              main_focus_calls = main_focus_calls + 1
+            end,
+          }
+        end,
+      },
+    }, { __index = StandardView })
+
+    view:restore_focus_after_layout_swap(true)
+
+    eq(1, panel_focus_calls)
+    eq(0, main_focus_calls)
+  end)
+
+  it("preserves main-window focus when the diff layout was focused before the swap", function()
+    local panel_focus_calls = 0
+    local main_focus_calls = 0
+
+    ---@diagnostic disable-next-line: missing-fields
+    local view = setmetatable({
+      panel = {
+        focus = function()
+          panel_focus_calls = panel_focus_calls + 1
+        end,
+      },
+      cur_layout = {
+        is_focused = function()
+          return true
+        end,
+        get_main_win = function()
+          return {
+            focus = function()
+              main_focus_calls = main_focus_calls + 1
+            end,
+          }
+        end,
+      },
+    }, { __index = StandardView })
+
+    view:restore_focus_after_layout_swap(false)
+
+    eq(0, panel_focus_calls)
+    eq(1, main_focus_calls)
+  end)
+
+  it("does nothing when neither the panel nor the layout was focused before the swap", function()
+    local panel_focus_calls = 0
+    local main_focus_calls = 0
+
+    ---@diagnostic disable-next-line: missing-fields
+    local view = setmetatable({
+      panel = {
+        focus = function()
+          panel_focus_calls = panel_focus_calls + 1
+        end,
+      },
+      cur_layout = {
+        is_focused = function()
+          return false
+        end,
+        get_main_win = function()
+          return {
+            focus = function()
+              main_focus_calls = main_focus_calls + 1
+            end,
+          }
+        end,
+      },
+    }, { __index = StandardView })
+
+    view:restore_focus_after_layout_swap(false)
+
+    eq(0, panel_focus_calls)
+    eq(0, main_focus_calls)
+  end)
+end)
+
 -- Rapid navigation (e.g., mashing `<Tab>` faster than the async HEAD~ git
 -- fetch can complete) used to spawn overlapping `_set_file` coroutines
 -- that shared the same windows. The second's `Layout.use_entry`


### PR DESCRIPTION
## Summary

Allow users to keep the file panel focused while browsing diffs with `j` / `k`.

This adds an opt-in `file_panel.follow_navigation` setting. When enabled, the existing file-panel `next_entry` / `prev_entry` actions also preview the file under the cursor without moving focus out of the panel.

The default behavior and default keymaps stay unchanged. Users who want this behavior only on selected mappings can use the new `actions.next_entry_follow` and `actions.prev_entry_follow` actions directly.

## Why the focus fix is included

`file_panel.follow_navigation` relies on `set_file(..., focus=false, ...)` so that previewing a file does not move focus out of the file panel.

Some file changes recreate the diff layout, for example when `view.one_sided_layout = "raw"` switches between a two-window diff layout and a one-window raw layout. The layout recreation could move focus back to the diff window even though the caller passed `focus=false`.

This PR preserves the original file-panel focus across that layout swap.