### PR TITLE
feat(session): persist `:DiffviewOpen` and `:DiffviewFileHistory` views across sessions

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -675,6 +675,20 @@ clean_up_buffers                                *diffview-config-clean_up_buffer
         Only affects buffers that were not open before the Diffview was
         opened.
 
+restore_session                                 *diffview-config-restore_session*
+        Type: `boolean`, Default: `true`
+
+        Restore open `:DiffviewOpen` / `:DiffviewFileHistory` views from a
+        sourced Vim session, including per-file cursor and viewport. State
+        is written to a `<session>.diffview.json` sidecar alongside the
+        session file. Setting this to `false` still cleans up stale state
+        from a sourced session: `diffview://` buffers are wiped, and
+        unmodified file buffers that Diffview created in the prior session
+        (recorded in the sidecar) are unlisted, so they drop out of `:ls`
+        and `:bnext`.
+
+        See |diffview.changelog-session-restoration|.
+
 icons                                           *diffview-config-icons*
         Type: `table`, Default: (see defaults)
 

--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -5,6 +5,20 @@ CHANGELOG
 
 NOTE: Breaking changes and notable feature additions are listed here.
 
+                                                *diffview.changelog-session-restoration*
+
+Open `:DiffviewOpen` and `:DiffviewFileHistory` views now survive a
+`:mksession` + `:source Session.vim` round trip. Per-file cursor and
+viewport are restored for every file visited in the saved session.
+
+State is written to a `<session>.diffview.json` sidecar on
+`:mksession` and `VimLeave`, and replayed on `SessionLoadPost`.
+Gated by `|diffview-config-restore_session|` (default `true`).
+
+Session managers that run `-c "DiffviewOpen ..."` at startup should
+defer the open past `VimEnter`; otherwise the tab is created before
+the session is sourced and the manager's `%bw!` strands its buffers.
+
                                                 *diffview.changelog-jj-adapter*
 
 ISSUE: https://github.com/sindrets/diffview.nvim/issues/562

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -37,6 +37,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
     large_file_threshold = 0, -- Line count above which treesitter is disabled on non-LOCAL diff buffers. 0 = disabled.
     diffopt = {},             -- Override diffopt settings while diffview is open. Restored on close.
     clean_up_buffers = false, -- Delete file buffers created by diffview on close.
