### PR TITLE
fix(jj): quote paths so fileset metacharacters match literally

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -278,6 +278,18 @@ COMMANDS                                        *diffview-commands*
         and git pathspec is supported (see `:Man gitglossary(7)` for
         information about pathspec).
 
+        With the Jujutsu adapter, [paths] are jj filesets rather than git
+        pathspecs. A bare path is matched as a glob (jj's default `cwd`
+        pattern kind), so a literal filename that contains fileset
+        metacharacters can match the wrong file: `*`, `?`, `[`, and `]` act
+        as glob symbols, while `(`, `)`, `|`, `&`, and `~` are parser
+        operators. To match such a file literally, prefix it with the
+        exact-file kind `file:` (or use `glob:` to force an explicit glob).
+        If the literal name also contains a parser operator, wrap it in a jj
+        string literal using the opposite quote character, so that Vim's
+        command-line parser preserves the inner quotes (see the examples
+        below). See `jj help -k filesets` for the full fileset syntax.
+
         If [range] is given, the file history view will trace the line
         evolution of the given range in the current file (see the `-L` flag
         below). Not supported by the Jujutsu adapter.
@@ -314,6 +326,14 @@ COMMANDS                                        *diffview-commands*
 
             " History for multiple paths:
             :DiffviewFileHistory multiple/paths foo/bar baz/qux
+
+            " jj: a literal path containing glob-like route params:
+            :DiffviewFileHistory file:src/routes/[id]/page.svelte
+
+            " jj: a literal path with both a route group and a glob param;
+            " single-quote the arg so the jj string literal's double quotes
+            " survive Vim's command-line parser:
+            :DiffviewFileHistory 'file:"src/routes/(app)/[id]/page.svelte"'
 
             " Compare history against a fixed base:
             :DiffviewFileHistory --base=HEAD~4

--- a/lua/diffview/tests/functional/jj_adapter_spec.lua
+++ b/lua/diffview/tests/functional/jj_adapter_spec.lua
@@ -208,6 +208,42 @@ describe("diffview.vcs.adapters.jj", function()
     end)
   end)
 
