### PR TITLE
fix(jj): include user-configured `jj_cmd` global flags in `jj log`

### DIFF
--- a/lua/diffview/tests/functional/jj_adapter_spec.lua
+++ b/lua/diffview/tests/functional/jj_adapter_spec.lua
@@ -274,6 +274,18 @@ describe("diffview.vcs.adapters.jj", function()
 
       eq({ "log", "-n10", "-r", "abc123" }, adapter:get_log_args({ "-n10", "abc123" }))
     end)
+
+    it("prepends user-configured global flags from `jj_cmd`", function()
+      local adapter = new_adapter()
+      adapter.get_command = function(_)
+        return { "jj", "--repository", "/some/path" }
+      end
+
+      eq(
+        { "--repository", "/some/path", "log", "-r", "abc123" },
+        adapter:get_log_args({ "abc123" })
+      )
+    end)
   end)
 
   describe("_warn_once()", function()

--- a/lua/diffview/vcs/adapters/jj/init.lua
+++ b/lua/diffview/vcs/adapters/jj/init.lua
@@ -332,8 +332,10 @@ end
 function JjAdapter:get_log_args(args)
   -- `jj log` treats positional arguments as filesets, so non-flag args (the
   -- revsets `JjRev.to_range` produces) need to go through `-r`. Flags pass
-  -- through unchanged.
-  local out = { "log" }
+  -- through unchanged. `self:args()` carries any user-configured global
+  -- flags (e.g., `--repository`) ahead of the subcommand, matching how
+  -- `get_show_args` builds its invocation.
+  local out = utils.vec_join(self:args(), "log")
   for _, arg in ipairs(args) do
     if vim.startswith(arg, "-") then
       utils.vec_push(out, arg)


### PR DESCRIPTION
Relates to #260.