### PR TITLE
perf(file-history): skip log rebuild on `FocusGained`

### DIFF
--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -1066,6 +1066,7 @@ end
 
 ---@class DiffviewRefreshFilesOpts
 ---@field force? boolean Force-reload stage diff buffers, discarding unsaved edits.
+---@field focus_gained? boolean Set when the refresh was triggered by `FocusGained`. The file-history view ignores these (rebuilding the whole log on every focus is costly and rarely reflects a real change); the diff view still refreshes.
 
 ---Refresh the file list for the current view.
 ---

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -46,9 +46,13 @@ function M.init()
     end,
   })
   -- Throttle `FocusGained` so bursts of focus events can't drive
-  -- `refresh_files` faster than it can complete.
+  -- `refresh_files` faster than it can complete. The `focus_gained` flag lets
+  -- views opt out: the diff view refreshes (the working tree may have changed while
+  -- Neovim was in the background), while the file-history view ignores it
+  -- (rebuilding the whole log on every focus is costly and rarely reflects a
+  -- real change in commit history).
   local refresh_files_throttled = debounce.throttle_trailing(500, true, function()
-    M.emit("refresh_files")
+    M.emit("refresh_files", { focus_gained = true })
   end)
   au("FocusGained", {
     group = M.augroup,

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -272,7 +272,14 @@ return function(view)
     toggle_files = function()
       view.panel:toggle(true)
     end,
-    refresh_files = function()
+    refresh_files = function(_, opts)
+      -- Ignore `FocusGained`-triggered refreshes: re-streaming the whole log
+      -- and rebuilding every entry on each focus is costly and rarely reflects
+      -- a real change in commit history. Explicit refreshes (the `R` keymap)
+      -- and `FugitiveChanged` still update the history.
+      if opts and opts.focus_gained then
+        return
+      end
       view.panel:update_entries(function(_, status)
         if status >= JobStatus.ERROR then
           return

--- a/lua/diffview/tests/functional/file_history_focus_refresh_spec.lua
+++ b/lua/diffview/tests/functional/file_history_focus_refresh_spec.lua
@@ -1,0 +1,46 @@
+local helpers = require("diffview.tests.helpers")
+
+local eq = helpers.eq
+
+local make_listeners = require("diffview.scene.views.file_history.listeners")
+
+-- Build a fake FileHistoryView whose panel records update_entries calls.
+---@return table view
+---@return table calls
+local function fake_view()
+  local calls = { update_entries = 0 }
+
+  local view = {
+    panel = {
+      update_entries = function(_, _)
+        calls.update_entries = calls.update_entries + 1
+      end,
+    },
+    cur_file = function()
+      return {}
+    end,
+    next_item = function() end,
+  }
+
+  return view, calls
+end
+
+describe("file_history refresh_files listener", function()
+  it("skips update_entries on a focus-triggered refresh", function()
+    local view, calls = fake_view()
+    make_listeners(view).refresh_files(nil, { focus_gained = true })
+    eq(0, calls.update_entries)
+  end)
+
+  it("updates entries on an explicit refresh (no opts)", function()
+    local view, calls = fake_view()
+    make_listeners(view).refresh_files(nil, nil)
+    eq(1, calls.update_entries)
+  end)
+
+  it("updates entries on a forced, non-focus refresh", function()
+    local view, calls = fake_view()
+    make_listeners(view).refresh_files(nil, { force = true })
+    eq(1, calls.update_entries)
+  end)
+end)


### PR DESCRIPTION
Fixes #248.