### PR TITLE
Execute git commands in `-C{path}` when git cwd and toplevel are different

### DIFF
--- a/lua/diffview/tests/functional/git_adapter_spec.lua
+++ b/lua/diffview/tests/functional/git_adapter_spec.lua
@@ -40,7 +40,66 @@ local function make_repo_and_adapter()
   return repo, adapter
 end
 
+local function make_linked_worktree_like_repo()
+  local repo = vim.fn.tempname()
+  assert.equals(1, vim.fn.mkdir(repo, "p"))
+
+  run({ "git", "init", "-q" }, repo)
+  run({ "git", "config", "user.name", "Diffview Test" }, repo)
+  run({ "git", "config", "user.email", "diffview@test.local" }, repo)
+
+  local tracked = repo .. "/tracked.txt"
+  local f = assert(io.open(tracked, "w"))
+  f:write("init\n")
+  f:close()
+
+  run({ "git", "add", "tracked.txt" }, repo)
+  run({ "git", "-c", "commit.gpgsign=false", "commit", "-q", "-m", "init" }, repo)
+
+  local shadow = vim.fn.tempname()
+  assert.equals(1, vim.fn.mkdir(shadow, "p"))
+  local gitdir = shadow .. "/.git"
+  local gf = assert(io.open(gitdir, "w"))
+  gf:write("gitdir: " .. repo:gsub("\\", "/") .. "/.git\n")
+  gf:close()
+
+  local ok, err = GitAdapter.find_toplevel({ shadow })
+  assert.is_nil(ok)
+
+  return {
+    repo = repo,
+    shadow = shadow,
+    cleanup = function()
+      pcall(vim.fn.delete, shadow, "rf")
+      pcall(vim.fn.delete, repo, "rf")
+    end,
+    toplevel = err,
+  }
+end
+
 describe("diffview.vcs.adapters.git", function()
+  it(
+    "prefers explicit cpath when git show-toplevel escapes it",
+    test_utils.async_test(function()
+      local env = make_linked_worktree_like_repo()
+
+      local ok, err = pcall(function()
+        assert.equals(env.shadow, env.toplevel)
+
+        local adapter_err, adapter = GitAdapter.create(env.toplevel, {}, env.shadow)
+        assert.is_nil(adapter_err)
+        assert.equals(env.shadow, adapter.ctx.toplevel)
+      end)
+
+      vim.schedule(env.cleanup)
+      async.await(async.scheduler())
+
+      if not ok then
+        error(err)
+      end
+    end)
+  )
+
   describe("get_show_args", function()
     it(
       "includes --no-show-signature",

--- a/lua/diffview/tests/functional/git_adapter_spec.lua
+++ b/lua/diffview/tests/functional/git_adapter_spec.lua
@@ -79,16 +79,18 @@ end
 
 describe("diffview.vcs.adapters.git", function()
   it(
-    "prefers explicit cpath when git show-toplevel escapes it",
+    "keeps git toplevel for paths and explicit cpath for command execution",
     test_utils.async_test(function()
       local env = make_linked_worktree_like_repo()
 
       local ok, err = pcall(function()
-        assert.equals(env.shadow, env.toplevel)
+        assert.equals(env.repo, env.toplevel)
 
         local adapter_err, adapter = GitAdapter.create(env.toplevel, {}, env.shadow)
         assert.is_nil(adapter_err)
-        assert.equals(env.shadow, adapter.ctx.toplevel)
+        assert.equals(env.repo, adapter.ctx.toplevel)
+        assert.equals(env.shadow, adapter:exec_root())
+        assert.equals(env.shadow, adapter.ctx.dir)
       end)
 
       vim.schedule(env.cleanup)

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -39,6 +39,7 @@ local M = {}
 
 ---@class vcs.adapter.VCSAdapter.Ctx
 ---@field toplevel? string # VCS repository toplevel directory
+---@field exec_root? string # Directory from which VCS commands should execute
 ---@field dir? string # VCS directory
 ---@field path_args? string[] # Resolved path arguments
 
@@ -391,6 +392,11 @@ function VCSAdapter:args()
   return utils.vec_slice(self:get_command(), 2)
 end
 
+---@return string? cwd The preferred execution directory for VCS commands.
+function VCSAdapter:exec_root()
+  return self.ctx.exec_root or self.ctx.toplevel
+end
+
 ---Execute a VCS command synchronously.
 ---@param args string[]
 ---@param cwd_or_opt? string|utils.job.Opt
@@ -616,7 +622,7 @@ VCSAdapter.show = async.wrap(function(self, path, rev, callback)
   job = Job({
     command = self:bin(),
     args = self:get_show_args(path, rev),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     retry = 2,
     fail_cond = Job.FAIL_COND.on_empty,
     log_opt = { label = "VCSAdapter:show()" },

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -149,6 +149,7 @@ function GitAdapter.get_repo_paths(path_args, cpath)
     end
   end
 
+  ---@diagnostic disable-next-line: undefined-field
   VCSAdapter.append_implicit_indicators(top_indicators, cpath)
 
   return paths, top_indicators
@@ -205,7 +206,20 @@ local function normalize_cygwin_path(path)
   return path
 end
 
----Get the git toplevel directory from a path to file or directory
+---Check if one path is contained within another
+---@param base string
+---@param candidate string
+---@return boolean
+local function is_within(base, candidate)
+  base = pl:remove_trailing(base)
+  candidate = pl:remove_trailing(candidate)
+  return candidate == base or vim.startswith(candidate, pl:add_trailing(base))
+end
+
+---Get the git toplevel directory from a path to file or directory.
+---When an explicit `-C` points at a linked worktree-like location, git can
+---report the main worktree for `--show-toplevel` even though commands should
+---continue to execute from the given path.
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
@@ -219,7 +233,15 @@ local function get_toplevel(path)
   if code ~= 0 then
     return nil
   end
-  return normalize_cygwin_path(out[1] and vim.trim(out[1]))
+
+  local toplevel = normalize_cygwin_path(out[1] and vim.trim(out[1]))
+  local cpath = pl:realpath(path)
+
+  if cpath and toplevel and pl:is_dir(cpath) and not is_within(toplevel, cpath) then
+    return cpath
+  end
+
+  return toplevel
 end
 
 ---@param top_indicators string[] A list of paths that might indicate what working tree we are in.

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -206,20 +206,7 @@ local function normalize_cygwin_path(path)
   return path
 end
 
----Check if one path is contained within another
----@param base string
----@param candidate string
----@return boolean
-local function is_within(base, candidate)
-  base = pl:remove_trailing(base)
-  candidate = pl:remove_trailing(candidate)
-  return candidate == base or vim.startswith(candidate, pl:add_trailing(base))
-end
-
 ---Get the git toplevel directory from a path to file or directory.
----When an explicit `-C` points at a linked worktree-like location, git can
----report the main worktree for `--show-toplevel` even though commands should
----continue to execute from the given path.
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
@@ -233,15 +220,7 @@ local function get_toplevel(path)
   if code ~= 0 then
     return nil
   end
-
-  local toplevel = normalize_cygwin_path(out[1] and vim.trim(out[1]))
-  local cpath = pl:realpath(path)
-
-  if cpath and toplevel and pl:is_dir(cpath) and not is_within(toplevel, cpath) then
-    return cpath
-  end
-
-  return toplevel
+  return normalize_cygwin_path(out[1] and vim.trim(out[1]))
 end
 
 ---@param top_indicators string[] A list of paths that might indicate what working tree we are in.
@@ -284,13 +263,15 @@ function GitAdapter:init(opt)
   opt = opt or {}
   self:super(opt)
 
-  local cwd = opt.cpath or uv.cwd()
+  local base_cwd = opt.cpath or assert(uv.cwd(), "uv.cwd() failed")
+  local exec_root = pl:realpath(base_cwd) or base_cwd
 
   self.ctx = {
     toplevel = opt.toplevel,
-    dir = self:get_dir(opt.toplevel),
+    exec_root = exec_root,
+    dir = self:get_dir(exec_root),
     path_args = vim.tbl_map(function(pathspec)
-      return GitAdapter.pathspec_expand(opt.toplevel, cwd, pathspec)
+      return GitAdapter.pathspec_expand(opt.toplevel, exec_root, pathspec)
     end, opt.path_args or {}) --[[@as string[] ]],
   }
 
@@ -322,6 +303,22 @@ function GitAdapter:get_dir(path)
     return nil
   end
   return normalize_cygwin_path(out[1] and vim.trim(out[1]))
+end
+
+function GitAdapter:exec_sync(args, cwd_or_opt)
+  if type(cwd_or_opt) == "string" then
+    if cwd_or_opt == self.ctx.toplevel then
+      cwd_or_opt = self:exec_root()
+    end
+  elseif type(cwd_or_opt) == "table" then
+    if cwd_or_opt.cwd == self.ctx.toplevel then
+      cwd_or_opt = vim.tbl_extend("force", {}, cwd_or_opt, { cwd = self:exec_root() })
+    end
+  elseif cwd_or_opt == nil then
+    cwd_or_opt = self:exec_root()
+  end
+
+  return VCSAdapter.exec_sync(self, args, cwd_or_opt)
 end
 
 ---Verify that a given git rev is valid.
@@ -554,7 +551,7 @@ function GitAdapter:stream_fh_data(state)
       "--",
       state.path_args
     ),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     log_opt = { label = "GitAdapter:incremental_fh_data()" },
     on_stdout = on_stdout,
     on_exit = utils.hard_bind(stream.close, stream),
@@ -635,7 +632,7 @@ function GitAdapter:stream_line_trace_data(state)
       state.prepared_log_opts.rev_range,
       "--"
     ),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     log_opt = { label = "GitAdapter:incremental_line_trace_data()" },
     on_stdout = on_stdout,
     on_exit = utils.hard_bind(stream.close, stream),
@@ -1289,7 +1286,7 @@ GitAdapter.fh_retry_commit = async.wrap(function(self, rev_arg, state, opt, call
       "--",
       state.old_path or state.path_args
     ),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     fail_cond = Job.FAIL_COND.on_empty,
     log_opt = { label = "GitAdapter:fh_retry_commit()" },
   })
@@ -1897,12 +1894,18 @@ function GitAdapter:parse_revs(rev_arg, opt)
   ---@type Rev?
   local right
 
-  local head = self:head_rev()
-  ---@cast head Rev
+  ---@type Rev?
+  local head
+  local function get_head()
+    if head == nil then
+      head = self:head_rev()
+    end
+    return head
+  end
 
   if not rev_arg then
     if opt.cached then
-      left = head or GitRev.new_null_tree()
+      left = get_head() or GitRev.new_null_tree()
       right = GitRev(RevType.STAGE, 0)
     else
       left = GitRev(RevType.STAGE, 0)
@@ -1915,7 +1918,10 @@ function GitAdapter:parse_revs(rev_arg, opt)
     elseif opt.imply_local then
       ---@cast left Rev
       ---@cast right Rev
-      left, right = self:imply_local(left, right, head)
+      local resolved_head = get_head()
+      if resolved_head then
+        left, right = self:imply_local(left, right, resolved_head)
+      end
     end
   else
     local rev_strings, code, stderr = self:exec_sync(
@@ -1949,7 +1955,10 @@ function GitAdapter:parse_revs(rev_arg, opt)
       end
 
       if opt.imply_local then
-        left, right = self:imply_local(left, right, head)
+        local resolved_head = get_head()
+        if resolved_head then
+          left, right = self:imply_local(left, right, resolved_head)
+        end
       end
     else
       local hash = rev_strings[1]:gsub("^%^", "")
@@ -1959,8 +1968,14 @@ function GitAdapter:parse_revs(rev_arg, opt)
       else
         -- When comparing a single ref with working tree, optionally use merge-base.
         if opt.merge_base then
+          local resolved_head = get_head()
+          if not resolved_head then
+            left = GitRev(RevType.COMMIT, hash)
+            right = GitRev(RevType.LOCAL)
+            return left, right
+          end
           local merge_base_out, merge_base_code = self:exec_sync(
-            { "merge-base", "HEAD", hash },
+            { "merge-base", resolved_head.commit, hash },
             { cwd = self.ctx.toplevel, fail_on_empty = true, retry = 2 }
           )
           if merge_base_code == 0 and #merge_base_out > 0 then
@@ -2239,7 +2254,7 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
       "--name-status",
       args
     ),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     log_opt = log_opt,
   })
   local numstat_job = Job({
@@ -2253,7 +2268,7 @@ GitAdapter.tracked_files = async.wrap(function(self, left, right, args, kind, op
       "--numstat",
       args
     ),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     log_opt = log_opt,
   })
 
@@ -2441,7 +2456,7 @@ GitAdapter.untracked_files = async.wrap(function(self, left, right, opt, callbac
       "--others",
       "--exclude-standard"
     ),
-    cwd = self.ctx.toplevel,
+    cwd = self:exec_root(),
     log_opt = { label = "GitAdapter:untracked_files()" },
   })
 
@@ -2516,6 +2531,14 @@ function GitAdapter:is_binary(path, rev)
     ".",
   }
   if rev.type == RevType.LOCAL then
+    local tracked_cmd = vim.deepcopy(cmd)
+    utils.vec_push(tracked_cmd, "--", path)
+
+    local _, tracked_code = self:exec_sync(tracked_cmd, { cwd = self.ctx.toplevel, silent = true })
+    if tracked_code == 0 then
+      return false
+    end
+
     cmd[#cmd + 1] = "--untracked"
     cmd[#cmd + 1] = "--no-exclude-standard"
   elseif rev.type == RevType.STAGE then


### PR DESCRIPTION
## Summary
I ran into a case where `git -C <path> diff <rev>` returned a proper diff, but `:DiffviewOpen -C=<path> <rev>` couldn't.

This PR makes `DiffviewOpen -C=<path>` behave the way git would in snapshot/worktree-like layouts where `--show-toplevel` and `--git-dir` do not resolve to the same directory.

## Problem
Diffview was treating two concepts as the same path:

- the directory git commands should execute from
- the repo toplevel used for relative path resolution

`-C` usage works for normal repos, but breaks where:
- git commands must run from the `-C` directory
- `git rev-parse --show-toplevel` points somewhere else
- git still emits repo-relative paths against the reported toplevel

My use case was against an OpenCode snapshot directory, but the underlying problem would occur in snapshot/worktree-like setups where git's cwd and its reported toplevel diverge.

While working through this, I hit another issue affecting single-rev commit-vs-local diffs. The RHS `LOCAL` file could collapse to `diffview://null` when it was mistakenly classified as a binary.

## Fix
This PR separates the execution root from the path-resolution root in the case that toplevel and git-dir are not the same.

- add `ctx.exec_root` for git command execution
- keep `ctx.toplevel` for repo-relative path resolution
- make `parse_revs()` resolve `HEAD` lazily so a `COMMIT` to `LOCAL` diff doesn't require a `HEAD`
- test if a tracked `LOCAL` file is text before falling back to the existing untracked binary check

## Result
This restores the expected behavior for snapshot/worktree-style `-C` diffs, including:

- `:DiffviewOpen -C=<snapshot> <rev>`
- `:DiffviewOpen -C=<snapshot> <revA>..<revB>`

In particular, the RHS `LOCAL` side now opens the real working-tree file instead of collapsing to a null buffer.

## Note
This is not a general `-C` fix for ordinary repos; those already worked. The narrower issue here is that git's execution root and reported repo toplevel can differ, and Diffview was assuming they were always the same.

The main semantic change is:

- `toplevel` stays the base for repo-relative paths
- `exec_root` becomes the cwd for git operations
