### PR TITLE
fix(merge): show `merge_only` keymaps in help panel for `FileMergeView`

### DIFF
--- a/lua/diffview/scene/views/diff/file_merge_view.lua
+++ b/lua/diffview/scene/views/diff/file_merge_view.lua
@@ -100,6 +100,12 @@ function FileMergeView:init(opt)
 
   self.files:set_conflicting({ entry })
   self.files:update_file_trees()
+
+  -- Keep `merge_only` keymaps visible in the help panel (filtered by
+  -- `actions._is_applicable` via `merge_ctx ~= nil`). Field values are
+  -- unread: their only consumer, `FileEntry:update_merge_context`, runs
+  -- from `DiffView:update_files`, which `NullDiffView` no-ops.
+  self.merge_ctx = { ours = { hash = "" }, theirs = { hash = "" }, base = { hash = "" } }
 end
 
 -- `post_open`, `init_layout`, and `update_files` are inherited from

--- a/lua/diffview/tests/functional/file_merge_view_spec.lua
+++ b/lua/diffview/tests/functional/file_merge_view_spec.lua
@@ -1,3 +1,4 @@
+local actions = require("diffview.actions")
 local helpers = require("diffview.tests.helpers")
 local lib = require("diffview.lib")
 local Diff3Hor = require("diffview.scene.layouts.diff_3_hor").Diff3Hor
@@ -139,6 +140,20 @@ describe("diffview.scene.views.diff.file_merge_view", function()
       eq(output_path, layout.b.file.path) -- OUTPUT (editable)
       eq(right_path, layout.c.file.path) -- THEIRS
       eq(base_path, layout.d.file.path) -- BASE
+    end)
+
+    it("populates `merge_ctx` so `merge_only` keymaps show in the help panel", function()
+      local adapter = NullAdapter.create({ toplevel = "/tmp" })
+      local view = FileMergeView({
+        adapter = adapter,
+        output_path = output_path,
+        left_path = left_path,
+        right_path = right_path,
+      })
+
+      assert.is_not_nil(view.merge_ctx)
+      assert.is_true(actions._is_applicable(actions.conflict_choose("ours"), view))
+      assert.is_true(actions._is_applicable(actions.conflict_choose_all("ours"), view))
     end)
   end)
 


### PR DESCRIPTION
Relates to #263.