+  describe("get_show_args()", function()
+    it("wraps the path in an exact-file fileset pattern", function()
+      local adapter = new_adapter()
+      local args = adapter:get_show_args("src/main.lua", adapter.Rev(RevType.COMMIT, "abc123"))
+
+      eq({ "file", "show", "-r", "abc123", "--", 'file:"src/main.lua"' }, args)
+    end)
+
+    it("escapes fileset metacharacters so jj matches the path literally", function()
+      local adapter = new_adapter()
+      -- Svelte route groups use parentheses, which are fileset operators in jj.
+      local args = adapter:get_show_args(
+        "frontend/src/routes/(test)/View.svelte",
+        adapter.Rev(RevType.COMMIT, "abc123")
+      )
+
+      eq('file:"frontend/src/routes/(test)/View.svelte"', args[#args])
+    end)
+
+    it("uses the exact-file kind so glob symbols match literally", function()
+      local adapter = new_adapter()
+      -- The `file:` kind disables glob expansion, so `[1]` is not a character
+      -- class and the bracketed filename resolves to itself.
+      local args = adapter:get_show_args("a[1].txt", adapter.Rev(RevType.COMMIT, "abc123"))
+
+      eq('file:"a[1].txt"', args[#args])
+    end)
+
+    it("backslash-escapes embedded quotes and backslashes", function()
+      local adapter = new_adapter()
+      local args = adapter:get_show_args([[a"b\c.txt]], adapter.Rev(RevType.COMMIT, "abc123"))
+
+      eq([[file:"a\"b\\c.txt"]], args[#args])
+    end)
+  end)
+
   describe("_warn_once()", function()
     local orig_warn
 
@@ -359,7 +395,7 @@ describe("diffview.vcs.adapters.jj", function()
 
         eq(true, ok)
         eq(":!jj op undo", undo)
-        eq({ "restore", "--from", "@-", "--", "src/main.lua" }, captured_args)
+        eq({ "restore", "--from", "@-", "--", 'file:"src/main.lua"' }, captured_args)
       end)
     )
 
@@ -376,7 +412,7 @@ describe("diffview.vcs.adapters.jj", function()
         local ok = await(adapter:file_restore("src/main.lua", "working", "abcdef"))
 
         eq(true, ok)
-        eq({ "restore", "--from", "abcdef", "--", "src/main.lua" }, captured_args)
+        eq({ "restore", "--from", "abcdef", "--", 'file:"src/main.lua"' }, captured_args)
       end)
     )
 
@@ -561,6 +597,60 @@ describe("diffview.vcs.adapters.jj", function()
           assert.is_nil(err)
           assert.is_not_nil(content)
           assert.equals("hello world", vim.trim(table.concat(content, "\n")))
+        end)
+      )
+
+      it(
+        "shows file content for a path containing fileset metacharacters",
+        helpers.async_test(function()
+          if not jj_available() then
+            pending("jj not installed")
+            return
+          end
+
+          -- Svelte route groups embed parentheses in the path, which jj reads
+          -- as fileset operators unless the path is quoted (regression test
+          -- for the "Failed to parse fileset" error on `:DiffviewOpen`).
+          local path = "frontend/src/routes/(test)/View.svelte"
+          repo.write(path, "<svelte/>\n")
+          repo.jj({ "describe", "-m", "add svelte route group" })
+
+          local adapter = repo.adapter()
+          local commit_id = run({ "jj", "show", "-T", "commit_id", "@", "--no-patch" }, repo.dir)
+          local rev = adapter.Rev(RevType.COMMIT, commit_id)
+
+          local err, content = await(adapter:show(path, rev))
+
+          assert.is_nil(err)
+          assert.is_not_nil(content)
+          assert.equals("<svelte/>", vim.trim(table.concat(content, "\n")))
+        end)
+      )
+
+      it(
+        "shows the exact file when a glob-collision sibling exists",
+        helpers.async_test(function()
+          if not jj_available() then
+            pending("jj not installed")
+            return
+          end
+
+          -- `a[1].txt` would be a glob character class matching `a1.txt` under
+          -- jj's default pattern kind. The exact-file (`file:`) kind must pin
+          -- the lookup to the literally-named file, not its glob sibling.
+          repo.write("a[1].txt", "BRACKET\n")
+          repo.write("a1.txt", "GLOBBED\n")
+          repo.jj({ "describe", "-m", "add glob-collision files" })
+
+          local adapter = repo.adapter()
+          local commit_id = run({ "jj", "show", "-T", "commit_id", "@", "--no-patch" }, repo.dir)
+          local rev = adapter.Rev(RevType.COMMIT, commit_id)
+
+          local err, content = await(adapter:show("a[1].txt", rev))
+
+          assert.is_nil(err)
+          assert.is_not_nil(content)
+          assert.equals("BRACKET", vim.trim(table.concat(content, "\n")))
         end)
       )
 
@@ -752,6 +842,54 @@ describe("diffview.vcs.adapters.jj", function()
           assert.is_true(seen_paths["a.txt"], "expected a.txt in history")
           assert.is_true(seen_paths["b.txt"], "expected b.txt in history")
           assert.is_nil(seen_paths["c.md"], "c.md should have been filtered out")
+        end)
+      )
+
+      it(
+        "builds history for a literal path containing fileset metacharacters",
+        helpers.async_test(function()
+          if not jj_available() then
+            pending("jj not installed")
+            return
+          end
+
+          -- A Svelte route group path embeds parentheses, which jj parses as
+          -- fileset operators. `:DiffviewFileHistory <path>` must quote the
+          -- path so `jj log`/`jj file list` match it literally instead of
+          -- failing with "Failed to parse fileset".
+          local path = "frontend/src/routes/(test)/View.svelte"
+          repo.write(path, "<svelte/>\n")
+          repo.jj({ "describe", "-m", "add svelte route group" })
+
+          local adapter = repo.adapter()
+          local AsyncListStream = require("diffview.stream").AsyncListStream
+          local JobStatus = require("diffview.vcs.utils").JobStatus
+
+          local stream = AsyncListStream()
+          adapter:file_history_worker(stream, {
+            log_opt = {
+              single_file = { path_args = { path }, revisions = "::@" },
+              multi_file = { path_args = { path }, revisions = "::@" },
+            },
+            layout_opt = { default_layout = Diff2, merge_layout = Diff2 },
+          })
+
+          local statuses = {}
+          local found = false
+          for _, item in stream:iter() do
+            local status, log_entry = unpack(item, 1, 2)
+            statuses[#statuses + 1] = status
+            if status == JobStatus.PROGRESS and log_entry then
+              for _, f in ipairs(log_entry.files) do
+                if f.path == path then
+                  found = true
+                end
+              end
+            end
+          end
+
+          assert.equals(JobStatus.SUCCESS, statuses[#statuses])
+          assert.is_true(found, "history dropped the parenthesised path")
         end)
       )
     end)
@@ -1089,12 +1227,21 @@ describe("diffview.vcs.adapters.jj", function()
       assert.is_false(is_non_literal_pathspec(""))
     end)
 
-    it("flags jj pathspec prefixes", function()
+    it("flags known jj fileset kind prefixes", function()
       assert.is_true(is_non_literal_pathspec("glob:*.lua"))
       assert.is_true(is_non_literal_pathspec("root:foo"))
       assert.is_true(is_non_literal_pathspec("cwd:foo"))
       assert.is_true(is_non_literal_pathspec("cwd-glob:**/*.lua"))
-      assert.is_true(is_non_literal_pathspec("file-list:paths.txt"))
+      assert.is_true(is_non_literal_pathspec("file:foo.txt"))
+      assert.is_true(is_non_literal_pathspec("root-file:foo.txt"))
+      assert.is_true(is_non_literal_pathspec("root-glob:**/*.lua"))
+      assert.is_true(is_non_literal_pathspec("prefix-glob:*.d"))
+    end)
+
+    it("flags the case-insensitive `-i` glob variants", function()
+      assert.is_true(is_non_literal_pathspec("glob-i:*.TXT"))
+      assert.is_true(is_non_literal_pathspec("cwd-glob-i:*.TXT"))
+      assert.is_true(is_non_literal_pathspec("root-glob-i:*.TXT"))
     end)
 
     it("flags shell glob metacharacters", function()
@@ -1108,11 +1255,66 @@ describe("diffview.vcs.adapters.jj", function()
       assert.is_false(is_non_literal_pathspec("D:\\bar.txt"))
     end)
 
+    it("keeps a literal filename with a colon literal", function()
+      -- A colon is legal in a Unix filename. Only jj's recognised kinds are
+      -- non-literal, so an unknown `<word>:` prefix (a real filename, or `jj
+      -- file-list:` which is not a fileset kind) must stay literal and get
+      -- quoted rather than parsed by jj as an invalid pattern kind.
+      assert.is_false(is_non_literal_pathspec("foo:bar.txt"))
+      assert.is_false(is_non_literal_pathspec("src/foo:bar.txt"))
+      assert.is_false(is_non_literal_pathspec("2024:01:01.log"))
+      assert.is_false(is_non_literal_pathspec("file-list:paths.txt"))
+    end)
+
     it("keeps bare relative and absolute paths literal", function()
       assert.is_false(is_non_literal_pathspec("foo.txt"))
       assert.is_false(is_non_literal_pathspec("src/foo.txt"))
       assert.is_false(is_non_literal_pathspec("/abs/foo.txt"))
       assert.is_false(is_non_literal_pathspec("./foo.txt"))
+    end)
+  end)
+
+  describe("quote_path_args", function()
+    local quote_path_args = require("diffview.vcs.adapters.jj")._test.quote_path_args
+
+    it("quotes a literal path so fileset metacharacters match literally", function()
+      eq(
+        { '"frontend/src/routes/(test)/View.svelte"' },
+        quote_path_args({
+          "frontend/src/routes/(test)/View.svelte",
+        })
+      )
+    end)
+
+    it("leaves non-literal pathspecs untouched so filesets keep working", function()
+      eq(
+        { "glob:*.lua", "root:foo", "*.lua" },
+        quote_path_args({
+          "glob:*.lua",
+          "root:foo",
+          "*.lua",
+        })
+      )
+    end)
+
+    it("quotes a literal filename containing a colon", function()
+      -- `foo:bar.txt` is a valid Unix filename, not a jj `<kind>:` pathspec, so
+      -- it must be quoted; left bare, jj would reject `foo:` as a pattern kind.
+      eq({ '"foo:bar.txt"' }, quote_path_args({ "foo:bar.txt" }))
+    end)
+
+    it("leaves the `.` and empty sentinels untouched", function()
+      eq({ ".", "" }, quote_path_args({ ".", "" }))
+    end)
+
+    it("quotes only the literal members of a mixed list", function()
+      eq(
+        { '"src/(a)/x.lua"', "glob:*.lua" },
+        quote_path_args({
+          "src/(a)/x.lua",
+          "glob:*.lua",
+        })
+      )
     end)
   end)
 end)

--- a/lua/diffview/vcs/adapters/jj/init.lua
+++ b/lua/diffview/vcs/adapters/jj/init.lua
@@ -127,6 +127,113 @@ function JjAdapter:get_command()
   return config.get_config().jj_cmd
 end
 
+---Escape a path as a jj fileset string literal: double-quoted, with `\` and
+---`"` backslash-escaped to satisfy jj's string-literal grammar. Quoting stops
+---jj from reading the fileset parser's metacharacters (`(`, `)`, `|`, `&`,
+---`~`, whitespace) in a real path (e.g., a Svelte route group like `(group)`)
+---as operators. The returned string still carries jj's default `cwd` pattern
+---kind, which matches the path and its descendants and leaves glob symbols
+---(`*`, `?`, `[`, `]`) active; callers needing an exact single file must use
+---`fileset_exact` instead.
+---@param path string
+---@return string
+local function fileset_string(path)
+  return '"' .. path:gsub("\\", "\\\\"):gsub('"', '\\"') .. '"'
+end
+
+---Build an exact-file jj fileset pattern for `path`. The `file:` (a.k.a.
+---`cwd-file:`) kind matches exactly one file relative to cwd, with no prefix
+---or glob expansion, so a path containing parser metacharacters (`(`, `|`,
+---...) or glob symbols (`*`, `?`, `[`, `]`) resolves to that one file rather
+---than erroring or matching siblings. Used for single-file operations
+---(`show`, `restore`) where `path` is a concrete tracked file.
+---@param path string
+---@return string
+local function fileset_exact(path)
+  return "file:" .. fileset_string(path)
+end
+
+-- The fileset pattern kinds jj recognises before a `:` (see `jj help -k
+-- filesets`). A leading `<kind>:` marks an intentional fileset expression
+-- rather than a literal path. Glob kinds also accept a case-insensitive `-i`
+-- suffix, which is stripped before the lookup.
+local JJ_PATTERN_KINDS = {
+  cwd = true,
+  root = true,
+  file = true,
+  ["cwd-file"] = true,
+  ["root-file"] = true,
+  glob = true,
+  ["cwd-glob"] = true,
+  ["root-glob"] = true,
+  ["prefix-glob"] = true,
+  ["cwd-prefix-glob"] = true,
+  ["root-prefix-glob"] = true,
+}
+
+---Detect a non-literal jj pathspec: one carrying a known fileset kind prefix
+---(`glob:`, `root:`, `file:`, ...) or a bare glob (`*.lua`). The per-path
+---canonicalise in `compute_fh_scope_args` can't resolve either, and
+---`quote_path_args` hands them to jj untouched so intentional filesets keep
+---working. Only jj's recognised kinds count: an unknown `<word>:` prefix is
+---treated as literal, so a real filename that merely contains a colon (e.g.
+---`foo:bar.txt`, legal on Unix) gets quoted rather than parsed by jj as an
+---invalid pattern kind. A user-defined fileset alias (also `<word>:`) is
+---likewise treated as literal, which is the safe default for a path argument.
+---@param p string
+---@return boolean
+local function is_non_literal_pathspec(p)
+  if p == "." or p == "" then
+    return false
+  end
+  local kind = p:match("^([%w-]+):")
+  if kind then
+    -- Strip the optional case-insensitive `-i` suffix before the lookup.
+    local base_kind = kind:gsub("%-i$", "")
+    if JJ_PATTERN_KINDS[base_kind] then
+      return true
+    end
+  end
+  if p:match("[*?%[%]]") then
+    return true
+  end
+  return false
+end
+
+---Quote each literal path in `path_args` as a fileset string literal (see
+---`fileset_string`) so jj matches it verbatim. Non-literal pathspecs
+---(`glob:*.lua`, `root:foo`, bare globs) and the `.`/empty sentinels are left
+---untouched so intentional fileset expressions keep working. Applied at every
+---boundary where user-supplied or derived paths are handed to a jj command
+---after `--`, since jj parses those arguments as filesets. Uses
+---`fileset_string` (the default `cwd` kind) rather than `fileset_exact` so a
+---directory path keeps matching its descendants, preserving history scope.
+---@param path_args string[]
+---@return string[]
+local function quote_path_args(path_args)
+  return vim.tbl_map(function(p)
+    if p == "" or p == "." or is_non_literal_pathspec(p) then
+      return p
+    end
+    return fileset_string(p)
+  end, path_args) --[[@as string[] ]]
+end
+
+---List the files matching `path_args` at the working-copy revision (`@`). The
+---path args are quoted (see `quote_path_args`) so fileset metacharacters in a
+---literal path don't get parsed as operators. The scope helpers below use this
+---to count matches and to canonicalise a pathspec to its concrete
+---workspace-relative file(s).
+---@param path_args string[]
+---@return string[] # Workspace-relative paths, one per line
+function JjAdapter:list_files_at_head(path_args)
+  local out = self:exec_sync(
+    utils.vec_join("file", "list", "-r", "@", "--", quote_path_args(path_args)),
+    { cwd = self.ctx.toplevel, silent = true }
+  )
+  return out or {}
+end
+
 ---@param path string
 ---@param rev Rev?
 ---@return string[]
@@ -138,7 +245,7 @@ function JjAdapter:get_show_args(path, rev)
     "-r",
     rev and rev:object_name() or "@",
     "--",
-    path
+    fileset_exact(path)
   )
 end
 
@@ -467,11 +574,7 @@ function JjAdapter:is_single_file(path_args, lflags)
   if path_args and self.ctx.toplevel then
     return #path_args == 1
       and not pl:is_dir(path_args[1])
-      and #self:exec_sync(
-          utils.vec_join("file", "list", "-r", "@", "--", path_args),
-          { cwd = self.ctx.toplevel, silent = true }
-        )
-        < 2
+      and #self:list_files_at_head(path_args) < 2
   end
   return true
 end
@@ -495,10 +598,7 @@ function JjAdapter:history_scope(path_args, log_options) ---@diagnostic disable-
   -- no `--follow` and callers consume `scope.path` as a literal post-filter
   -- against `f.target().path()`. Returning a non-canonical `path_args[1]`
   -- (`./foo.txt`, `glob:*`, ...) there would empty otherwise-valid history.
-  local out = self:exec_sync(
-    utils.vec_join("file", "list", "-r", "@", "--", path_args),
-    { cwd = self.ctx.toplevel, silent = true }
-  )
+  local out = self:list_files_at_head(path_args)
   if #out == 1 then
     return { single_file = true, path = out[1] }
   end
@@ -510,26 +610,6 @@ function JjAdapter:history_scope(path_args, log_options) ---@diagnostic disable-
     return { single_file = true }
   end
   return { single_file = false }
-end
-
----Detect a non-literal jj pathspec. jj recognises prefixes such as `glob:`,
----`root:`, `cwd:`, `cwd-glob:`, and `file-list:`; the per-path canonicalise
----in `compute_fh_scope_args` can't resolve any of these. Glob metacharacters
----outside a prefix (`*.lua`) are also non-literal. Requires at least two
----characters before `:` so Windows drive letters (`C:/...`) stay literal.
----@param p string
----@return boolean
-local function is_non_literal_pathspec(p)
-  if p == "." or p == "" then
-    return false
-  end
-  if p:match("^[%w_-][%w_-]+:") then
-    return true
-  end
-  if p:match("[*?%[%]]") then
-    return true
-  end
-  return false
 end
 
 ---Resolve `path_args` to workspace-relative paths used by `parse_fh_data`'s
@@ -551,10 +631,7 @@ function JjAdapter:compute_fh_scope_args(path_args)
   local toplevel = self.ctx.toplevel
   for _, p in ipairs(path_args) do
     if is_non_literal_pathspec(p) then
-      local out = self:exec_sync(
-        utils.vec_join("file", "list", "-r", "@", "--", path_args),
-        { cwd = toplevel, silent = true }
-      )
+      local out = self:list_files_at_head(path_args)
       return #out > 0 and out or {}
     end
   end
@@ -676,7 +753,7 @@ function JjAdapter:file_history_dry_run(log_opt)
     log_options.revisions and { "-r", log_options.revisions } or nil,
     options,
     "--",
-    log_options.path_args
+    quote_path_args(log_options.path_args)
   )
 
   local out, code = self:exec_sync(cmd, {
@@ -858,7 +935,7 @@ function JjAdapter:stream_fh_data(state)
       prepared.revisions and { "-r", prepared.revisions } or nil,
       prepared.flags,
       "--",
-      prepared.path_args
+      quote_path_args(prepared.path_args)
     ),
     cwd = self.ctx.toplevel,
     log_opt = { label = "JjAdapter:stream_fh_data()" },
@@ -1242,7 +1319,7 @@ JjAdapter.file_restore = async.wrap(function(self, path, kind, commit, callback)
   local from = commit or "@-"
   local abs_path = pl:join(self.ctx.toplevel, path)
   local _, code, stderr = self:exec_sync(
-    { "restore", "--from", from, "--", path },
+    { "restore", "--from", from, "--", fileset_exact(path) },
     { cwd = self.ctx.toplevel }
   )
 
@@ -1378,5 +1455,6 @@ M._test = {
   structure_fh_data = structure_fh_data,
   FH_TEMPLATE = FH_TEMPLATE,
   is_non_literal_pathspec = is_non_literal_pathspec,
+  quote_path_args = quote_path_args,
 }
 return M


### PR DESCRIPTION
Relates to #244: fixes the easy cases.

May miss some cases where filenames contain literal glob characters.