+    restore_session = true,   -- Restore open Diffview/FileHistory views from a sourced Vim session.
     persist_selections = {
       enabled = false,        -- Persist file selections to disk across Neovim restarts.
       path = nil,             -- Storage path. Nil uses stdpath("data") .. "/diffview_selections.json".

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -142,6 +142,7 @@ local conflict_keymaps = {
 ---@field diffopt table
 ---@field clean_up_buffers boolean
 ---@field persist_selections DiffviewPersistSelectionsConfig
+---@field restore_session boolean
 ---@field icons DiffviewIcons
 ---@field status_icons DiffviewStatusIcons
 ---@field signs DiffviewSigns
@@ -173,6 +174,7 @@ local conflict_keymaps = {
 ---@field diffopt? table Override `diffopt` while diffview is open. Restored on close.
 ---@field clean_up_buffers? boolean Delete file buffers created by diffview on close.
 ---@field persist_selections? DiffviewPersistSelectionsConfig.user Persist file selections across Neovim restarts.
+---@field restore_session? boolean Restore open Diffview/FileHistory views from a sourced Vim session.
 ---@field icons? DiffviewIcons.user Folder icons; only applies when `use_icons` is true.
 ---@field status_icons? DiffviewStatusIcons.user Icons for git status letters.
 ---@field signs? DiffviewSigns.user Sign characters used throughout the UI.
@@ -223,6 +225,7 @@ M.defaults = {
     enabled = false, -- Persist file selections to disk across Neovim restarts.
     path = nil, -- Storage path. Nil uses stdpath("data") .. "/diffview_selections.json".
   },
+  restore_session = true, -- Restore open Diffview/FileHistory views from a sourced Vim session.
 
   ---@class DiffviewIcons
   ---@field folder_closed string
@@ -409,7 +412,7 @@ M.defaults = {
     ---@field deletion_treesitter? boolean Layer tree-sitter syntax highlights over the deleted virt_lines so they read like the rest of the buffer. Falls back transparently when no parser is attached.
     -- Options specific to the `diff1_inline` layout.
     inline = {
-      -- Rendering style. "unified": proper unified diff — old lines shown
+      -- Rendering style. "unified": proper unified diff -- old lines shown
       -- above modifications as virt_lines, added chars highlighted in place.
       -- "overleaf": deleted chars on modified lines rendered inline as
       -- strikethrough virtual text (Overleaf-editor style); no block echo.
@@ -1506,6 +1509,7 @@ function M.setup(user_config)
   validate.integer(c, "large_file_threshold", d.large_file_threshold, { min = 0 })
   validate.table(c, "diffopt", d.diffopt)
   validate.boolean(c, "clean_up_buffers", d.clean_up_buffers)
+  validate.boolean(c, "restore_session", d.restore_session)
 
   -- persist_selections
   validate.table(c, "persist_selections", d.persist_selections)

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -17,6 +17,7 @@ local StandardView = lazy.access("diffview.scene.views.standard.standard_view", 
 local arg_parser = lazy.require("diffview.arg_parser") ---@module "diffview.arg_parser"
 local config = lazy.require("diffview.config") ---@module "diffview.config"
 local rev_lib = lazy.require("diffview.vcs.rev") ---@module "diffview.vcs.rev"
+local session = lazy.require("diffview.session") ---@module "diffview.session"
 local vcs = lazy.require("diffview.vcs") ---@module "diffview.vcs"
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
@@ -111,6 +112,9 @@ function M.diffview_open(args)
   end
 
   table.insert(M.views, v)
+  -- Record at the canonical creation site so every caller (user
+  -- commands, `M.restore`, third-party plugins) gets session coverage.
+  session.record_view(v, "diffview_open", args)
   logger:debug("DiffView instantiation successful!")
 
   return v
@@ -206,6 +210,8 @@ function M.file_history(range, args)
   end
 
   table.insert(M.views, v)
+  -- See `M.diffview_open` for why recording happens here.
+  session.record_view(v, "file_history", args, range)
   logger:debug("FileHistoryView instantiation successful!")
 
   return v

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -80,6 +80,8 @@ function DiffView:init(opt)
   })
 
   self.attached_bufs = {}
+  DiffView._seed_cursor_map_from_selection(self.cursor_map, self.options)
+
   self.emitter:on("file_open_post", utils.bind(self.file_open_post, self))
   self:_init_selection_events()
   self.valid = true
@@ -643,6 +645,18 @@ DiffView.get_updated_files = async.wrap(function(self, callback)
   }, callback)
 end)
 
+---Seed `cursor_map` from `--selected-row`/`--selected-file` so the first-open
+---listener handles it the same as session-restored state. `winrestview` (the
+---consumer in `restore_main_view`) clamps the upper bound; we clamp the
+---lower at 1 so non-positive rows don't reach `nvim_win_set_cursor`.
+---@param cursor_map table<string, table>
+---@param options DiffViewOptions
+function DiffView._seed_cursor_map_from_selection(cursor_map, options)
+  if options.selected_row and options.selected_file then
+    cursor_map[options.selected_file] = { lnum = math.max(1, options.selected_row) }
+  end
+end
+
 ---Determine whether to focus the diff window on initial open.
 ---@param next_file FileEntry?
 ---@return boolean
@@ -948,17 +962,8 @@ local update_files_impl = debounce.debounce_trailing(
       self:set_file(next_file, focus, not self.initialized or nil)
     end
 
-    -- Position cursor at the requested row on first open.
-    if not self.initialized and self.options.selected_row then
-      local win = self.cur_layout:get_main_win()
-      if win and api.nvim_win_is_valid(win.id) then
-        api.nvim_set_current_win(win.id)
-        local buf = api.nvim_win_get_buf(win.id)
-        local line_count = api.nvim_buf_line_count(buf)
-        local row = math.min(self.options.selected_row, line_count)
-        pcall(api.nvim_win_set_cursor, win.id, { math.max(1, row), 0 })
-      end
-    end
+    -- Cursor positioning lives in the `file_open_new` listener; setting
+    -- it here races the async file open and gets overwritten.
 
     self.update_needed = false
     perf:time()

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -111,6 +111,33 @@ return function(view)
       retry_auto_close()
     end,
     file_open_new = function(_, entry)
+      -- `file_open_new` is bridged via `DiffviewGlobal.emitter` →
+      -- current view's emitter, so while multiple views are restoring
+      -- in parallel an event from view A can arrive bound to view B's
+      -- closure. Drop events that aren't ours.
+      if view.cur_entry ~= entry then
+        return
+      end
+
+      -- Session-restored entries: replay the saved cursor + viewport
+      -- instead of jumping to the first hunk. `restore_main_view` is
+      -- one-shot, so re-visits in the same nvim run fall through.
+      if view:restore_main_view(entry.path) then
+        -- Per-invocation `--selected-row` is an explicit "land me here"
+        -- request, so it focuses the main diff window on the targeted
+        -- file regardless of `focus_diff`. Session restore reuses the
+        -- `cursor_map` plumbing but must not yank focus, so we
+        -- discriminate by `selected_row`: only the CLI path sets it.
+        local opts = view.options
+        if opts and opts.selected_row and opts.selected_file == entry.path then
+          local win = view.cur_layout and view.cur_layout:get_main_win()
+          if win and win.id and api.nvim_win_is_valid(win.id) then
+            api.nvim_set_current_win(win.id)
+          end
+          opts.selected_row = nil
+        end
+        return
+      end
       actions.jump_to_first_change(view)
     end,
     ---@diagnostic disable-next-line: unused-local

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -39,6 +39,14 @@ return function(view)
       end
     end,
     file_open_new = function(_, entry)
+      -- See `DiffView`'s listener: drop bridged events from sibling
+      -- views, and replay saved cursor + viewport on first open.
+      if view.cur_entry ~= entry then
+        return
+      end
+      if view:restore_main_view(entry.path) then
+        return
+      end
       actions.jump_to_first_change(view)
     end,
     open_in_diffview = function()

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -24,6 +24,7 @@ local M = {}
 ---@field cur_layout Layout
 ---@field cur_entry FileEntry
 ---@field layouts table<Layout, Layout>
+---@field cursor_map table<string, table> # Repo-relative path → `winsaveview()` dict; consumed by `file_open_new` to restore cursor + viewport on first open after session restore.
 ---@field package _set_file_in_flight Future? # Active `_set_file` worker; queued callers await this so `await(set_file)` returns only after the latest pending file is opened.
 ---@field package _set_file_pending FileEntry? # Newest file queued while `_set_file_in_flight` is set; the worker picks it up before terminating.
 local StandardView = oop.create_class("StandardView", View.__get())
@@ -68,7 +69,61 @@ function StandardView:init(opt)
       diff4 = { a = {}, b = {}, c = {}, d = {} },
     }
 
+  self.cursor_map = opt.cursor_map or {}
+
+  -- Snapshot the leaving file's view state before `_detach_files_for_next`
+  -- strips the window association, so mid-navigation saves keep cursor +
+  -- viewport for every visited file.
+  self.emitter:on("file_open_pre", function(_, _, cur_entry)
+    if cur_entry and cur_entry.path then
+      self:snapshot_main_view(cur_entry.path)
+    end
+  end)
+
   self.emitter:on("post_layout", utils.bind(self.post_layout, self))
+end
+
+---Snapshot the main diff window's cursor + viewport into
+---`self.cursor_map[path]`. No-op if the main window is unavailable.
+---@param path string repo-relative file path; the map key.
+function StandardView:snapshot_main_view(path)
+  local layout = self.cur_layout
+  local main = layout and layout:get_main_win()
+  if not (main and main.id and api.nvim_win_is_valid(main.id)) then
+    return
+  end
+  local ok, vs = pcall(api.nvim_win_call, main.id, function()
+    return vim.fn.winsaveview()
+  end)
+  if ok and type(vs) == "table" then
+    self.cursor_map[path] = vs
+  end
+end
+
+---Pop and apply the saved `winsaveview` dict for `path`. One-shot per
+---path: the entry is removed once successfully applied, so re-visits
+---fall through to the caller's default cursor placement. A failed apply
+---(main window unavailable, or `winrestview` errors) leaves the saved
+---state in place so a later attempt can still restore it.
+---@param path string repo-relative file path.
+---@return boolean # `true` when a saved state was applied successfully.
+function StandardView:restore_main_view(path)
+  local target = self.cursor_map[path]
+  if target == nil then
+    return false
+  end
+  local layout = self.cur_layout
+  local win = layout and layout:get_main_win()
+  if not (win and win.id and api.nvim_win_is_valid(win.id)) then
+    return false
+  end
+  local ok = pcall(api.nvim_win_call, win.id, function()
+    vim.fn.winrestview(target)
+  end)
+  if ok then
+    self.cursor_map[path] = nil
+  end
+  return ok
 end
 
 ---@override

--- a/lua/diffview/session.lua
+++ b/lua/diffview/session.lua
@@ -1,14 +1,22 @@
--- Session restoration cleanup.
+-- Session restoration.
 --
--- A Vim session file (`:mksession`) saves buffer names but not their
--- contents. When sourced, any `diffview://...` buffer comes back empty and
--- has no backing view, so the `:Diffview*` commands cannot interact with
--- it. This module wipes those stale buffers (and any tabpage that held
--- nothing else) after the session loads.
+-- `:mksession` saves buffer names but not contents, so `diffview://...`
+-- buffers come back empty and inert. On `SessionLoadPost` this module
+-- wipes those stale buffers, then replays the `:DiffviewOpen` /
+-- `:DiffviewFileHistory` invocations recorded in a `<session>.diffview.json`
+-- sidecar (written on `SessionWritePost` / `VimLeave`), restoring per-file
+-- cursor and viewport via `winrestview`.
+--
+-- Gated by `restore_session` (default true). When false, the cleanup pass
+-- still runs but save and restore are skipped.
 
 local api = vim.api
 
 local M = {}
+
+-- Bump on any breaking change to the sidecar entry shape; older versions
+-- are rejected on read.
+local SIDECAR_VERSION = 1
 
 ---Returns `true` if `bufnr` belongs to this plugin's UI.
 ---@param bufnr integer
@@ -73,16 +81,37 @@ end
 
 ---Wipe leftover diffview buffers and close any tabpage that held only
 ---diffview windows. Safe to call when no such buffers exist.
-local function cleanup()
-  -- Tabs hosting a live Diffview view are excluded entirely: their
-  -- buffers are filtered out by `is_stale_diffview_buf`, and the tabs
-  -- themselves never enter `tab_has_other`.
+---
+---`stale_local_paths` are absolute paths of LOCAL files the prior
+---diffview session created. Their buffers count as stale for the
+---tab-classification pass but are *unlisted*, not wiped: third-party
+---plugins (LSP, gitsigns, ...) may hold scheduled callbacks against the
+---bufnr that would hit `E680` if it disappeared. Modified buffers are
+---left alone so the user's edits stay visible.
+---@param stale_local_paths? string[]
+local function cleanup(stale_local_paths)
+  stale_local_paths = stale_local_paths or {}
+
+  local stale_local_bufs = {}
+  for _, path in ipairs(stale_local_paths) do
+    local bufnr = vim.fn.bufnr(path)
+    if bufnr > 0 and api.nvim_buf_is_valid(bufnr) and not vim.bo[bufnr].modified then
+      stale_local_bufs[bufnr] = true
+    end
+  end
+
+  -- Tabs hosting a live Diffview view are excluded entirely.
   local live_tabs = live_tab_set()
 
-  -- For each tabpage that displays a stale diffview buffer, track whether
-  -- it also contains unrelated windows. Tabs that hosted *only* stale
-  -- diffview content can be closed after wipeout; tabs with other windows
-  -- must be left alone so the user's layout survives.
+  local function is_stale(bufnr)
+    return is_stale_diffview_buf(bufnr, live_tabs) or stale_local_bufs[bufnr] == true
+  end
+
+  -- Seed `tab_has_other` only from stale `diffview://` buffers. A stale
+  -- LOCAL can also appear in a user-owned tab opened during the same
+  -- session, and seeding from those would auto-close that user tab.
+  -- LOCAL staleness still factors into the second pass so it doesn't
+  -- keep a diffview tab alive.
   local tab_has_other = {}
   for _, bufnr in ipairs(api.nvim_list_bufs()) do
     if is_stale_diffview_buf(bufnr, live_tabs) then
@@ -97,19 +126,21 @@ local function cleanup()
   for tab in pairs(tab_has_other) do
     for _, win in ipairs(api.nvim_tabpage_list_wins(tab)) do
       local b = api.nvim_win_get_buf(win)
-      -- The `diffview://null` singleton is diffview UI too, even though it
-      -- isn't stale; treating it as "other" would leave behind orphan tabs
-      -- whose only remaining content is a null-buffer split.
-      if not is_stale_diffview_buf(b, live_tabs) and not is_null_buf(b) then
+      -- The `diffview://null` singleton is diffview UI but isn't "stale";
+      -- counting it as "other" would strand orphan null-buffer tabs.
+      if not is_stale(b) and not is_null_buf(b) then
         tab_has_other[tab] = true
         break
       end
     end
   end
 
+  -- Wipe `diffview://` buffers; only unlist stale LOCALs (see docstring).
   for _, bufnr in ipairs(api.nvim_list_bufs()) do
     if is_stale_diffview_buf(bufnr, live_tabs) then
       pcall(api.nvim_buf_delete, bufnr, { force = true })
+    elseif stale_local_bufs[bufnr] then
+      vim.bo[bufnr].buflisted = false
     end
   end
 
@@ -127,20 +158,452 @@ end
 
 M.cleanup = cleanup
 
----Register the `SessionLoadPost` autocmd. Called from `plugin/diffview.lua`
----so the hook is in place before any session is sourced.
+---Returns the sidecar path for the currently-loaded session, or nil if no
+---named session is associated with this Neovim instance.
+---@return string?
+local function sidecar_path()
+  local sess = vim.v.this_session
+  if sess == nil or sess == "" then
+    return nil
+  end
+  return sess .. ".diffview.json"
+end
+
+---Returns the effective `restore_session` config value (defaults to true
+---if `diffview.config` fails to load).
+---@return boolean
+local function enabled()
+  local ok, config = pcall(require, "diffview.config")
+  if not ok then
+    return true
+  end
+  return config.get_config().restore_session ~= false
+end
+
+---Returns the 1-based tabnr of `tabpage`, or a large sentinel if invalid
+---(so it sorts last).
+---@param tabpage integer
+---@return integer
+local function tabpage_order(tabpage)
+  if tabpage and api.nvim_tabpage_is_valid(tabpage) then
+    return api.nvim_tabpage_get_number(tabpage)
+  end
+  return math.huge
+end
+
+---@class diffview.session.ViewEntry
+---@field kind "diffview_open"|"file_history"
+---@field args string[] Original command-line args as passed to `lib.*`.
+---@field range? integer[] `{line1, line2}` for `:DiffviewFileHistory` ranges.
+---@field tabpage_order integer Sort key so restored views come back in their original tab order.
+---@field selected_file? string Repo-relative path of the active file (`DiffviewOpen` only).
+---@field cursor_map? table<string, table> Repo-relative path → `winsaveview()` dict for every file visited at save time.
+---@field toplevel? string Repo root, for debugging.
+
+---Absolute paths of LOCAL buffers the prior diffview session created
+---(via `File.created_bufs`), so restore can unlist them without touching
+---user-owned buffers.
+---@return string[]
+local function capture_created_paths()
+  local ok, vcs_file = pcall(require, "diffview.vcs.file")
+  if not ok then
+    return {}
+  end
+  local paths = {}
+  for bufnr in pairs(vcs_file.File.created_bufs or {}) do
+    if api.nvim_buf_is_valid(bufnr) then
+      local name = api.nvim_buf_get_name(bufnr)
+      if name ~= "" then
+        paths[#paths + 1] = name
+      end
+    end
+  end
+  return paths
+end
+
+---Build a serializable entry for `view`, or nil if the view wasn't created
+---through one of the recorded entry points or is no longer valid.
+---@param view any
+---@return diffview.session.ViewEntry?
+local function capture_view(view)
+  local rec = view._session_record
+  if not rec then
+    return nil
+  end
+  if not (view.tabpage and api.nvim_tabpage_is_valid(view.tabpage)) then
+    return nil
+  end
+
+  local entry = {
+    kind = rec.kind,
+    args = rec.args,
+    range = rec.range,
+    tabpage_order = tabpage_order(view.tabpage),
+  }
+
+  if view.adapter and view.adapter.ctx then
+    entry.toplevel = view.adapter.ctx.toplevel
+  end
+
+  -- `selected_file` is `DiffView`-only and feeds the constructor on
+  -- restore. `FileHistoryPanel:cur_file()` is a method, and its active
+  -- file is meaningful only inside an entry, so we don't record one.
+  local cur_file_path
+  if rec.kind == "diffview_open" and view.panel and view.panel.cur_file then
+    cur_file_path = view.panel.cur_file.path
+    entry.selected_file = cur_file_path
+  elseif rec.kind == "file_history" and view.panel and view.panel.cur_file then
+    local ok, file = pcall(view.panel.cur_file, view.panel)
+    if ok and file and file.path then
+      cur_file_path = file.path
+    end
+  end
+
+  -- `file_open_pre` snapshots files the user navigated *away* from;
+  -- refresh the still-active one before serializing.
+  if cur_file_path and view.snapshot_main_view then
+    view:snapshot_main_view(cur_file_path)
+  end
+
+  if view.cursor_map and next(view.cursor_map) ~= nil then
+    entry.cursor_map = view.cursor_map
+  end
+
+  return entry
+end
+
+---Walk the live view list, build sidecar entries, and write them to disk.
+---When no eligible views exist, deletes any stale sidecar instead.
+function M.save()
+  if not enabled() then
+    return
+  end
+  local path = sidecar_path()
+  if not path then
+    return
+  end
+
+  local ok, lib = pcall(require, "diffview.lib")
+  if not ok then
+    return
+  end
+
+  local entries = {}
+  for _, view in ipairs(lib.views or {}) do
+    local entry = capture_view(view)
+    if entry then
+      entries[#entries + 1] = entry
+    end
+  end
+
+  if #entries == 0 then
+    -- Nothing to restore: remove any stale sidecar from a previous save.
+    os.remove(path)
+    return
+  end
+
+  table.sort(entries, function(a, b)
+    return a.tabpage_order < b.tabpage_order
+  end)
+
+  -- Atomic write via temp file + rename (mirrors `selection_store.lua`)
+  -- so a crash mid-write can't strand a half-encoded sidecar.
+  local payload = vim.json.encode({
+    version = SIDECAR_VERSION,
+    views = entries,
+    created_paths = capture_created_paths(),
+  })
+  local tmp = path .. ".tmp"
+  if vim.fn.writefile({ payload }, tmp) ~= 0 then
+    DiffviewGlobal.logger:warn(("[session] failed to write sidecar at %q"):format(tmp))
+    pcall(vim.fn.delete, tmp)
+    return
+  end
+  local rename_ok, rename_err = vim.uv.fs_rename(tmp, path)
+  if not rename_ok then
+    DiffviewGlobal.logger:warn(
+      ("[session] failed to rename sidecar %q -> %q: %s"):format(tmp, path, tostring(rename_err))
+    )
+    pcall(vim.fn.delete, tmp)
+  end
+end
+
+---Read the sidecar (if any) and return the parsed entries plus the list
+---of LOCAL paths the prior session's diffview created, or nil when the
+---sidecar is absent / corrupt / wrong version.
+---@return diffview.session.ViewEntry[]?, string[]?
+local function read_sidecar()
+  local path = sidecar_path()
+  if not path then
+    return nil
+  end
+  local f = io.open(path, "r")
+  if not f then
+    return nil
+  end
+  local data = f:read("*a")
+  f:close()
+  if not data or data == "" then
+    return nil
+  end
+  local ok, parsed = pcall(vim.json.decode, data)
+  if not ok or type(parsed) ~= "table" or type(parsed.views) ~= "table" then
+    return nil
+  end
+  if parsed.version ~= SIDECAR_VERSION then
+    return nil
+  end
+  -- Drop non-table / non-string elements so a hand-edited sidecar can't
+  -- crash the restore loop or feed garbage into `vim.fn.bufnr`.
+  local entries = {}
+  for _, e in ipairs(parsed.views) do
+    if type(e) == "table" then
+      entries[#entries + 1] = e
+    end
+  end
+  local created_paths = {}
+  if type(parsed.created_paths) == "table" then
+    for _, p in ipairs(parsed.created_paths) do
+      if type(p) == "string" and p ~= "" then
+        created_paths[#created_paths + 1] = p
+      end
+    end
+  end
+  return entries, created_paths
+end
+
+---Unlist LOCAL buffers the prior diffview session created so they drop
+---out of `:ls`/`:bnext` and the next `:mksession`. Modified buffers are
+---skipped. Why unlist and not wipe: see `cleanup`'s docstring.
+---@param paths string[] Absolute paths captured at save time.
+local function unlist_stale_locals(paths)
+  for _, path in ipairs(paths) do
+    local bufnr = vim.fn.bufnr(path)
+    if bufnr > 0 and api.nvim_buf_is_valid(bufnr) and not vim.bo[bufnr].modified then
+      vim.bo[bufnr].buflisted = false
+    end
+  end
+end
+
+-- Re-entry guard. `lib.diffview_open` runs adapter bootstraps that pump
+-- the event loop via `vim.wait`, so a sibling `SessionLoadPost` firing
+-- can schedule another `M.restore` during the wait. Those re-entrant
+-- calls would see `bootstrap.done = true` and emit spurious "Not a repo"
+-- errors. This collapses sibling firings to a single call.
+local restore_in_progress = false
+
+local function warn_failed(err)
+  local ok, utils = pcall(require, "diffview.utils")
+  if ok then
+    utils.warn("Failed to restore view: " .. tostring(err))
+  else
+    vim.notify("[diffview+] Failed to restore view: " .. tostring(err), vim.log.levels.WARN)
+  end
+end
+
+---Filter a raw sidecar `cursor_map` to string→table entries, or nil
+---if nothing usable remains.
+---@param raw any
+---@return table<string, table>?
+local function sanitize_cursor_map(raw)
+  if type(raw) ~= "table" then
+    return nil
+  end
+  local out = {}
+  for path, value in pairs(raw) do
+    if type(path) == "string" and type(value) == "table" then
+      out[path] = value
+    end
+  end
+  if next(out) == nil then
+    return nil
+  end
+  return out
+end
+
+---@param lib any
+---@param entry diffview.session.ViewEntry
+local function restore_diffview_entry(lib, entry)
+  if type(entry.args) ~= "table" then
+    return
+  end
+  local create_ok, view = pcall(lib.diffview_open, entry.args)
+  if not create_ok then
+    warn_failed(view)
+    return
+  end
+  if not view then
+    return
+  end
+  -- Cursor positioning is owned by `cursor_map` + `file_open_new`;
+  -- `selected_file` only chooses which file the view opens first.
+  if type(entry.selected_file) == "string" then
+    view.options = view.options or {}
+    view.options.selected_file = entry.selected_file
+  end
+  local cursor_map = sanitize_cursor_map(entry.cursor_map)
+  if cursor_map then
+    view.cursor_map = cursor_map
+  end
+  if not (view.tabpage and api.nvim_tabpage_is_valid(view.tabpage)) then
+    local open_ok, open_err = pcall(view.open, view)
+    if not open_ok then
+      warn_failed(open_err)
+    end
+  end
+end
+
+---@param lib any
+---@param entry diffview.session.ViewEntry
+local function restore_file_history_entry(lib, entry)
+  if type(entry.args) ~= "table" then
+    return
+  end
+  local range = type(entry.range) == "table" and entry.range or nil
+  local create_ok, view = pcall(lib.file_history, range, entry.args)
+  if not create_ok then
+    warn_failed(view)
+    return
+  end
+  if not view then
+    return
+  end
+  local cursor_map = sanitize_cursor_map(entry.cursor_map)
+  if cursor_map then
+    view.cursor_map = cursor_map
+  end
+  local open_ok, open_err = pcall(view.open, view)
+  if not open_ok then
+    warn_failed(open_err)
+  end
+end
+
+---Re-open the diffview views captured in the sidecar associated with the
+---current session, in approximately their original tab order.
+function M.restore()
+  if restore_in_progress then
+    return
+  end
+  if not enabled() then
+    return
+  end
+  local entries, created_paths = read_sidecar()
+  if not entries then
+    return
+  end
+
+  -- Run unconditionally so callers that bypass `cleanup` still get the
+  -- buflist cleaned. `_create_local_buffer` re-lists the selected file
+  -- when the view opens.
+  if created_paths then
+    unlist_stale_locals(created_paths)
+  end
+
+  if #entries == 0 then
+    return
+  end
+
+  -- Force the main diffview module to load so its global autocmds are
+  -- wired up before any view opens.
+  local ok_diffview = pcall(require, "diffview")
+  if not ok_diffview then
+    return
+  end
+  local lib = require("diffview.lib")
+
+  -- If a view is already live (e.g., from `-c DiffviewOpen ...` or a
+  -- user's own autocmd), honour that instead of overwriting it.
+  for _, view in ipairs(lib.views or {}) do
+    if view.tabpage and api.nvim_tabpage_is_valid(view.tabpage) then
+      return
+    end
+  end
+
+  -- Defensive: a hand-edited sidecar may have non-numeric tabpage_order.
+  table.sort(entries, function(a, b)
+    local ao = type(a.tabpage_order) == "number" and a.tabpage_order or math.huge
+    local bo = type(b.tabpage_order) == "number" and b.tabpage_order or math.huge
+    return ao < bo
+  end)
+
+  -- Set before any `lib.diffview_open` (which can yield); pcall-wrap so
+  -- a throw doesn't leave the guard latched.
+  restore_in_progress = true
+  local ok, err = pcall(function()
+    for _, entry in ipairs(entries) do
+      if entry.kind == "diffview_open" then
+        restore_diffview_entry(lib, entry)
+      elseif entry.kind == "file_history" then
+        restore_file_history_entry(lib, entry)
+      end
+    end
+  end)
+  restore_in_progress = false
+  if not ok then
+    warn_failed(err)
+  end
+end
+
+---Record the args used to create `view` so they can be re-invoked on
+---session restore. Called from `lua/diffview/init.lua` entry points.
+---@param view any
+---@param kind "diffview_open"|"file_history"
+---@param args string[]
+---@param range? integer[]
+function M.record_view(view, kind, args, range)
+  if not view then
+    return
+  end
+  view._session_record = {
+    kind = kind,
+    args = vim.deepcopy(args or {}),
+    range = range and vim.deepcopy(range) or nil,
+  }
+end
+
+---Register session autocmds. The save path uses both `VimLeave` and
+---`SessionWritePost`; either alone is incomplete (see comments inside).
 function M.setup()
+  local group = api.nvim_create_augroup("diffview_session", { clear = true })
+
   api.nvim_create_autocmd("SessionLoadPost", {
-    group = api.nvim_create_augroup("diffview_session", { clear = true }),
-    -- Defer past the autocmd context: if the restored layout left the
-    -- cursor on a stale diffview buffer with no real-buffer fallback,
-    -- deleting it inside the autocmd hits `E814` because doing so would
-    -- leave only the autocmd window. Running on the next tick lets
-    -- Neovim drop into a `[No Name]` buffer instead.
+    group = group,
+    -- Defer past the autocmd context: deleting the cursor's buffer
+    -- inside the autocmd hits `E814` (would leave only the autocmd
+    -- window). The next tick drops into `[No Name]` instead.
     callback = function()
-      vim.schedule(cleanup)
+      vim.schedule(function()
+        local _, created_paths = read_sidecar()
+        cleanup(created_paths)
+        -- Defer restore so TabClosed/WinClosed autocmds queued by
+        -- cleanup fire before any view is created.
+        vim.schedule(M.restore)
+      end)
     end,
   })
+
+  -- Session managers run `:mksession` from `VimLeavePre`, and nested
+  -- `SessionWritePost` events are suppressed unless the parent was
+  -- registered `nested = true` -- so we can't rely on it. `VimLeave`
+  -- fires after every `VimLeavePre`, by which point `v:this_session`
+  -- is set.
+  --
+  -- TODO: when Neovim ports Vim 9.1's `SessionWritePre`
+  -- (neovim/neovim#39004, neovim/neovim#22814), switch to it and embed
+  -- the payload in a `g:` variable so it rides inside the session file.
+  api.nvim_create_autocmd("VimLeave", {
+    group = group,
+    callback = M.save,
+  })
+
+  -- Catch interactive `:mksession` outside any session-manager exit
+  -- hook. A duplicate save on exit is harmless.
+  if vim.fn.exists("##SessionWritePost") ~= 0 then
+    api.nvim_create_autocmd("SessionWritePost", {
+      group = group,
+      callback = M.save,
+    })
+  end
 end
 
 return M

--- a/lua/diffview/tests/functional/focus_diff_spec.lua
+++ b/lua/diffview/tests/functional/focus_diff_spec.lua
@@ -106,108 +106,167 @@ describe("DiffView._should_focus_diff", function()
   end)
 end)
 
-describe("DiffView selected_row focuses main window", function()
-  local orig_set_current_win, orig_win_is_valid, orig_win_get_buf
-  local orig_buf_line_count, orig_win_set_cursor
+-- `--selected-row` is an explicit "land me here" request, so it focuses
+-- the main diff window on the targeted file regardless of `focus_diff`.
+-- Session restore reuses the `cursor_map` plumbing but must not yank
+-- focus, so the listener discriminates on `view.options.selected_row`.
+describe("file_open_new listener: --selected-row focus", function()
+  local listeners_factory = require("diffview.scene.views.diff.listeners")
+  local actions = require("diffview.actions")
+
+  local MAIN_WIN_ID = 77
+
+  local stubs = {}
+  local focused
+
+  --- Replace tbl[key] with val, automatically restored in after_each.
+  local function stub(tbl, key, val)
+    stubs[#stubs + 1] = { tbl, key, tbl[key] }
+    tbl[key] = val
+  end
 
   before_each(function()
-    orig_set_current_win = vim.api.nvim_set_current_win
-    orig_win_is_valid = vim.api.nvim_win_is_valid
-    orig_win_get_buf = vim.api.nvim_win_get_buf
-    orig_buf_line_count = vim.api.nvim_buf_line_count
-    orig_win_set_cursor = vim.api.nvim_win_set_cursor
+    focused = nil
+    stub(vim.api, "nvim_set_current_win", function(id)
+      focused = id
+    end)
+    stub(vim.api, "nvim_win_is_valid", function()
+      return true
+    end)
   end)
 
   after_each(function()
-    vim.api.nvim_set_current_win = orig_set_current_win
-    vim.api.nvim_win_is_valid = orig_win_is_valid
-    vim.api.nvim_win_get_buf = orig_win_get_buf
-    vim.api.nvim_buf_line_count = orig_buf_line_count
-    vim.api.nvim_win_set_cursor = orig_win_set_cursor
+    for i = #stubs, 1, -1 do
+      local s = stubs[i]
+      s[1][s[2]] = s[3]
+    end
+    stubs = {}
   end)
 
-  it("calls nvim_set_current_win on the main window", function()
-    local focused_win = nil
-    local cursor_set = nil
-    local main_win_id = 77
-
-    vim.api.nvim_win_is_valid = function()
-      return true
-    end
-    vim.api.nvim_set_current_win = function(id)
-      focused_win = id
-    end
-    vim.api.nvim_win_get_buf = function()
-      return 1
-    end
-    vim.api.nvim_buf_line_count = function()
-      return 100
-    end
-    vim.api.nvim_win_set_cursor = function(id, pos)
-      cursor_set = { id = id, pos = pos }
-    end
-
-    -- Simulate the selected_row block from update_files.
-    local initialized = false
-    local selected_row = 42
-    local cur_layout = {
-      get_main_win = function()
-        return { id = main_win_id }
+  local function make_view(opts)
+    opts = opts or {}
+    return {
+      cur_entry = nil,
+      options = opts.options,
+      cur_layout = {
+        get_main_win = function()
+          return { id = MAIN_WIN_ID }
+        end,
+      },
+      restore_main_view = function()
+        return opts.restore_returns ~= false
       end,
+      panel = {},
+      adapter = {},
     }
+  end
 
-    if not initialized and selected_row then
-      local win = cur_layout:get_main_win()
-      if win and vim.api.nvim_win_is_valid(win.id) then
-        vim.api.nvim_set_current_win(win.id)
-        local buf = vim.api.nvim_win_get_buf(win.id)
-        local line_count = vim.api.nvim_buf_line_count(buf)
-        local row = math.min(selected_row, line_count)
-        pcall(vim.api.nvim_win_set_cursor, win.id, { math.max(1, row), 0 })
-      end
-    end
+  it("focuses the main window when selected_row + matching file are set", function()
+    local view = make_view({
+      options = { selected_row = 42, selected_file = "foo.lua" },
+    })
+    local listeners = listeners_factory(view)
+    local entry = { path = "foo.lua" }
+    view.cur_entry = entry
 
-    assert.equals(main_win_id, focused_win)
-    assert.equals(main_win_id, cursor_set.id)
-    assert.same({ 42, 0 }, cursor_set.pos)
+    listeners.file_open_new(nil, entry)
+    assert.equals(MAIN_WIN_ID, focused)
+    -- One-shot: re-visits must not re-focus.
+    assert.is_nil(view.options.selected_row)
   end)
 
-  it("clamps row to buffer line count", function()
-    local cursor_set = nil
+  it("does not focus when selected_row is unset (session-restore path)", function()
+    local view = make_view({
+      options = { selected_file = "foo.lua" },
+    })
+    local listeners = listeners_factory(view)
+    local entry = { path = "foo.lua" }
+    view.cur_entry = entry
 
-    vim.api.nvim_win_is_valid = function()
-      return true
-    end
-    vim.api.nvim_set_current_win = function() end
-    vim.api.nvim_win_get_buf = function()
-      return 1
-    end
-    vim.api.nvim_buf_line_count = function()
-      return 10
-    end
-    vim.api.nvim_win_set_cursor = function(id, pos)
-      cursor_set = { id = id, pos = pos }
-    end
+    listeners.file_open_new(nil, entry)
+    assert.is_nil(focused)
+  end)
 
-    local initialized = false
-    local selected_row = 999
-    local cur_layout = {
-      get_main_win = function()
-        return { id = 1 }
-      end,
-    }
+  it("does not focus when selected_file does not match the opened entry", function()
+    local view = make_view({
+      options = { selected_row = 42, selected_file = "other.lua" },
+    })
+    local listeners = listeners_factory(view)
+    local entry = { path = "foo.lua" }
+    view.cur_entry = entry
 
-    if not initialized and selected_row then
-      local win = cur_layout:get_main_win()
-      if win and vim.api.nvim_win_is_valid(win.id) then
-        vim.api.nvim_set_current_win(win.id)
-        local buf = vim.api.nvim_win_get_buf(win.id)
-        local line_count = vim.api.nvim_buf_line_count(buf)
-        local row = math.min(selected_row, line_count)
-        pcall(vim.api.nvim_win_set_cursor, win.id, { math.max(1, row), 0 })
-      end
-    end
+    listeners.file_open_new(nil, entry)
+    assert.is_nil(focused)
+    -- selected_row belongs to a different file; leave it untouched.
+    assert.equals(42, view.options.selected_row)
+  end)
 
-    assert.same({ 10, 0 }, cursor_set.pos)
+  it("does not focus when restore_main_view returns false", function()
+    local view = make_view({
+      options = { selected_row = 42, selected_file = "foo.lua" },
+      restore_returns = false,
+    })
+    local listeners = listeners_factory(view)
+    local entry = { path = "foo.lua" }
+    view.cur_entry = entry
+
+    -- Stub `jump_to_first_change` so we don't dive into real action code.
+    stub(actions, "jump_to_first_change", function() end)
+
+    listeners.file_open_new(nil, entry)
+    assert.is_nil(focused)
+  end)
+end)
+
+describe("DiffView._seed_cursor_map_from_selection", function()
+  local DiffView = require("diffview.scene.views.diff.diff_view").DiffView
+
+  it("populates cursor_map with the selected row when both args are set", function()
+    local cursor_map = {}
+    DiffView._seed_cursor_map_from_selection(cursor_map, {
+      selected_row = 42,
+      selected_file = "foo.lua",
+    })
+    assert.same({ lnum = 42 }, cursor_map["foo.lua"])
+  end)
+
+  it("clamps the row to 1 when selected_row is 0", function()
+    local cursor_map = {}
+    DiffView._seed_cursor_map_from_selection(cursor_map, {
+      selected_row = 0,
+      selected_file = "foo.lua",
+    })
+    assert.same({ lnum = 1 }, cursor_map["foo.lua"])
+  end)
+
+  it("clamps the row to 1 when selected_row is negative", function()
+    local cursor_map = {}
+    DiffView._seed_cursor_map_from_selection(cursor_map, {
+      selected_row = -5,
+      selected_file = "foo.lua",
+    })
+    assert.same({ lnum = 1 }, cursor_map["foo.lua"])
+  end)
+
+  it("leaves cursor_map untouched when selected_file is missing", function()
+    local cursor_map = {}
+    DiffView._seed_cursor_map_from_selection(cursor_map, { selected_row = 42 })
+    assert.same({}, cursor_map)
+  end)
+
+  it("leaves cursor_map untouched when selected_row is missing", function()
+    local cursor_map = {}
+    DiffView._seed_cursor_map_from_selection(cursor_map, { selected_file = "foo.lua" })
+    assert.same({}, cursor_map)
+  end)
+
+  it("does not overwrite unrelated entries", function()
+    local cursor_map = { ["other.lua"] = { lnum = 7, col = 3 } }
+    DiffView._seed_cursor_map_from_selection(cursor_map, {
+      selected_row = 42,
+      selected_file = "foo.lua",
+    })
+    assert.same({ lnum = 7, col = 3 }, cursor_map["other.lua"])
+    assert.same({ lnum = 42 }, cursor_map["foo.lua"])
   end)
 end)

--- a/lua/diffview/tests/functional/session_spec.lua
+++ b/lua/diffview/tests/functional/session_spec.lua
@@ -122,6 +122,90 @@ describe("session cleanup", function()
     end
   end)
 
+  it("closes a diffview tab whose only non-diffview window is a stale LOCAL", function()
+    -- The session's diffview tab restores as: panel + diff-left + LOCAL
+    -- right-side. Without `stale_local_paths`, the LOCAL window keeps
+    -- the tab alive and the user lands on a half-restored stub (no
+    -- panel, no diff). Passing the path classifies the LOCAL as
+    -- diffview content for tab accounting, the tab closes entirely.
+    -- The LOCAL buffer is unlisted (not wiped) so third-party plugins'
+    -- pending callbacks against that bufnr don't `E680`.
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, "p")
+    local path_local = tmpdir .. "/right_side.txt"
+    vim.fn.writefile({ "" }, path_local)
+
+    local diff_buf = api.nvim_create_buf(true, false)
+    api.nvim_buf_set_name(diff_buf, "diffview:///repo/blob/abc/right_side.txt")
+    local panel_buf = api.nvim_create_buf(true, false)
+    vim.bo[panel_buf].filetype = "DiffviewFiles"
+    local local_buf = vim.fn.bufadd(path_local)
+    vim.fn.bufload(local_buf)
+    local local_name = api.nvim_buf_get_name(local_buf)
+
+    vim.cmd("tabnew")
+    api.nvim_set_current_buf(panel_buf)
+    vim.cmd("vsplit")
+    api.nvim_set_current_buf(diff_buf)
+    vim.cmd("vsplit")
+    api.nvim_set_current_buf(local_buf)
+    local tab = api.nvim_get_current_tabpage()
+
+    session.cleanup({ local_name })
+
+    assert.is_false(api.nvim_tabpage_is_valid(tab))
+    assert.is_false(api.nvim_buf_is_valid(diff_buf))
+    assert.is_false(api.nvim_buf_is_valid(panel_buf))
+    assert.is_true(api.nvim_buf_is_valid(local_buf))
+    assert.is_false(vim.bo[local_buf].buflisted)
+
+    pcall(api.nvim_buf_delete, local_buf, { force = true })
+    vim.fn.delete(tmpdir, "rf")
+  end)
+
+  it("keeps a tab when a stale LOCAL is modified (data-loss avoidance)", function()
+    -- Modified buffers are excluded from `stale_local_bufs` so the
+    -- tab's `tab_has_other` check sees a real non-diffview window and
+    -- keeps the tab open. The user's edits survive, even though it
+    -- means the half-restored stub stays around.
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, "p")
+    local path_local = tmpdir .. "/dirty.txt"
+    vim.fn.writefile({ "" }, path_local)
+
+    local diff_buf = api.nvim_create_buf(true, false)
+    api.nvim_buf_set_name(diff_buf, "diffview:///repo/blob/abc/dirty.txt")
+    local local_buf = vim.fn.bufadd(path_local)
+    vim.fn.bufload(local_buf)
+    vim.bo[local_buf].buflisted = true
+    api.nvim_buf_set_lines(local_buf, 0, -1, false, { "unsaved edits" })
+    assert.is_true(vim.bo[local_buf].modified)
+    local local_name = api.nvim_buf_get_name(local_buf)
+
+    vim.cmd("tabnew")
+    api.nvim_set_current_buf(diff_buf)
+    vim.cmd("vsplit")
+    api.nvim_set_current_buf(local_buf)
+    local tab = api.nvim_get_current_tabpage()
+
+    session.cleanup({ local_name })
+
+    assert.is_true(api.nvim_tabpage_is_valid(tab))
+    assert.is_false(api.nvim_buf_is_valid(diff_buf))
+    assert.is_true(api.nvim_buf_is_valid(local_buf))
+    -- Modified buffers are skipped entirely: not unlisted either, so
+    -- the user can still see and reach their unsaved edits.
+    assert.is_true(vim.bo[local_buf].buflisted)
+
+    vim.bo[local_buf].modified = false
+    pcall(api.nvim_buf_delete, local_buf, { force = true })
+    if api.nvim_tabpage_is_valid(tab) then
+      api.nvim_set_current_tabpage(tab)
+      vim.cmd("tabclose")
+    end
+    vim.fn.delete(tmpdir, "rf")
+  end)
+
   it("leaves a buffer flagged `b:diffview_loaded` untouched", function()
     -- A live Diffview view sets this flag once buffer contents are
     -- populated (see `vcs/file.lua`). Stale, session-restored buffers
@@ -219,6 +303,36 @@ describe("session cleanup", function()
     assert.is_true(#cmds >= 1)
   end)
 
+  it("registers VimLeave (primary) and SessionWritePost (interactive)", function()
+    -- `VimLeave` is the primary save trigger because session managers
+    -- typically run `:mksession` from `VimLeavePre`, and the
+    -- `SessionWritePost` nested under that fires is suppressed
+    -- (Neovim's nested-autocmd rule). `VimLeave` runs after every
+    -- `VimLeavePre` autocmd has completed, so `v:this_session` is set
+    -- by then. `SessionWritePost` is registered too, but only catches
+    -- the interactive `:mksession` case. `VimLeavePre` is NOT
+    -- registered: it would just hit the same suppression issue when
+    -- it races auto-session's own `VimLeavePre`.
+    session.setup()
+    local vimleave = api.nvim_get_autocmds({
+      event = "VimLeave",
+      group = "diffview_session",
+    })
+    local vlp = api.nvim_get_autocmds({
+      event = "VimLeavePre",
+      group = "diffview_session",
+    })
+    assert.is_true(#vimleave >= 1)
+    assert.equals(0, #vlp)
+    if vim.fn.exists("##SessionWritePost") ~= 0 then
+      local swp = api.nvim_get_autocmds({
+        event = "SessionWritePost",
+        group = "diffview_session",
+      })
+      assert.is_true(#swp >= 1)
+    end
+  end)
+
   it("defers cleanup past the SessionLoadPost autocmd context", function()
     -- Regression: when the restored layout left the cursor on a stale
     -- diffview buffer and the source flow held an autocmd window open,
@@ -234,5 +348,567 @@ describe("session cleanup", function()
     assert.is_true(vim.wait(500, function()
       return not api.nvim_buf_is_valid(diff_buf)
     end))
+  end)
+end)
+
+describe("session save/restore", function()
+  local lib = require("diffview.lib")
+  local config = require("diffview.config")
+  local original_config
+  local tmp_session
+
+  ---Build a minimal stand-in for a view. Avoids constructing a real DiffView
+  ---(which would need an adapter + repo). Anything `capture_view` reads is
+  ---present; the rest is left nil.
+  ---@param opts table
+  ---@return table
+  local function fake_view(opts)
+    return {
+      _session_record = opts._session_record,
+      tabpage = opts.tabpage,
+      adapter = opts.adapter or { ctx = { toplevel = "/fake/repo" } },
+      panel = opts.panel,
+      cur_layout = opts.cur_layout,
+    }
+  end
+
+  before_each(function()
+    -- Drop any non-startup tabs left behind by a previous test so the
+    -- tabpage-order assertions below don't depend on run order.
+    while #api.nvim_list_tabpages() > 1 do
+      vim.cmd("tabclose")
+    end
+    original_config = vim.deepcopy(config.get_config())
+    tmp_session = vim.fn.tempname() .. ".vim"
+    vim.v.this_session = tmp_session
+    lib.views = {}
+  end)
+
+  after_each(function()
+    vim.v.this_session = ""
+    pcall(os.remove, tmp_session .. ".diffview.json")
+    pcall(os.remove, tmp_session)
+    lib.views = {}
+    config.setup(original_config)
+    while #api.nvim_list_tabpages() > 1 do
+      vim.cmd("tabclose")
+    end
+  end)
+
+  describe("record_view", function()
+    it("attaches a `_session_record` with deep-copied args and range", function()
+      local view = {}
+      local args = { "HEAD~3..@", "src/foo.lua" }
+      local range = { 1, 10 }
+      session.record_view(view, "file_history", args, range)
+
+      assert.equals("file_history", view._session_record.kind)
+      assert.are.same(args, view._session_record.args)
+      assert.are.same(range, view._session_record.range)
+
+      -- Mutating the original input must not affect the stored record.
+      args[1] = "MUTATED"
+      range[1] = 99
+      assert.equals("HEAD~3..@", view._session_record.args[1])
+      assert.equals(1, view._session_record.range[1])
+    end)
+
+    it("is a no-op on a nil view", function()
+      assert.has_no.errors(function()
+        session.record_view(nil, "diffview_open", { "HEAD" })
+      end)
+    end)
+  end)
+
+  describe("save", function()
+    it("writes a sidecar JSON with one entry per recorded view", function()
+      local tab1 = api.nvim_get_current_tabpage()
+      vim.cmd("tabnew")
+      local tab2 = api.nvim_get_current_tabpage()
+
+      lib.views = {
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "HEAD~1..@" } },
+          tabpage = tab1,
+          panel = { cur_file = { path = "src/init.lua" } },
+        }),
+        fake_view({
+          _session_record = { kind = "file_history", args = { "--follow", "src/foo.lua" } },
+          tabpage = tab2,
+        }),
+      }
+
+      session.save()
+
+      local f = assert(io.open(tmp_session .. ".diffview.json", "r"))
+      local payload = vim.json.decode(f:read("*a"))
+      f:close()
+
+      assert.equals(1, payload.version)
+      assert.equals(2, #payload.views)
+      assert.equals("diffview_open", payload.views[1].kind)
+      assert.equals("src/init.lua", payload.views[1].selected_file)
+      assert.equals("file_history", payload.views[2].kind)
+      assert.are.same({ "--follow", "src/foo.lua" }, payload.views[2].args)
+    end)
+
+    it("sorts entries by tabpage order", function()
+      local tab1 = api.nvim_get_current_tabpage()
+      vim.cmd("tabnew")
+      local tab2 = api.nvim_get_current_tabpage()
+      vim.cmd("tabnew")
+      local tab3 = api.nvim_get_current_tabpage()
+
+      -- Insert out of order: tab3 first, tab1 second, tab2 third.
+      lib.views = {
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "C" } },
+          tabpage = tab3,
+        }),
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "A" } },
+          tabpage = tab1,
+        }),
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "B" } },
+          tabpage = tab2,
+        }),
+      }
+
+      session.save()
+
+      local f = assert(io.open(tmp_session .. ".diffview.json", "r"))
+      local payload = vim.json.decode(f:read("*a"))
+      f:close()
+
+      assert.equals("A", payload.views[1].args[1])
+      assert.equals("B", payload.views[2].args[1])
+      assert.equals("C", payload.views[3].args[1])
+    end)
+
+    it("removes a stale sidecar when no eligible views remain", function()
+      -- Pre-existing sidecar from a previous save.
+      local sidecar = tmp_session .. ".diffview.json"
+      local f = assert(io.open(sidecar, "w"))
+      f:write("{}")
+      f:close()
+
+      lib.views = {}
+      session.save()
+
+      assert.is_nil(io.open(sidecar, "r"))
+    end)
+
+    it("skips views that were never recorded", function()
+      lib.views = {
+        fake_view({ tabpage = api.nvim_get_current_tabpage() }), -- no `_session_record`
+      }
+
+      session.save()
+
+      assert.is_nil(io.open(tmp_session .. ".diffview.json", "r"))
+    end)
+
+    it("is a no-op when `v:this_session` is empty", function()
+      vim.v.this_session = ""
+      lib.views = {
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "HEAD" } },
+          tabpage = api.nvim_get_current_tabpage(),
+        }),
+      }
+      assert.has_no.errors(session.save)
+    end)
+
+    it("is a no-op when `restore_session = false`", function()
+      config.get_config().restore_session = false
+      lib.views = {
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "HEAD" } },
+          tabpage = api.nvim_get_current_tabpage(),
+        }),
+      }
+
+      session.save()
+
+      assert.is_nil(io.open(tmp_session .. ".diffview.json", "r"))
+    end)
+
+    it("captures `File.created_bufs` paths into `created_paths`", function()
+      local tmpdir = vim.fn.tempname()
+      vim.fn.mkdir(tmpdir, "p")
+      local path_a = tmpdir .. "/a.lua"
+      local path_b = tmpdir .. "/b.lua"
+      vim.fn.writefile({ "" }, path_a)
+      vim.fn.writefile({ "" }, path_b)
+      local buf_a = vim.fn.bufadd(path_a)
+      local buf_b = vim.fn.bufadd(path_b)
+      local name_a = api.nvim_buf_get_name(buf_a)
+      local name_b = api.nvim_buf_get_name(buf_b)
+
+      local prev_created = vim.deepcopy(File.created_bufs)
+      File.created_bufs[buf_a] = true
+      File.created_bufs[buf_b] = true
+
+      lib.views = {
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "HEAD" } },
+          tabpage = api.nvim_get_current_tabpage(),
+        }),
+      }
+
+      local ok, err = pcall(session.save)
+
+      -- Reset shared state before asserting so a failure here doesn't
+      -- leak `File.created_bufs` entries into later tests.
+      for k in pairs(File.created_bufs) do
+        File.created_bufs[k] = nil
+      end
+      for k, v in pairs(prev_created) do
+        File.created_bufs[k] = v
+      end
+      pcall(api.nvim_buf_delete, buf_a, { force = true })
+      pcall(api.nvim_buf_delete, buf_b, { force = true })
+      vim.fn.delete(tmpdir, "rf")
+
+      assert.is_true(ok, tostring(err))
+
+      local f = assert(io.open(tmp_session .. ".diffview.json", "r"))
+      local payload = vim.json.decode(f:read("*a"))
+      f:close()
+
+      assert.is_table(payload.created_paths)
+      table.sort(payload.created_paths)
+      local expected = { name_a, name_b }
+      table.sort(expected)
+      assert.are.same(expected, payload.created_paths)
+    end)
+  end)
+
+  describe("restore", function()
+    local orig_diffview_open, orig_file_history
+    local invocations
+
+    before_each(function()
+      invocations = {}
+      orig_diffview_open = lib.diffview_open
+      orig_file_history = lib.file_history
+      lib.diffview_open = function(args)
+        table.insert(invocations, { fn = "diffview_open", args = args })
+        return {
+          options = {},
+          tabpage = nil,
+          open = function() end,
+        }
+      end
+      lib.file_history = function(range, args)
+        table.insert(invocations, { fn = "file_history", range = range, args = args })
+        return {
+          tabpage = nil,
+          open = function() end,
+        }
+      end
+    end)
+
+    after_each(function()
+      lib.diffview_open = orig_diffview_open
+      lib.file_history = orig_file_history
+    end)
+
+    it("re-invokes the right entry points for each saved view", function()
+      local payload = {
+        version = 1,
+        views = {
+          {
+            kind = "diffview_open",
+            args = { "HEAD~2..@" },
+            tabpage_order = 1,
+            selected_file = "init.lua",
+          },
+          {
+            kind = "file_history",
+            args = { "--follow", "src/foo.lua" },
+            range = { 5, 8 },
+            tabpage_order = 2,
+          },
+        },
+      }
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode(payload))
+      f:close()
+
+      session.restore()
+
+      assert.equals(2, #invocations)
+      assert.equals("diffview_open", invocations[1].fn)
+      assert.are.same({ "HEAD~2..@" }, invocations[1].args)
+      assert.equals("file_history", invocations[2].fn)
+      assert.are.same({ 5, 8 }, invocations[2].range)
+      assert.are.same({ "--follow", "src/foo.lua" }, invocations[2].args)
+    end)
+
+    it("propagates `selected_file` to options and rehydrates `cursor_map`", function()
+      local captured
+      lib.diffview_open = function(_)
+        local v = { options = {}, tabpage = nil, open = function() end }
+        captured = v
+        return v
+      end
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {
+          {
+            kind = "diffview_open",
+            args = { "HEAD" },
+            tabpage_order = 1,
+            selected_file = "src/main.lua",
+            cursor_map = {
+              ["src/main.lua"] = { lnum = 42, col = 3, topline = 10 },
+              ["src/other.lua"] = { lnum = 100, col = 0, topline = 80 },
+            },
+          },
+        },
+      }))
+      f:close()
+
+      session.restore()
+
+      assert.is_not_nil(captured)
+      assert.equals("src/main.lua", captured.options.selected_file)
+      assert.are.same({
+        ["src/main.lua"] = { lnum = 42, col = 3, topline = 10 },
+        ["src/other.lua"] = { lnum = 100, col = 0, topline = 80 },
+      }, captured.cursor_map)
+    end)
+
+    it("is a no-op when no sidecar exists", function()
+      assert.has_no.errors(session.restore)
+      assert.equals(0, #invocations)
+    end)
+
+    it("is a no-op when `restore_session = false`", function()
+      config.get_config().restore_session = false
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {
+          { kind = "diffview_open", args = { "HEAD" }, tabpage_order = 1 },
+        },
+      }))
+      f:close()
+
+      session.restore()
+
+      assert.equals(0, #invocations)
+    end)
+
+    it("ignores entries with an unknown kind", function()
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {
+          { kind = "nonsense", args = { "x" }, tabpage_order = 1 },
+        },
+      }))
+      f:close()
+
+      session.restore()
+
+      assert.equals(0, #invocations)
+    end)
+
+    it("does not crash on a corrupt sidecar", function()
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write("not valid json {{{")
+      f:close()
+
+      assert.has_no.errors(session.restore)
+      assert.equals(0, #invocations)
+    end)
+
+    it("skips restore when a diffview view is already live", function()
+      -- Mirrors `nvim -c "DiffviewOpen ..."` and similar startup paths
+      -- that put a view into `lib.views` before `SessionLoadPost` fires.
+      -- We don't want to stack a sidecar view on top of the user's
+      -- explicit view.
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {
+          { kind = "diffview_open", args = { "HEAD~1" }, tabpage_order = 1 },
+        },
+      }))
+      f:close()
+
+      local existing_tab = api.nvim_get_current_tabpage()
+      table.insert(
+        lib.views,
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "HEAD~3" } },
+          tabpage = existing_tab,
+        })
+      )
+
+      session.restore()
+
+      assert.equals(0, #invocations)
+    end)
+
+    it("still restores when `lib.views` only holds entries with invalid tabpages", function()
+      -- A View object that lingered in `lib.views` without a live tab
+      -- shouldn't block restore: it's a leftover, not a deliberate
+      -- user-initiated view.
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {
+          { kind = "diffview_open", args = { "HEAD~1" }, tabpage_order = 1 },
+        },
+      }))
+      f:close()
+
+      table.insert(
+        lib.views,
+        fake_view({
+          _session_record = { kind = "diffview_open", args = { "stale" } },
+          tabpage = 999999, -- never a valid tabpage
+        })
+      )
+
+      session.restore()
+
+      assert.equals(1, #invocations)
+      assert.are.same({ "HEAD~1" }, invocations[1].args)
+    end)
+
+    it("records `_session_record` on restored views so the next save can recapture them", function()
+      -- Regression: without this, capturing during the next `:mksession`
+      -- drops the restored view (no `_session_record`), the sidecar is
+      -- wiped on the empty save, and the diffview disappears on the
+      -- third run.
+      --
+      -- Recording now happens inside `lib.diffview_open` /
+      -- `lib.file_history` themselves, so any caller (user command,
+      -- `M.restore`, third-party plugin) gets covered. The stubs below
+      -- mimic that placement: they tag the returned view as the real
+      -- functions do.
+      local captured_views = {}
+      lib.diffview_open = function(args)
+        local v = { options = {}, tabpage = nil, open = function() end }
+        session.record_view(v, "diffview_open", args)
+        captured_views[#captured_views + 1] = v
+        return v
+      end
+      lib.file_history = function(range, args)
+        local v = { tabpage = nil, open = function() end }
+        session.record_view(v, "file_history", args, range)
+        captured_views[#captured_views + 1] = v
+        return v
+      end
+
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {
+          {
+            kind = "diffview_open",
+            args = { "HEAD~1" },
+            tabpage_order = 1,
+            selected_file = "src/a.lua",
+          },
+          {
+            kind = "file_history",
+            args = { "src/b.lua" },
+            range = { 1, 10 },
+            tabpage_order = 2,
+          },
+        },
+      }))
+      f:close()
+
+      session.restore()
+
+      assert.equals(2, #captured_views)
+      assert.equals("diffview_open", captured_views[1]._session_record.kind)
+      assert.are.same({ "HEAD~1" }, captured_views[1]._session_record.args)
+      assert.equals("file_history", captured_views[2]._session_record.kind)
+      assert.are.same({ "src/b.lua" }, captured_views[2]._session_record.args)
+      assert.are.same({ 1, 10 }, captured_views[2]._session_record.range)
+    end)
+
+    it("unlists prior-session LOCAL buffers via the created_paths field", function()
+      -- The user navigated through these files in diffview; on save
+      -- they ended up in `:mksession`'s `badd` list and on load Neovim
+      -- recreated them. `M.restore` unlists them so `:ls`/`:bnext`
+      -- skip them and the next `:mksession` doesn't carry them
+      -- forward. Buffers stay valid so third-party plugins' pending
+      -- callbacks don't `E680`.
+      local tmpdir = vim.fn.tempname()
+      vim.fn.mkdir(tmpdir, "p")
+      local path_a = tmpdir .. "/a.txt"
+      local path_b = tmpdir .. "/b.txt"
+      vim.fn.writefile({ "" }, path_a)
+      vim.fn.writefile({ "" }, path_b)
+      local buf_a = vim.fn.bufadd(path_a)
+      local buf_b = vim.fn.bufadd(path_b)
+      vim.fn.bufload(buf_a)
+      vim.fn.bufload(buf_b)
+      -- `bufadd` defaults to unlisted; simulate the session-restore
+      -- state where these buffers came back via `:badd` (which lists).
+      vim.bo[buf_a].buflisted = true
+      vim.bo[buf_b].buflisted = true
+
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {},
+        created_paths = { api.nvim_buf_get_name(buf_a), api.nvim_buf_get_name(buf_b) },
+      }))
+      f:close()
+
+      session.restore()
+
+      assert.is_true(api.nvim_buf_is_valid(buf_a))
+      assert.is_true(api.nvim_buf_is_valid(buf_b))
+      assert.is_false(vim.bo[buf_a].buflisted)
+      assert.is_false(vim.bo[buf_b].buflisted)
+
+      pcall(api.nvim_buf_delete, buf_a, { force = true })
+      pcall(api.nvim_buf_delete, buf_b, { force = true })
+      vim.fn.delete(tmpdir, "rf")
+    end)
+
+    it("leaves a modified LOCAL buffer listed (data-loss avoidance)", function()
+      -- Modified buffers are skipped entirely: the user has unsaved
+      -- edits, so we don't touch `:ls` visibility either.
+      local tmpdir = vim.fn.tempname()
+      vim.fn.mkdir(tmpdir, "p")
+      local path = tmpdir .. "/modified.txt"
+      vim.fn.writefile({ "" }, path)
+      local bufnr = vim.fn.bufadd(path)
+      vim.fn.bufload(bufnr)
+      vim.bo[bufnr].buflisted = true
+      api.nvim_buf_set_lines(bufnr, 0, -1, false, { "dirty content" })
+      assert.is_true(vim.bo[bufnr].modified)
+
+      local name = api.nvim_buf_get_name(bufnr)
+      local f = assert(io.open(tmp_session .. ".diffview.json", "w"))
+      f:write(vim.json.encode({
+        version = 1,
+        views = {},
+        created_paths = { name },
+      }))
+      f:close()
+
+      session.restore()
+
+      assert.is_true(api.nvim_buf_is_valid(bufnr))
+      assert.is_true(vim.bo[bufnr].buflisted)
+
+      vim.bo[bufnr].modified = false
+      pcall(api.nvim_buf_delete, bufnr, { force = true })
+      vim.fn.delete(tmpdir, "rf")
+    end)
   end)
 end)


### PR DESCRIPTION
Save view args (plus current file and cursor row) to a companion `<session>.diffview.json` file on `SessionWritePost`/`VimLeave`, and re-invoke them on `SessionLoadPost` after the cleanup pass.

Gated by new `restore_session` option (defaults to `true`).

Fixes #217.